### PR TITLE
Fix #375 and pass row to widget.clean()

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -61,8 +61,16 @@ class Field(object):
                            "columns are: %s" % (self.column_name,
                                                 list(data.keys())))
 
+        # If this Field uses a ForeignKeyWidget, also pass the row data to the
+        # widget's clean method because it might be needed for additional
+        # filtering on the related objects queryset.
+        if isinstance(self.widget, widgets.ForeignKeyWidget):
+            clean_args = (value, data)
+        else:
+            clean_args = (value,)
+
         try:
-            value = self.widget.clean(value)
+            value = self.widget.clean(*clean_args)
         except ValueError as e:
             raise ValueError("Column '%s': %s" % (self.column_name, e))
 

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -61,16 +61,8 @@ class Field(object):
                            "columns are: %s" % (self.column_name,
                                                 list(data.keys())))
 
-        # If this Field uses a ForeignKeyWidget, also pass the row data to the
-        # widget's clean method because it might be needed for additional
-        # filtering on the related objects queryset.
-        if isinstance(self.widget, widgets.ForeignKeyWidget):
-            clean_args = (value, data)
-        else:
-            clean_args = (value,)
-
         try:
-            value = self.widget.clean(*clean_args)
+            value = self.widget.clean(value, row=data)
         except ValueError as e:
             raise ValueError("Column '%s': %s" % (self.column_name, e))
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -256,9 +256,35 @@ class ForeignKeyWidget(Widget):
         self.field = field
         super(ForeignKeyWidget, self).__init__(*args, **kwargs)
 
-    def clean(self, value):
+    def get_queryset(self, value, row, *args, **kwargs):
+        """
+        Returns a queryset of all objects for this Model.
+
+        Overwrite this method if you want to limit the pool of objects from
+        which the related object is retrieved.
+
+        :param value: The field's value in the datasource.
+        :param row: The datasource's current row.
+
+        As an example; if you'd like to have ForeignKeyWidget look up a Person
+        by their pre- **and** lastname column, you could subclass the widget
+        like so::
+
+            class FullNameForeignKeyWidget(ForeignKeyWidget):
+                def get_queryset(self, value, row):
+                    return self.model.objects.filter(
+                        first_name__iexact=row["first_name"],
+                        last_name__iexact=row["last_name"]
+                    )
+        """
+        return self.model.objects.all()
+
+    def clean(self, value, row=None, *args, **kwargs):
         val = super(ForeignKeyWidget, self).clean(value)
-        return self.model.objects.get(**{self.field: val}) if val else None
+        if val:
+            return self.get_queryset(value, row, *args, **kwargs).get(**{self.field: val})
+        else:
+            return None
 
     def render(self, value):
         if value is None:

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -21,8 +21,7 @@ class Widget(object):
     :meth:`~import_export.widgets.Widget.clean` and
     :meth:`~import_export.widgets.Widget.render`.
     """
-
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         """
         Returns an appropriate Python object for an imported value.
 
@@ -63,7 +62,7 @@ class IntegerWidget(NumberWidget):
     Widget for converting integer fields.
     """
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if self.is_empty(value):
             return None
         return int(float(value))
@@ -74,7 +73,7 @@ class DecimalWidget(NumberWidget):
     Widget for converting decimal fields.
     """
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if self.is_empty(value):
             return None
         return Decimal(value)
@@ -101,7 +100,7 @@ class BooleanWidget(Widget):
             return ""
         return self.TRUE_VALUES[0] if value else self.FALSE_VALUE
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if value == "":
             return None
         return True if value in self.TRUE_VALUES else False
@@ -124,7 +123,7 @@ class DateWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return None
         for format in self.formats:
@@ -161,7 +160,7 @@ class DateTimeWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return None
         for format in self.formats:
@@ -200,7 +199,7 @@ class TimeWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return None
         for format in self.formats:
@@ -312,7 +311,7 @@ class ManyToManyWidget(Widget):
         self.field = field
         super(ManyToManyWidget, self).__init__(*args, **kwargs)
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return self.model.objects.none()
         if isinstance(value, float):

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -156,6 +156,19 @@ class ForeignKeyWidgetTest(TestCase):
     def test_render_empty(self):
         self.assertEqual(self.widget.render(None), "")
 
+    def test_clean_multi_column(self):
+        class BirthdayWidget(widgets.ForeignKeyWidget):
+            def get_queryset(self, value, row):
+                return self.model.objects.filter(
+                    birthday=row['birthday']
+                )
+        author2 = Author.objects.create(name='Foo')
+        author2.birthday = "2016-01-01"
+        author2.save()
+        birthday_widget = BirthdayWidget(Author, 'name')
+        row = {'name': "Foo", 'birthday': author2.birthday}
+        self.assertEqual(birthday_widget.clean("Foo", row), author2)
+
 
 class ManyToManyWidget(TestCase):
 


### PR DESCRIPTION
This commit adds a `get_queryset()` method to `ForeignKeyWidget` and makes `fields.Field` pass row data on to the widget (in case it's a `ForeignKeyWidget`) so that the queryset can be narrowed down in case `ForeignKeyWidget.field` is not unique on its own.