### PR TITLE
remove invalid form action "form_url"

### DIFF
--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -24,14 +24,14 @@
   </form>
 
 {% else %}
-  <form action="{{ form_url }}" method="post" id="{{ opts.module_name }}_form" enctype="multipart/form-data">
+  <form action="" method="post" id="{{ opts.module_name }}_form" enctype="multipart/form-data">
     {% csrf_token %}
 
     <p>
       {% trans "This importer will import the following fields: " %}
       {% for f in fields  %}
         {% if forloop.counter0 %}
-        , 
+        ,
         {% endif %}
         <tt>{{ f }}</tt>
       {% endfor %}

--- a/tests/core/tests/admin_integration_tests.py
+++ b/tests/core/tests/admin_integration_tests.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os.path
 
+from django.test.utils import override_settings
 from django.test.testcases import TestCase
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
@@ -29,7 +30,15 @@ class ImportExportAdminIntegrationTest(TestCase):
         self.assertContains(response, _('Import'))
         self.assertContains(response, _('Export'))
 
+    @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
     def test_import(self):
+        # GET the import form
+        response = self.client.get('/admin/core/book/import/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/import_export/import.html')
+        self.assertContains(response, 'form action=""')
+
+        # POST the import form
         input_format = '0'
         filename = os.path.join(
             os.path.dirname(__file__),


### PR DESCRIPTION
When running with the django server locally with `TEMPLATE_DEBUG = True` and `TEMPLATE_STRING_IF_INVALID = 'INVALID_VARIABLE'` the import fails because the form action is set to `INVALID_VARIABLE`. I believe it is due to this line:

https://github.com/bmihelac/django-import-export/blob/b83aec0bc651f9e3e3a6b5498c20a9b2d312be43/import_export/templates/admin/import_export/import.html#L27

There is no `form_url` variable. In this pull request, I simply remove that variable so the form action is blank. I added some test code which failed before, but passes after this update.
