### PR TITLE
Use 'fields' order if resource's fields are explicitly defined in the meta class

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -206,6 +206,8 @@ class Resource(object):
         return result
 
     def get_export_order(self):
+        if self._meta.fields:
+            return self._meta.export_order or self._meta.fields
         return self._meta.export_order or self.fields.keys()
 
     def export_field(self, field, obj):


### PR DESCRIPTION
This allows users to avoid redefining another 'export_order' list just to change the ordering.
