### PR TITLE
add suport for django 1.8 - RelatedObject is deprecated - ForeignObjetRe...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - DJANGO=1.5.5
   - DJANGO=1.6.1
   - DJANGO=1.7.0
+  - DJANGO=1.8.0
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install -e git+https://github.com/kennethreitz/tablib.git#egg=tablib

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -13,7 +13,7 @@ from django.utils import six
 from django.db import transaction
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.query import QuerySet
-from django.db.models.related import RelatedObject
+
 from django.conf import settings
 
 from .results import Error, Result, RowResult
@@ -23,6 +23,10 @@ from .instance_loaders import (
     ModelInstanceLoader,
 )
 
+try:  # django< 1.8
+    from django.db.models.related import RelatedObject
+except ImportError:  # django >= 1.8
+    from django.db.models.fields.related import ForeignObjectRel as RelatedObject
 
 try:
     from django.utils.encoding import force_text


### PR DESCRIPTION
Due to the django 1.8 release was needed to update the RelatedObject reference to ForeignObjectRelated.