### PR TITLE
Fixed XLS import on python 3. Optimized loop

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from django.utils.six import moves
 
 import warnings
 import tablib
@@ -159,10 +160,6 @@ class XLS(TablibFormat):
         sheet = xls_book.sheets()[0]
 
         dataset.headers = sheet.row_values(0)
-        if six.PY2:
-            for i in xrange(1, sheet.nrows):
-                dataset.append(sheet.row_values(i))
-        else:
-            for i in range(1, sheet.nrows):
-                dataset.append(sheet.row_values(i))
+        for i in moves.range(1, sheet.nrows):
+            dataset.append(sheet.row_values(i))
         return dataset


### PR DESCRIPTION
Fixed XLS import. Changed xrange function to range for use with python3.
Throw out from loop unneeded "if" statement.
