### PR TITLE
Add total counts to import success msg

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -15,6 +15,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import HttpResponseRedirect, HttpResponse
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.template.defaultfilters import pluralize
 
 from .forms import (
     ImportForm,
@@ -141,6 +142,8 @@ class ImportMixin(ImportExportMixinBase):
         '''
         opts = self.model._meta
         resource = self.get_import_resource_class()()
+        total_imports = 0
+        total_updates = 0
 
         confirm_form = ConfirmImportForm(request.POST)
         if confirm_form.is_valid():
@@ -177,8 +180,15 @@ class ImportMixin(ImportExportMixinBase):
                             action_flag=logentry_map[row.import_type],
                             change_message="%s through import_export" % row.import_type,
                         )
+                    if row.import_type == row.IMPORT_TYPE_NEW:
+                        total_imports += 1
+                    elif row.import_type == row.IMPORT_TYPE_UPDATE:
+                        total_updates += 1
 
-            success_message = _('Import finished')
+            success_message = u'Import finished, with {} new {}{} and ' \
+                              u'{} updated {}{}.'.format(total_imports, opts.model_name, pluralize(total_imports),
+                                                         total_updates, opts.model_name, pluralize(total_updates))
+
             messages.success(request, success_message)
             tmp_storage.remove()
 

--- a/tests/core/tests/admin_integration_tests.py
+++ b/tests/core/tests/admin_integration_tests.py
@@ -62,7 +62,7 @@ class ImportExportAdminIntegrationTest(TestCase):
         response = self.client.post('/admin/core/book/process_import/', data,
                                     follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, _('Import finished'))
+        self.assertContains(response, _('Import finished, with 1 new book'))
 
     @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
     def test_import_mac(self):
@@ -96,7 +96,8 @@ class ImportExportAdminIntegrationTest(TestCase):
         response = self.client.post('/admin/core/book/process_import/', data,
                                     follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, _('Import finished'))
+        self.assertContains(response, _('Import finished, with 1 new book'))
+
 
     def test_export(self):
         response = self.client.get('/admin/core/book/export/')

--- a/tests/core/tests/admin_integration_tests.py
+++ b/tests/core/tests/admin_integration_tests.py
@@ -98,7 +98,6 @@ class ImportExportAdminIntegrationTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _('Import finished, with 1 new book'))
 
-
     def test_export(self):
         response = self.client.get('/admin/core/book/export/')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
When importing large lists, it would be helpful for admin to quickly see a count of the total number of new objects versus the updated objects that were already in the database.

I added these counts to the success message that occurs after importing in the admin panel. 