### PR TITLE
Follow MRO to collect declared fields from parent classes and mixins

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -290,7 +290,10 @@ class ExportMixin(ImportExportMixinBase):
             ]()
 
             resource_class = self.get_export_resource_class()
-            queryset = self.get_export_queryset(request)
+            if form.cleaned_data['skeleton_only']:
+                queryset = self.model.objects.none()
+            else:
+                queryset = self.get_export_queryset(request)
             content_type = 'application/octet-stream'
             data = resource_class().export(queryset)
             export_data = file_format.export_data(data)

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -18,6 +18,7 @@ except ImportError:
 
 from django.utils.importlib import import_module
 from django.utils import six
+from django.utils.six.moves import xrange
 
 
 class Format(object):

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -43,6 +43,7 @@ class ExportForm(forms.Form):
             )
     skeleton_only = forms.BooleanField(
             label=_('Download skeleton only'),
+            required=False
             )
 
     def __init__(self, formats, *args, **kwargs):

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -41,6 +41,9 @@ class ExportForm(forms.Form):
             label=_('Format'),
             choices=(),
             )
+    skeleton_only = forms.BooleanField(
+            label=_('Download skeleton only'),
+            )
 
     def __init__(self, formats, *args, **kwargs):
         super(ExportForm, self).__init__(*args, **kwargs)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -285,9 +285,12 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         """
         data = []
         dmp = diff_match_patch()
+        # print(original, current)
         for field in self.get_fields():
             v1 = self.export_field(field, original) if original else ""
             v2 = self.export_field(field, current) if current else ""
+            # if field.attribute in ['name', 'references']:
+            #     print(field.attribute, v1, "//", v2)
             diff = dmp.diff_main(force_text(v1), force_text(v2))
             dmp.diff_cleanupSemantic(diff)
             html = dmp.diff_prettyHtml(diff)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -39,6 +39,8 @@ class ResourceOptions(object):
     The inner Meta class allows for class-level configuration of how the
     Resource should behave. The following options are available:
 
+    * ``title`` - The exported document will use title if defined.
+
     * ``fields`` - Controls what introspected fields the Resource
       should include. A whitelist of fields.
 
@@ -72,6 +74,7 @@ class ResourceOptions(object):
     fields = None
     model = None
     exclude = None
+    title = None
     instance_loader_class = None
     import_id_fields = ['id']
     export_order = None
@@ -145,6 +148,12 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             return USE_TRANSACTIONS
         else:
             return self._meta.use_transactions
+
+    def get_title(self):
+        """
+        Returns title.
+        """
+        return self._meta.title
 
     def get_fields(self):
         """
@@ -412,7 +421,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if queryset is None:
             queryset = self.get_queryset()
         headers = self.get_export_headers()
-        data = tablib.Dataset(headers=headers)
+        data = tablib.Dataset(headers=headers, title=self.get_title())
         # Iterate without the queryset cache, to avoid wasting memory when
         # exporting large datasets.
         for obj in queryset.iterator():

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -25,7 +25,7 @@ class Widget(object):
         """
         Returns appropriate python objects for import value.
         """
-        return value
+        return value.strip()
 
     def render(self, value):
         """
@@ -65,6 +65,7 @@ class CharWidget(Widget):
         return value.strip()
 
     def render(self, value):
+        value.strip()
         return force_text(value)
 
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -61,6 +61,9 @@ class CharWidget(Widget):
     Widget for converting text fields.
     """
 
+    def clean(self, value):
+        return value.strip()
+
     def render(self, value):
         return force_text(value)
 

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -39,6 +39,7 @@ class MyResource(NameMixin, resources.Resource):
 
     class Meta:
         export_order = ('email', 'name')
+        title = 'My Title'
 
 
 class ResourceTestCase(TestCase):
@@ -62,12 +63,17 @@ class ResourceTestCase(TestCase):
         self.assertEqual(self.my_resource.get_export_headers(),
                 ['email', 'name'])
 
+    def test_get_title(self):
+        self.assertEqual(self.my_resource.get_title(),
+                'My Title')
+
 
 class BookResource(resources.ModelResource):
     published = fields.Field(column_name='published_date')
 
     class Meta:
         model = Book
+        title = 'My Book'
         exclude = ('imported', )
 
 
@@ -138,6 +144,11 @@ class ModelResourceTest(TestCase):
     def test_export(self):
         dataset = self.resource.export(Book.objects.all())
         self.assertEqual(len(dataset), 1)
+
+    def test_title(self):
+        dataset = self.resource.export(Book.objects.all())
+        self.assertEqual(dataset.title, self.resource.get_title())
+        self.assertEqual(dataset.title, 'My Book')
 
     def test_get_diff(self):
         book2 = Book(name="Some other book")

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -30,8 +30,11 @@ except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
 
-class MyResource(resources.Resource):
+class NameMixin(object):
     name = fields.Field()
+
+
+class MyResource(NameMixin, resources.Resource):
     email = fields.Field()
 
     class Meta:


### PR DESCRIPTION
Following the pattern of django.forms.forms.DeclaritiveFieldsMetaClass the **new** method has been changed to follow parent classes and pick up the declared fields. This allows:

```
class BaseResourceMixin(object):

    name = fields.Field(
        column_name='Name',
        attribute='name'
        )
    description = fields.Field(
        column_name='Description',
        attribute='description'
        )

class ThingResource(ResourceMixin, resources.ModelResource):

    user = fields.Field(
        column_name='User',
        attribute='user',
        widget=UserWidget(
            get_model(*settings.AUTH_USER_MODEL.split('.'))
            )
        )

    class Meta:
        model = Thing
        fields = ('name', 'description', 'user')
```

No tests yet but happily used as is.

Regards,
Darryl
