### PR TITLE
Fix diff for objects with RelatedManager attributes

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -432,11 +432,11 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             if self.for_delete(row, instance):
                 if new:
                     row_result.import_type = RowResult.IMPORT_TYPE_SKIP
-                    row_result.diff = self.get_diff(None, False, None, dry_run)
+                    row_result.diff = self.get_diff([], False, [], dry_run)
                 else:
                     row_result.import_type = RowResult.IMPORT_TYPE_DELETE
                     self.delete_instance(instance, dry_run)
-                    row_result.diff = self.get_diff(original, False, None, dry_run)
+                    row_result.diff = self.get_diff(original_fields, False, [], dry_run)
             else:
                 self.import_obj(instance, row, dry_run)
                 if self.skip_row(instance, original):

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import itertools
 import functools
 import sys
 import tablib
@@ -341,7 +342,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                     return False
         return True
 
-    def get_diff(self, original, new, current, dry_run=False):
+    def get_diff(self, original_fields, new, current_fields, dry_run=False):
         """
         Get diff between original and current object when ``import_data``
         is run.
@@ -351,9 +352,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         """
         data = []
         dmp = diff_match_patch()
-        for field in self.get_fields():
-            v1 = self.export_field(field, original) if original else ""
-            v2 = self.export_field(field, current) if current else ""
+        for v1, v2 in itertools.izip(original_fields, current_fields):
             if v1 != v2 and new:
                 v1 = ""
             diff = dmp.diff_main(force_text(v1), force_text(v2))
@@ -429,6 +428,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             row_result.object_repr = force_text(instance)
             row_result.object_id = instance.pk
             original = deepcopy(instance)
+            original_fields = [self.export_field(f, original) if original else "" for f in self.get_fields()]
             if self.for_delete(row, instance):
                 if new:
                     row_result.import_type = RowResult.IMPORT_TYPE_SKIP
@@ -448,7 +448,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                     # Add object info to RowResult for LogEntry
                     row_result.object_repr = force_text(instance)
                     row_result.object_id = instance.pk
-                row_result.diff = self.get_diff(original, new, instance, dry_run)
+                instance_fields = [self.export_field(f, instance) if instance else "" for f in self.get_fields()]
+                row_result.diff = self.get_diff(original_fields, new, instance_fields, dry_run)
             self.after_import_row(row, row_result, **kwargs)
         except Exception as e:
             # There is no point logging a transaction error for each row

--- a/tests/core/fixtures/category.yaml
+++ b/tests/core/fixtures/category.yaml
@@ -1,0 +1,6 @@
+-   model: core.category
+    pk: 1
+    fields: {name: Category1}
+-   model: core.category
+    pk: 2
+    fields: {name: Category2}

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -219,8 +219,12 @@ class ModelResourceTest(TestCase):
         self.assertEqual(len(dataset), 1)
 
     def test_get_diff(self):
+        book_fields = [self.resource.export_field(f, self.book) if self.book else ""
+                       for f in self.resource.get_user_visible_fields()]
         book2 = Book(name="Some other book")
-        diff = self.resource.get_diff(self.book, False, book2)
+        book2_fields = [self.resource.export_field(f, book2) if book2 else ""
+                        for f in self.resource.get_user_visible_fields()]
+        diff = self.resource.get_diff(book_fields, False, book2_fields)
         headers = self.resource.get_export_headers()
         self.assertEqual(diff[headers.index('name')],
                          u'<span>Some </span><ins style="background:#e6ffe6;">'
@@ -235,7 +239,11 @@ class ModelResourceTest(TestCase):
         author2 = Author(name="Some author")
         self.book.author = author
         self.book.save()
-        diff = resource.get_diff(author2, False, author)
+        author_fields = [self.resource.export_field(f, author) if author else ""
+                         for f in self.resource.get_user_visible_fields()]
+        author2_fields = [self.resource.export_field(f, author2) if author2 else ""
+                          for f in self.resource.get_user_visible_fields()]
+        diff = resource.get_diff(author2_fields, False, author_fields)
         headers = resource.get_export_headers()
         self.assertEqual(diff[headers.index('books')],
                          '<span>core.Book.None</span>')


### PR DESCRIPTION
Diffs are incorrect for objects with `RelatedManager` attributes since the lookup (using `export_field()`) obtains the same values for both `original` and `current`. To fix this, the fields in `original` need to be exported before `import_obj()` is called.