### PR TITLE
Take _meta.fields ordering into account when _meta.export_order is not set.

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -296,7 +296,12 @@ class Resource(object):
         return result
 
     def get_export_order(self):
-        return self._meta.export_order or self.fields.keys()
+        '''
+        Return the export order if set, the fields order if set or the ordering of
+        the internal resource field dict.
+        '''
+        return self._meta.export_order or self._meta.fields or self.fields.keys()
+        
 
     def export_field(self, field, obj):
         method = getattr(self, 'dehydrate_%s' % field.column_name, None)


### PR DESCRIPTION
Hey Bojan, first of all thanks for this awesome app. Great work!

I had to add a custom field to my resource to provide a dehydrate function which returns some fancy stuff which is not on the model itself. I specified the fields attribute in my Meta class. The ordering worked fine, except the custom field, which was prepended as first item although it was the last in my Meta.fields definition. Then I noticed that there is an export_order option which works fine. But at a quick look at the code I decided to just add one additional OR statement in the get_export_order function. I would appreciate if you accept this pull request.

Cheers from Stuttgart, Germany
- Toni
