### PR TITLE
Update changelog.rst

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,8 +12,8 @@ Changelog for django-import-export
 
 - added use of get_diff_headers method into import.html template (#158)
 
-- Try to use OrderedDict instead of SortedDict, which is deprecated in 1
-  django 1.7 (#157)
+- Try to use OrderedDict instead of SortedDict, which is deprecated in 
+  Django 1.7 (#157)
 
 - fixed #105 unicode import
 


### PR DESCRIPTION
There was a stray character here, and I capitalised 'Django.'
