### PR TITLE
Fix AttributeErrors when importing readonly fields from annotated values

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ The following is a list of much appreciated contributors:
 * AyumuKasuga (Andrey Kostakov)
 * luto
 * gallochri (Christian Galeffi)
+* ericdwang (Eric Wang)

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -73,7 +73,7 @@ class Field(object):
 
         for attr in attrs:
             try:
-                value = getattr(value, attr)
+                value = getattr(value, attr, None)
             except (ValueError, ObjectDoesNotExist):
                 # needs to have a primary key value before a many-to-many
                 # relationship can be used.


### PR DESCRIPTION
When you have a readonly field in a ModelResource that gets its data from an annotated value (via `get_queryset` in ModelAdmin), you get AttributeErrors for each row during importing. This should fix that.