### PR TITLE
issue #124: implement export as an admin action.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ The following is a list of much appreciated contributors:
 * cherepski
 * cuchac
 * aidanlister (Aidan Lister)
+* tabac

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -18,6 +18,7 @@ from .forms import (
     ImportForm,
     ConfirmImportForm,
     ExportForm,
+    export_action_form_factory,
 )
 from .resources import (
     modelresource_factory,
@@ -282,6 +283,15 @@ class ExportMixin(ImportExportMixinBase):
         except AttributeError:
             return cl.query_set
 
+    def get_export_data(self, file_format, queryset):
+        """
+        Returns file_format representation for given queryset.
+        """
+        resource_class = self.get_export_resource_class()
+        data = resource_class().export(queryset)
+        export_data = file_format.export_data(data)
+        return export_data
+
     def export_action(self, request, *args, **kwargs):
         formats = self.get_export_formats()
         form = ExportForm(formats, request.POST or None)
@@ -290,11 +300,9 @@ class ExportMixin(ImportExportMixinBase):
                 int(form.cleaned_data['file_format'])
             ]()
 
-            resource_class = self.get_export_resource_class()
             queryset = self.get_export_queryset(request)
+            export_data = self.get_export_data(file_format, queryset)
             content_type = 'application/octet-stream'
-            data = resource_class().export(queryset)
-            export_data = file_format.export_data(data)
             # Django 1.7 uses the content_type kwarg instead of mimetype
             try:
                 response = HttpResponse(export_data, content_type=content_type)
@@ -323,4 +331,64 @@ class ImportExportMixin(ImportMixin, ExportMixin):
 class ImportExportModelAdmin(ImportExportMixin, admin.ModelAdmin):
     """
     Subclass of ModelAdmin with import/export functionality.
+    """
+
+
+class ExportActionModelAdmin(ExportMixin, admin.ModelAdmin):
+    """
+    Subclass of ModelAdmin with export functionality implemented as an
+    admin action.
+    """
+
+    # Don't use custom change list template.
+    change_list_template = None
+
+    def __init__(self, *args, **kwargs):
+        """
+        Adds a custom action form initialized with the available export
+        formats.
+        """
+        choices = []
+        formats = self.get_export_formats()
+        if formats:
+            choices.append(('', '---'))
+            for i, f in enumerate(formats):
+                choices.append((str(i), f().get_title()))
+
+        self.action_form = export_action_form_factory(choices)
+        super(ExportActionModelAdmin, self).__init__(*args, **kwargs)
+
+    def export_admin_action(self, request, queryset):
+        """
+        Exports the selected rows using file_format.
+        """
+        export_format = request.POST.get('file_format')
+
+        if not export_format:
+            messages.warning(request, _('You must select an export format.'))
+        else:
+            formats = self.get_export_formats()
+            file_format = formats[int(export_format)]()
+
+            export_data = self.get_export_data(file_format, queryset)
+            content_type = 'application/octet-stream'
+            # Django 1.7 uses the content_type kwarg instead of mimetype
+            try:
+                response = HttpResponse(export_data, content_type=content_type)
+            except TypeError:
+                response = HttpResponse(export_data, mimetype=content_type)
+            response['Content-Disposition'] = 'attachment; filename=%s' % (
+                self.get_export_filename(file_format),
+            )
+            return response
+    export_admin_action.short_description = _(
+        'Export selected %(verbose_name_plural)s')
+
+    actions = [export_admin_action]
+
+
+class ImportExportActionModelAdmin(ImportMixin, ExportActionModelAdmin):
+    """
+    Subclass of ExportActionModelAdmin with import/export functionality.
+    Export functionality is implemented as an admin action.
     """

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import os.path
 
 from django import forms
+from django.contrib.admin.helpers import ActionForm
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -51,3 +52,19 @@ class ExportForm(forms.Form):
             choices.insert(0, ('', '---'))
 
         self.fields['file_format'].choices = choices
+
+
+def export_action_form_factory(formats):
+    """
+    Returns an ActionForm subclass containing a ChoiceField populated with
+    the given formats.
+    """
+    class _ExportActionForm(ActionForm):
+        """
+        Action form with export format ChoiceField.
+        """
+        file_format = forms.ChoiceField(
+            label=_('Format'), choices=formats, required=False)
+    _ExportActionForm.__name__ = str('ExportActionForm')
+
+    return _ExportActionForm

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 
-from import_export.admin import ImportExportMixin
+from import_export.admin import ImportExportMixin, ExportActionModelAdmin
 
 from .models import Book, Category, Author
 
@@ -11,6 +11,9 @@ class BookAdmin(ImportExportMixin, admin.ModelAdmin):
     list_filter = ['categories', 'author']
 
 
+class CategoryAdmin(ExportActionModelAdmin):
+    pass
+
 admin.site.register(Book, BookAdmin)
-admin.site.register(Category)
+admin.site.register(Category, CategoryAdmin)
 admin.site.register(Author)


### PR DESCRIPTION
Instead of a different export action for each format a second ChoiceField is used with the available formats. This is done by subclassing ActionForm.

Let me know what you think,
kind regards
Tasos.
