### PR TITLE
Make line errors more readable

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -341,7 +341,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         except Exception as e:
             logging.exception(e)
             tb_info = traceback.format_exc()
-            result.base_errors.append(Error(repr(e), tb_info))
+            result.base_errors.append(Error(e, tb_info))
             if raise_errors:
                 if use_transactions:
                     savepoint_rollback(sp1)

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -28,12 +28,7 @@
 
     <p>
       {% trans "This importer will import the following fields: " %}
-      {% for f in fields  %}
-        {% if forloop.counter0 %}
-        ,
-        {% endif %}
-        <code>{{ f }}</code>
-      {% endfor %}
+      <code>{{ fields|join:", " }}</code>
     </p>
 
     <fieldset class="module aligned">
@@ -73,7 +68,7 @@
         {% for error in errors %}
           <li>
             {% trans "Line number" %}: {{ line }} - {{ error.error }}
-            <div>{{ error.row }}</div>
+            <div><code>{{ error.row.values|join:", " }}</code></div>
             <div class="traceback">{{ error.traceback|linebreaks }}</div>
           </li>
         {% endfor %}


### PR DESCRIPTION
Using the object representations in line errors hinders comprehensibility a lot because there's `OrderedDict([…])` and lots of `u'…'` obfuscating what really matters. 

These small changes make the error output a bit more pleasing to the end user.

---

On a different note: 

I wonder if it really is such a good idea to include the whole traceback with the errors on each line. As it contains information about the runtime environment and about script paths this 

  - might be a security risk
  - is more unhelpful than handy because it creates lots of noise compared to the more precise message in the exception itself.

But this is just my opinion and as everyone can just edit the template in their `Resource` this might not be of relevance.
