### PR TITLE
ImportMixin does not display the import button in admin for users w/o add permissions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ The following is a list of much appreciated contributors:
 * jnns (Jannis)
 * sgarcialaguna
 * carlosp420 (Carlos Peña)
+* freelancersunion (Freelancers Union)

--- a/import_export/templates/admin/import_export/change_list_import.html
+++ b/import_export/templates/admin/import_export/change_list_import.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_list.html" %}
+{% extends "admin/import_export/change_list.html" %}
 {% load i18n %}
 
 {% block object-tools-items %}

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 
-from import_export.admin import ImportExportMixin, ExportActionModelAdmin
+from import_export.admin import ImportExportMixin, ImportMixin, ExportActionModelAdmin
 
 from .models import Book, Category, Author
 
@@ -14,6 +14,10 @@ class BookAdmin(ImportExportMixin, admin.ModelAdmin):
 class CategoryAdmin(ExportActionModelAdmin):
     pass
 
+
+class AuthorAdmin(ImportMixin, admin.ModelAdmin):
+    pass
+
 admin.site.register(Book, BookAdmin)
 admin.site.register(Category, CategoryAdmin)
-admin.site.register(Author)
+admin.site.register(Author, AuthorAdmin)

--- a/tests/core/tests/admin_integration_tests.py
+++ b/tests/core/tests/admin_integration_tests.py
@@ -8,8 +8,8 @@ from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.admin.models import LogEntry
 
-from core.admin import BookAdmin
-from core.models import Category
+from core.admin import BookAdmin, AuthorAdmin
+from core.models import Category, Author
 
 
 class ImportExportAdminIntegrationTest(TestCase):
@@ -85,6 +85,18 @@ class ImportExportAdminIntegrationTest(TestCase):
 
         self.assertContains(response, _('Export'))
         self.assertContains(response, _('Import'))
+
+    def test_import_buttons_visible_without_add_permission(self):
+        # When using ImportMixin, users should be able to see the import button
+        # without add permission (to be consistent with ImportExportMixin)
+
+        original = AuthorAdmin.has_add_permission
+        AuthorAdmin.has_add_permission = lambda self, request: False
+        response = self.client.get('/admin/core/author/')
+        AuthorAdmin.has_add_permission = original
+
+        self.assertContains(response, _('Import'))
+        self.assertTemplateUsed(response, 'admin/import_export/change_list.html')
 
     def test_import_file_name_in_tempdir(self):
         # 65 - import_file_name form field can be use to access the filesystem


### PR DESCRIPTION

Using ImportMixin does not display the import button for users who do not have explicit add permissions (unlike ImportExportMixin or ExportMixin, which display buttons regardless).

This is because ImportMixin uses the django admin/change_list template, while ImportExportMixin and ExportMixin use django-import-export's change_list template. For consistency I updated so that they all use django-import-export's template.

I added AuthorAdmin to the admin panel using the ImportMixin and added a test to admin_integration_tests (test_import_buttons_visible_without_add_permission). The test checks that a user without add permissions can see the import button. It also verifies that the correct template is loaded.

The first branch results in a failing test; the second branch contains the template fix and results in the test passing.