### PR TITLE
Let Resource rollback if import throws exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 env:
   - DJANGO="Django>=1.5,<1.6"
   - DJANGO="Django>=1.6,<1.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,78 +1,84 @@
 [tox]
-envlist = py27-1.5, py27-1.6, py33-1.6, py27-1.7, py33-1.7, py34-1.7, py27-1.8, py33-1.8, py34-1.8, py27-1.9, py34-1.9, py27-dev, py34-dev
+envlist =
+    py{27,33}-1.6,
+    py{27,33,34}-1.7,
+    py{27,33,34}-1.8,
+    py{27,34,35}-1.9,
+    py{27,34,35}-dev
 
 [testenv]
 commands=python {toxinidir}/tests/manage.py test core
 deps = openpyxl
 
-[testenv:py27-1.5]
-basepython = python2.7
-deps = 
-    django==1.5.3
-    {[testenv]deps}
-
 [testenv:py27-1.6]
 basepython = python2.7
-deps = 
+deps =
     django==1.6
     {[testenv]deps}
 
 [testenv:py33-1.6]
 basepython = python3.3
-deps = 
+deps =
     django==1.6.1
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
     {[testenv]deps}
 
 [testenv:py27-1.7]
 basepython = python2.7
-deps = 
+deps =
     django==1.7.0
     {[testenv]deps}
 
 [testenv:py33-1.7]
 basepython = python3.3
-deps = 
+deps =
     django==1.7.0
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
     {[testenv]deps}
 
 [testenv:py34-1.7]
 basepython = python3.4
-deps = 
+deps =
     django==1.7.0
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
     {[testenv]deps}
 
 [testenv:py27-1.8]
 basepython = python2.7
-deps = 
+deps =
     django==1.8
     {[testenv]deps}
 
 [testenv:py33-1.8]
 basepython = python3.3
-deps = 
+deps =
     django==1.8
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
     {[testenv]deps}
 
 [testenv:py34-1.8]
 basepython = python3.4
-deps = 
+deps =
     django==1.8
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
     {[testenv]deps}
 
 [testenv:py27-1.9]
 basepython = python2.7
-deps = 
+deps =
     django==1.9
     {[testenv]deps}
 
 [testenv:py34-1.9]
 basepython = python3.4
-deps = 
+deps =
+    django==1.9
+    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
+    {[testenv]deps}
+
+[testenv:py35-1.9]
+basepython = python3.5
+deps =
     django==1.9
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
     {[testenv]deps}
@@ -84,6 +90,13 @@ deps =
     {[testenv]deps}
 
 [testenv:py34-dev]
+basepython = python3.4
+deps =
+    https://github.com/django/django/archive/master.tar.gz
+    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
+    {[testenv]deps}
+
+[testenv:py35-dev]
 basepython = python3.4
 deps =
     https://github.com/django/django/archive/master.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ deps =
     {[testenv]deps}
 
 [testenv:py35-dev]
-basepython = python3.4
+basepython = python3.5
 deps =
     https://github.com/django/django/archive/master.tar.gz
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib


### PR DESCRIPTION
If a db exception (such as `Key (name, primary_contact)=(squaberblabeergabatersh, Jenny Susans) already exists.` is thrown during Resource.import_data (when we try to save the instance), then attempting to rollback the database may result in
```TransactionManagementError “You can't execute queries until the end of the 'atomic' block” ```, causing import_data to throw an unhelpful transaction exception. With this fix the function will exit cleanly and the db error will be returned in one of the row_results as intended.

No time to add a failing test at the moment, but hopefully this is sufficient information to go on..