### PR TITLE
Removing Resource method `set_instance_attr` 

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -125,9 +125,6 @@ class Resource(object):
         else:
             return (self.init_instance(row), True)
 
-    def set_instance_attr(self, instance, row, field):
-        setattr(instance, self.get_mapping()[field], row[field])
-
     def save_instance(self, instance, dry_run=False):
         self.before_save_instance(instance, dry_run)
         if not dry_run:


### PR DESCRIPTION
Hi,

During my poking for a solution to my other github issue I came across this method on the Resource which doesn't seem to get called anywhere. Obviously it could be there so that other code can call it, but that seems unlikely given the fact it's referring to a method on the Resource class itself called `get_mapping` which no longer seems to exist. I couldn't find anything in the docs about this method either if it was one you were meant to implement yourself.

So is it just some legacy code accidentally left or am I missing something again?
The tests run fine both before and after removing the method. I've attached a pull request so it's easy to fix if correct.

cheers,
Darian
