### PR TITLE
xrange no longer in Py3 - using django.utils.six

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -18,6 +18,7 @@ except ImportError:
 
 from django.utils.importlib import import_module
 from django.utils import six
+from django.utils.six.moves import xrange
 
 
 class Format(object):


### PR DESCRIPTION
https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists
