### PR TITLE
support django 1.7 and mostly support 1.8

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -71,7 +71,9 @@ class Field(object):
             if value is None:
                 return None
 
-        if callable(value):
+        # Manyrelatedmanagers are callable in Django >= 1.7 but we don't want
+        # to call them
+        if callable(value) and not value.through:
             value = value()
         return value
 


### PR DESCRIPTION
A few changes to supprt Django 1.7 and mostly support Django 1.8*. Most of the changes are just renamed attributes or kwargs, according to the [deprecation timeline](https://docs.djangoproject.com/en/dev/internals/deprecation/). I followed a pattern of defaulting to the new attr/kwarg and falling back to the deprecated version when necessary.

In Django 1.7, the ManyRelatedManager object became callable, which messed up the `get_value` method in fields.py. My suggested solution is to detect ManyRelatedManager by checking for a non-empty value in the through attribute.

The tests all pass in Django 1.7, but from what I can tell, there isn't a test for callable values. I'm not sure how that works anyway, so I couldn't write a test for it.

---
- The missing Django 1.8 support has to do with transactions. Transaction management has received quite an overhaul in 1.8 and will require significant refactoring to support it.
