### PR TITLE
fix: get_value raised attribute error on model method call

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -82,7 +82,7 @@ class Field(object):
 
         # Manyrelatedmanagers are callable in Django >= 1.7 but we don't want
         # to call them
-        if callable(value) and not value.through:
+        if callable(value) and not hasattr(value, 'through'):
             value = value()
         return value
 


### PR DESCRIPTION
Not sure if it is intended to be able to specify model methods as attributes for export. Currently it breaks with attribute error in get_value when checking the callable for .through. 
