### PR TITLE
Add support for dynamic fields (columns)

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -377,8 +377,10 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         return result
 
     def get_export_order(self):
-        declared_fields = self._meta.export_order or self.fields.keys()
-        return list(declared_fields) + self.dynamic_fields.keys()
+        if self._meta.export_order:
+            return list(self._meta.export_order) + self.dynamic_fields.keys()
+        else:
+            return self.fields.keys()
 
     def export_field(self, field, obj):
         field_name = self.get_field_name(field)

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,1 +1,2 @@
-PYTHONPATH=".:tests:$PYTHONPATH" django-admin.py test core --settings=settings
+tests=${@:-core}
+PYTHONPATH=".:tests:$PYTHONPATH" django-admin.py test --settings=settings $tests

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -42,3 +42,14 @@ class Profile(models.Model):
 
 class Entry(models.Model):
     user = models.ForeignKey('auth.User')
+
+
+@python_2_unicode_compatible
+class Reader(models.Model):
+    book = models.ForeignKey(Book)
+    user = models.ForeignKey('auth.User')
+    when = models.DateField()
+
+    def __str__(self):
+        return "%s read %s on %s" % (self.user.last_name, self.book.name,
+            self.when)


### PR DESCRIPTION
These can be defined at run time, when the column names cannot be known in advance, for example because they depend on a database of countries or the administrator's configured language settings.

You'll need to override `get_dynamic_fields()` in your `Resource` class to return a list of `Field`s. These will probably need to be instances of a custom `Field` class that you define, because the standard classes won't know how to generate or store the values for fields that are not model fields, and if they were model fields then you wouldn't need them to be dynamic.

See `MyDynamicResource` and `ExampleDynamicModelResource` in `tests/core/tests/resource_tests.py` for usage examples.
