### PR TITLE
Add .isort.cfg

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+known_django=django
+sections=FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
+default_section=THIRDPARTY
+known_standard_library=tablib
+known_first_party=import_export
+multi_line_output=3
+line_length=100
+indent=4


### PR DESCRIPTION
Keep this file in the project's top level directory so that when isort is run on files in this project it will follow the rules set out in the config. Many editors also have a python-isort plugin, so that you can even enable automatic sorting on save in your favourite editor.

I've set the config to use 6 sections:
- future
- stdlib (including non-webby third party apps that you can specify yourself; I've added tablib to this section)
- webby third party apps
- django (django imports are usually extensive enough to warrant giving them their own section rather than mixing them with other third-party apps)
- first party (anything importing from 'import_export')
- local folder (any relative import, ie. starting with a dot)

But this is just how I like to set things out. By all means go ahead and change it if you want something different.