### PR TITLE
Store exception object rather than it's repr

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -345,7 +345,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                             real_dry_run)
             except Exception as e:
                 tb_info = traceback.format_exc(2)
-                row_result.errors.append(Error(repr(e), tb_info))
+                row_result.errors.append(Error(e, tb_info))
                 if raise_errors:
                     if use_transactions:
                         transaction.rollback()

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -154,8 +154,11 @@ class ModelResourceTest(TestCase):
 
         self.assertTrue(result.has_errors())
         self.assertTrue(result.rows[0].errors)
-        msg = 'ValueError("invalid literal for int() with base 10: \'foo\'",)'
-        self.assertTrue(result.rows[0].errors[0].error, msg)
+        msg = "invalid literal for int() with base 10: 'foo'"
+        actual = result.rows[0].errors[0].error
+        self.assertIsInstance(actual, ValueError)
+        self.assertEqual("invalid literal for int() with base 10: 'foo'",
+            str(actual))
 
     def test_import_data_delete(self):
 


### PR DESCRIPTION
To make it easier to deal with exceptions and display meaningful error
messages (may not be backwards compatible).
