### PR TITLE
[IMP] add meta option to disable use of iterator on resource export

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,7 +67,8 @@ The following is a list of much appreciated contributors:
 * carlosp420 (Carlos Peña)
 * freelancersunion (Freelancers Union)
 * jbradberry (Jeff Bradberry)
-* antoniablair 
+* antoniablair
 * kellerkind
 * yueyoum (Johnnie Wang)
 * shaggyfrog (Thomas Hauk)
+* pacotole (Paco Toledo)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -124,6 +124,13 @@ class ResourceOptions(object):
     Controls if the result reports skipped rows Default value is True
     """
 
+    use_iterator = True
+    """
+    Controls if export should use queryset iterator. Default value is
+    ``True``. Set to ``False`` if you want to use prefetch_related in
+    the export_queryset
+    """
+
 
 class DeclarativeMetaclass(type):
 
@@ -596,7 +603,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         headers = self.get_export_headers()
         data = tablib.Dataset(headers=headers)
 
-        if isinstance(queryset, QuerySet):
+        if self._meta.use_iterator and isinstance(queryset, QuerySet):
             # Iterate without the queryset cache, to avoid wasting memory when
             # exporting large datasets.
             iterable = queryset.iterator()


### PR DESCRIPTION
In complex exports with Many-to-one relationships the export method hit database for every object.
I optimize the queryset on `get_export_queryset()` prefetching related data but the use of iterator() ignore that.
I added a `use_iterator` meta option to disable it if is desired in a specific ModelResource.
