### PR TITLE
Change error message wording on UnicodeDecodeError

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -223,7 +223,7 @@ class ImportMixin(ImportExportMixinBase):
                     data = force_text(data, self.from_encoding)
                 dataset = input_format.create_dataset(data)
             except UnicodeDecodeError as e:
-                return HttpResponse(_(u"<h1>Imported file is not in unicode: %s</h1>" % e))
+                return HttpResponse(_(u"<h1>Imported file has a wrong encoding: %s</h1>" % e))
             except Exception as e:
                 return HttpResponse(_(u"<h1>%s encountred while trying to read file: %s</h1>" % (type(e).__name__, e)))
             result = resource.import_data(dataset, dry_run=True,


### PR DESCRIPTION
As far as I understand the whole unicode/encoding a file cannot be "in unicode" because it just consists of bytes which carry text information saved through a particular encoding table (i.e. UTF-8, etc.). 

I don't want to nitpick but it took me a while to wrap my head around the whole UnicodeDecodeErrors and implicit conversion that I don't want further misinformation to spread. In case I'm mistaken, please correct me and just close this pull request.