### PR TITLE
Use keywords for export format choice values.

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -273,10 +273,7 @@ class ExportMixin(object):
         formats = self.get_export_formats()
         form = ExportForm(formats, request.POST or None)
         if form.is_valid():
-            file_format = formats[
-                int(form.cleaned_data['file_format'])
-            ]()
-
+            file_format = form.formats[form.cleaned_data['file_format']]()
             resource_class = self.get_export_resource_class()
             queryset = self.get_export_queryset(request)
             data = resource_class().export(queryset)

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -22,6 +22,10 @@ from django.utils import six
 
 class Format(object):
 
+    @property
+    def id(self):
+        return type(self).__name__
+
     def get_title(self):
         return type(self)
 
@@ -85,7 +89,7 @@ class TablibFormat(Format):
     def get_extension(self):
         # we support both 'extentions' and 'extensions' because currently tablib's master
         # branch uses 'extentions' (which is a typo) but it's dev branch already uses 'extension'.
-        # TODO - remove this once the typo is fixxed in tablib's master branch
+        # TODO - remove this once the typo is fixed in tablib's master branch
         if hasattr(self.get_format(), 'extentions'):
             return self.get_format().extentions[0]
         return self.get_format().extensions[0]

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -49,6 +49,8 @@ class ExportForm(forms.Form):
 
         for f in formats:
             instance = f()
+            # https://github.com/bmihelac/django-import-export/pull/77#discussion_r11808019
+            assert instance.id is not in self.formats
             choices.append((instance.id, instance.get_title(),))
             self.formats[instance.id] = f
 

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -45,8 +45,13 @@ class ExportForm(forms.Form):
     def __init__(self, formats, *args, **kwargs):
         super(ExportForm, self).__init__(*args, **kwargs)
         choices = []
-        for i, f in enumerate(formats):
-            choices.append((str(i), f().get_title(),))
+        self.formats = {}
+
+        for f in formats:
+            instance = f()
+            choices.append((instance.id, instance.get_title(),))
+            self.formats[instance.id] = f
+
         if len(formats) > 1:
             choices.insert(0, ('', '---'))
 

--- a/tests/core/tests/admin_integration_tests.py
+++ b/tests/core/tests/admin_integration_tests.py
@@ -56,9 +56,15 @@ class ImportExportAdminIntegrationTest(TestCase):
     def test_export(self):
         response = self.client.get('/admin/core/book/export/')
         self.assertEqual(response.status_code, 200)
+        self.assertIn('form', response.context)
+        form = response.context['form']
+        from import_export.forms import ExportForm
+        self.assertIsInstance(form, ExportForm)
+        choices_dict = dict(form['file_format'].field.choices)
+        self.assertIn('CSV', choices_dict)
 
         data = {
-                'file_format': '0',
+                'file_format': 'CSV',
                 }
         response = self.client.post('/admin/core/book/export/', data)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Ensures that we don't get unexpected results if the format list changes between when the user GETs the form and when they POST it back, and makes it easier to write tests without scanning the list of choices to find the index of the CSV format.
