### PR TITLE
Fix warning Django 1.9

### DIFF
--- a/import_export/templates/admin/import_export/export.html
+++ b/import_export/templates/admin/import_export/export.html
@@ -1,5 +1,4 @@
 {% extends "admin/import_export/base.html" %}
-{% load url from future %}
 {% load i18n %}
 {% load admin_urls %}
 {% load import_export_tags %}


### PR DESCRIPTION
Fix this:
```
/home/tulipan/Proyectos/TiempoTurco/lib/python3.4/site-packages/django/templatetags/future.py:25: RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.
  RemovedInDjango19Warning)
```