### PR TITLE
introduce a new resource option: bulk_replace

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -244,6 +244,18 @@ class ImportMixin(ImportExportMixinBase):
                 return HttpResponse(_(u"<h1>Imported file has a wrong encoding: %s</h1>" % e))
             except Exception as e:
                 return HttpResponse(_(u"<h1>%s encountered while trying to read file: %s</h1>" % (type(e).__name__, import_file.name)))
+
+            if resource._meta.bulk_replace:
+                # No preview
+                resource.bulk_replace_import(dataset)
+                tmp_storage.remove()
+
+                post_import.send(sender=None, model=self.model)
+
+                url = reverse('admin:%s_%s_changelist' % self.get_model_info(),
+                              current_app=self.admin_site.name)
+                return HttpResponseRedirect(url)
+
             result = resource.import_data(dataset, dry_run=True,
                                           raise_errors=False,
                                           file_name=import_file.name,

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -124,6 +124,14 @@ class ResourceOptions(object):
     Controls if the result reports skipped rows Default value is True
     """
 
+    bulk_replace = False
+    """
+    Controls if import should be replace old data.
+    Default value is ``False`` meaning the default behavior.
+    ``True`` meaning delete old data totally, use the imported data.
+    and no preview page.
+    """
+
 
 class DeclarativeMetaclass(type):
 
@@ -545,6 +553,17 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 savepoint_commit(sp1)
 
         return result
+
+    @atomic()
+    def bulk_replace_import(self, dataset):
+        """
+
+        :param dataset: A ``tablib.Dataset``
+        """
+        data_list = [self._meta.model(**row) for row in dataset.dict]
+
+        self._meta.model.objects.all().delete()
+        self._meta.model.objects.bulk_create(data_list)
 
     def get_export_order(self):
         order = tuple(self._meta.export_order or ())


### PR DESCRIPTION
default is False, When set to True,
The import will finish immediately (if no errors).
Old data will be delete first, and using the imported data.
No preview page.
This will speed up the import time when import a large dataset.

Example:

``` python
class ResourceMyModel(resources.ModelResource):
    class Meta:
        model = MyModel
        bulk_replace = True
```

when import MyModel dataset,  No preview page,
and the old data will be deleted, using the imported data totally.

**NOTE**:

the model can not has `ForeignKey`,  `OneToOneField`, `ManyToManyField`.
