### PR TITLE
Fix exception handling of `before_import` in `import_data`

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -305,7 +305,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         try:
             self.before_import(dataset, real_dry_run)
         except Exception as e:
-            tb_info = traceback.format_exc(sys.exc_info()[2])
+            tb_info = traceback.format_exc(2)
             result.base_errors.append(Error(repr(e), tb_info))
             if raise_errors:
                 if use_transactions:


### PR DESCRIPTION
Set `traceback.format_exc` limit to 2 in exception handling of `before_import`  in `import_data` method on `Resource`.
- Before it was traceback, which causing the following error: `unorderable types: int() < traceback()`
  https://www.evernote.com/shard/s170/sh/734438dc-5db4-42ea-831f-55811ce87699/6cd97b6ffc5321a3092c6618202ca6df

Signed-off-by: Murat Akbal murat@udemy.com
