### PR TITLE
Reset SQL sequences when new objects are imported

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 -r base.txt
 sphinx
 mysql-python
-psycopg==2.6.1
+psycopg2==2.6.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r base.txt
 sphinx
 mysql-python
+psycopg==2.6.1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -62,8 +62,8 @@ elif os.environ.get('IMPORT_EXPORT_TEST_TYPE') == 'postgres':
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'import_export',
-            'USER': 'postgres',
-            'PASSWORD': 'postgres',
+            'USER': os.environ.get('IMPORT_EXPORT_POSTGRESQL_USER'),
+            'PASSWORD': os.environ.get('IMPORT_EXPORT_POSTGRESQL_PASSWORD'),
             'HOST': 'localhost',
             'PORT': 5432
         }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -56,6 +56,18 @@ if os.environ.get('IMPORT_EXPORT_TEST_TYPE') == 'mysql-innodb':
             }
         }
     }
+elif os.environ.get('IMPORT_EXPORT_TEST_TYPE') == 'postgres':
+    IMPORT_EXPORT_USE_TRANSACTIONS = True
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'import_export',
+            'USER': 'postgres',
+            'PASSWORD': 'postgres',
+            'HOST': 'localhost',
+            'PORT': 5432
+        }
+    }
 else:
     DATABASES = {
         'default': {


### PR DESCRIPTION
This addresses https://github.com/django-import-export/django-import-export/issues/59.

The problem:

I have created an example repository at https://github.com/sgarcialaguna/import-example which demonstrates the bug. The problem occurs with the latest django-import-export and PostgreSQL 9.5

The repository contains a simple model Widget which has nothing but an auto-increment field:

```python
class Widget(models.Model):
    pass
```

Set up the project and the database, then go into the admin interface and import the widgets via the contained widgets.csv (it just creates a widget with the id 1)

Now create a new widget via the admin interface and there's an Integrity Error as Django tries to create a widget with id 1, but 1 is already assigned. 

You can manually repair the situation by running the commands from sqlsequencereset against the database, but this shouldn't be necessary.

The solution:

Reset the sequences programatically whenever new objects are imported. This is exactly how Django's own loaddata command handles it and the code in my pull-request was adapted from it.