### PR TITLE
Allow Resource.export to accept iterables as well as querysets.

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -13,6 +13,7 @@ from django.utils.datastructures import SortedDict
 from django.utils import six
 from django.db import transaction
 from django.db.models.fields import FieldDoesNotExist
+from django.db.models.query import QuerySet
 from django.db.models.related import RelatedObject
 from django.conf import settings
 
@@ -390,9 +391,14 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             queryset = self.get_queryset()
         headers = self.get_export_headers()
         data = tablib.Dataset(headers=headers)
-        # Iterate without the queryset cache, to avoid wasting memory when
-        # exporting large datasets.
-        for obj in queryset.iterator():
+
+        if isinstance(queryset, QuerySet):
+            # Iterate without the queryset cache, to avoid wasting memory when
+            # exporting large datasets.
+            iterable = queryset.iterator()
+        else:
+            iterable = queryset
+        for obj in iterable:
             data.append(self.export_resource(obj))
         return data
 

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -136,6 +136,10 @@ class ModelResourceTest(TestCase):
         dataset = self.resource.export(Book.objects.all())
         self.assertEqual(len(dataset), 1)
 
+    def test_export_iterable(self):
+        dataset = self.resource.export(list(Book.objects.all()))
+        self.assertEqual(len(dataset), 1)
+
     def test_get_diff(self):
         book2 = Book(name="Some other book")
         diff = self.resource.get_diff(self.book, book2)


### PR DESCRIPTION
Heya, I've been using this to export models that have been filtered within python and are coming from lists or generators. I wanted to contribute it back. :)
