### PR TITLE
run tests on 3.3 unless django version is 1.4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - pip install -e git+https://github.com/kennethreitz/tablib.git#egg=tablib
   - pip install -r requirements/base.txt --use-mirrors
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION != '3.3' && $DJANGO != "1.4.10" ]]; then python tests/manage.py test core --settings=settings; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != '3.3' || $DJANGO != "1.4.10" ]]; then python tests/manage.py test core --settings=settings; fi


### PR DESCRIPTION
With things the way they were, travis didn't run any python 3.3 tests. I think this is the conditional you had intended, it only avoids running the tests on python 3.3 with django 1.4.10.
