### PR TITLE
Hide default value in diff when importing a new instance

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -341,7 +341,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                     return False
         return True
 
-    def get_diff(self, original, current, dry_run=False):
+    def get_diff(self, original, new, current, dry_run=False):
         """
         Get diff between original and current object when ``import_data``
         is run.
@@ -354,6 +354,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         for field in self.get_fields():
             v1 = self.export_field(field, original) if original else ""
             v2 = self.export_field(field, current) if current else ""
+            if v1 != v2 and new:
+                v1 = ""
             diff = dmp.diff_main(force_text(v1), force_text(v2))
             dmp.diff_cleanupSemantic(diff)
             html = dmp.diff_prettyHtml(diff)
@@ -430,11 +432,11 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             if self.for_delete(row, instance):
                 if new:
                     row_result.import_type = RowResult.IMPORT_TYPE_SKIP
-                    row_result.diff = self.get_diff(None, None, dry_run)
+                    row_result.diff = self.get_diff(None, False, None, dry_run)
                 else:
                     row_result.import_type = RowResult.IMPORT_TYPE_DELETE
                     self.delete_instance(instance, dry_run)
-                    row_result.diff = self.get_diff(original, None, dry_run)
+                    row_result.diff = self.get_diff(original, False, None, dry_run)
             else:
                 self.import_obj(instance, row, dry_run)
                 if self.skip_row(instance, original):
@@ -446,7 +448,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                     # Add object info to RowResult for LogEntry
                     row_result.object_repr = force_text(instance)
                     row_result.object_id = instance.pk
-                row_result.diff = self.get_diff(original, instance, dry_run)
+                row_result.diff = self.get_diff(original, new, instance, dry_run)
             self.after_import_row(row, row_result, **kwargs)
         except Exception as e:
             # There is no point logging a transaction error for each row

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -220,7 +220,7 @@ class ModelResourceTest(TestCase):
 
     def test_get_diff(self):
         book2 = Book(name="Some other book")
-        diff = self.resource.get_diff(self.book, book2)
+        diff = self.resource.get_diff(self.book, False, book2)
         headers = self.resource.get_export_headers()
         self.assertEqual(diff[headers.index('name')],
                          u'<span>Some </span><ins style="background:#e6ffe6;">'
@@ -235,7 +235,7 @@ class ModelResourceTest(TestCase):
         author2 = Author(name="Some author")
         self.book.author = author
         self.book.save()
-        diff = resource.get_diff(author2, author)
+        diff = resource.get_diff(author2, False, author)
         headers = resource.get_export_headers()
         self.assertEqual(diff[headers.index('books')],
                          '<span>core.Book.None</span>')


### PR DESCRIPTION
When importing a new instance that has a field with a default value, the preview diff shows a red deletion for the default value:

![new-instance-showing-default-value](https://cloud.githubusercontent.com/assets/19272434/15263751/a3a659bc-1921-11e6-907c-f3ff1e812453.png)

Since the instance is new, the diff should instead just highlight the new value, since nothing is being deleted. For rows that don't change the default value, continue to show the value without any highlighting:

![new-instance-hiding-default-value](https://cloud.githubusercontent.com/assets/19272434/15263747/8934129a-1921-11e6-8076-6a649ed20e18.png)
