### PR TITLE
Small docs fix: .export() on a Resource is not a classmethod

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -58,7 +58,8 @@ Exporting data
 
 Now that we have defined resource class, we can export books::
 
-    >>> dataset = BookResource().export()
+    >>> book_resource = BookResource()
+    >>> dataset = book_resource.export()
     >>> print dataset.csv
     id,name,author,author_email,imported,published,price,categories
     2,Some book,1,,0,2012-12-05,8.85,1


### PR DESCRIPTION
Hey,

Thanks for your work on this, so far it's been brilliant.

This is just a small doc update for the getting started section. export() should be ran against an instance and not the Class itself - unless I'm missing something huge I think this is just a simple mistake. :)

Cheers!
Darian
