### PR TITLE
show formats selector only when export action is selected

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,8 +1,7 @@
 Configuration
 =============
 
-You only need to perform this configuration step if you use
- django-import-export in the admin.
+You only need to perform this configuration step if you use django-import-export in the admin.
 
 Add ``import_export`` to your ``INSTALLED_APPS``:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,16 @@
 Configuration
 =============
 
-The only mandatory configuration is adding ``import_export`` to your
-``INSTALLED_APPS``. This isn't necessary, if admin integration is not
-used.
+You only need to perform this configuration step if you use
+ django-import-export in the admin.
+
+Add ``import_export`` to your ``INSTALLED_APPS``:
+
+    INSTALLED_APPS = [
+        # ...
+        'import_export',
+    ]
+
+Deploy static files:
+
+    $ python manage.py collectstatic

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -7,6 +7,7 @@ Add ``import_export`` to your ``INSTALLED_APPS``:
 
     INSTALLED_APPS = [
         # ...
+
         'import_export',
     ]
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -437,6 +437,9 @@ class ExportActionModelAdmin(ExportMixin, admin.ModelAdmin):
 
     actions = [export_admin_action]
 
+    class Media:
+        js = ['import_export/action_formats.js']
+
 
 class ImportExportActionModelAdmin(ImportMixin, ExportActionModelAdmin):
     """

--- a/import_export/static/import_export/action_formats.js
+++ b/import_export/static/import_export/action_formats.js
@@ -1,0 +1,12 @@
+(function($) {
+  $(document).on('ready', function() {
+    $('select[name="action"]', '#changelist-form').on('change', function() {
+      if ($(this).val() == 'export_admin_action') {
+        $('select[name="file_format"]', '#changelist-form').parent().show();
+      } else {
+        $('select[name="file_format"]', '#changelist-form').parent().hide();
+      }
+    });
+    $('select[name="action"]', '#changelist-form').change();
+  });
+})(django.jQuery);


### PR DESCRIPTION
Hi,

This little javascript hides the formats select and shows it only when the export action is selected. It is quite simple but IMHO a good usability improvement.

Should you like the idea, we also need to modify the documentation to include the collectstatic step in the installation.