### PR TITLE
fix for fields with a dyanmic default callable

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -67,8 +67,7 @@ class Field(object):
 
         if not value and self.default != NOT_PROVIDED:
             if callable(self.default):
-                self.default = self.default()
-            return self.default
+                return self.default()
 
         return value
 

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+import random
+import string
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
@@ -48,3 +50,12 @@ class Entry(models.Model):
 class WithDefault(models.Model):
     name = models.CharField('Default', max_length=75, blank=True,
                             default=lambda: 'foo_bar')
+
+
+class WithDynamicDefault(models.Model):
+    def random_name():
+        chars = string.ascii_lowercase
+        return ''.join(random.SystemRandom().choice(chars) for _ in range(100))
+
+    name = models.CharField('Dyn Default', max_length=100,
+            default=random_name)

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -26,7 +26,7 @@ from import_export import widgets
 from import_export import results
 from import_export.instance_loaders import ModelInstanceLoader
 
-from core.models import Book, Author, Category, Entry, Profile, WithDefault
+from core.models import Book, Author, Category, Entry, Profile, WithDefault, WithDynamicDefault
 
 try:
     from django.utils.encoding import force_text
@@ -586,6 +586,20 @@ class ModelResourceTest(TestCase):
             self.dataset, raise_errors=True, dry_run=False)
         self.assertFalse(result.has_errors())
         self.assertEquals(User.objects.get(pk=user.pk).username, 'bar')
+
+    def test_import_data_dynamic_default_callable(self):
+        class DynamicDefaultResource(resources.ModelResource):
+            class Meta:
+                model = WithDynamicDefault
+                fields = ('id', 'name',)
+
+        resource = DynamicDefaultResource()
+        dataset = tablib.Dataset(headers=['id', 'name',])
+        dataset.append([1, None])
+        dataset.append([2, None])
+        resource.import_data(dataset, raise_errors=False)
+        objs = WithDynamicDefault.objects.all()
+        self.assertNotEqual(objs[0].name, objs[1].name)
 
 
 class ModelResourceTransactionTest(TransactionTestCase):


### PR DESCRIPTION
some fields need to utilize a dynamic callable for their default
values.  for example a field with a current timestamp, a random
string or maybe a UUID.

the current Field.clean method is caching the first invocation of
the default callable, so later uses of this field only use the cached
value.  this fix removes the caching element, so each time the default
value is needed, the callable is invoked.