### PR TITLE
Allow Field.save() relation following

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -92,7 +92,10 @@ class Field(object):
         Cleans this field value and assign it to provided object.
         """
         if not self.readonly:
-            setattr(obj, self.attribute, self.clean(data))
+            attrs = self.attribute.split('__')
+            for attr in attrs[:-1]:
+                obj = getattr(obj, attr, None)
+            setattr(obj, attrs[-1], self.clean(data))
 
     def export(self, obj):
         """

--- a/tests/core/tests/fields_tests.py
+++ b/tests/core/tests/fields_tests.py
@@ -36,6 +36,17 @@ class FieldTest(TestCase):
         self.field.save(self.obj, self.row)
         self.assertEqual(self.obj.name, 'foo')
 
+    def test_save_follow(self):
+        class Test:
+            class name:
+                class follow:
+                    me = 'bar'
+        test = Test()
+        field = fields.Field(column_name='name', attribute='name__follow__me')
+        row = {'name': 'foo'}
+        field.save(test, row)
+        self.assertEqual(test.name.follow.me, 'foo')
+
     def test_following_attribute(self):
         field = fields.Field(attribute='other_obj__name')
         obj2 = Obj(name="bar")


### PR DESCRIPTION
This code allows relation following also on save. It's even possible to support m2m relations with customization such as:

```
    def init_instance(self, row=None):
        obj = self._meta.model()
        obj.pk = 1
        return obj
```

cc @bmihelac 