### PR TITLE
Basic implementation to support dates before 1900

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
 from decimal import Decimal
-from django.utils import datetime_safe as datetime
+from datetime import datetime
+from django.utils import datetime_safe
 
 try:
     from django.utils.encoding import force_text
@@ -99,7 +100,7 @@ class DateWidget(Widget):
         try:
             return value.strftime(self.format)
         except:
-            return datetime.new_date(value).strftime(self.format)
+            return datetime_safe.new_date(value).strftime(self.format)
 
 
 class DateTimeWidget(Widget):

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -35,6 +35,17 @@ class DateWidgetTest(TestCase):
     def test_clean(self):
         self.assertEqual(self.widget.clean("13.08.2012"), self.date)
 
+class DateWidgetBefore1900Test(TestCase):
+
+    def setUp(self):
+        self.date = date(1868, 8, 13)
+        self.widget = widgets.DateWidget('%d.%m.%Y')
+
+    def test_render(self):
+        self.assertEqual(self.widget.render(self.date), "13.08.1868")
+
+    def test_clean(self):
+        self.assertEqual(self.widget.clean("13.08.1868"), self.date)
 
 class DecimalWidgetTest(TestCase):
 


### PR DESCRIPTION
Fixes issue https://github.com/bmihelac/django-import-export/issues/93
Tested with:
Django Version: 1.6.2 and 1.6.5
Python Version: 2.7.5

Fixed using https://code.djangoproject.com/ticket/1443 developed method django.utils.datetime_safe
