### PR TITLE
Fix #375: add row to widget.clean(), obj to widget.render()

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -62,8 +62,16 @@ class Field(object):
                            "columns are: %s" % (self.column_name,
                                                 list(data.keys())))
 
+        # If this Field uses a ForeignKeyWidget, also pass the row data to the
+        # widget's clean method because it might be needed for additional
+        # filtering on the related objects queryset.
+        if isinstance(self.widget, widgets.ForeignKeyWidget):
+            clean_args = (value, data)
+        else:
+            clean_args = (value,)
+
         try:
-            value = self.widget.clean(value)
+            value = self.widget.clean(*clean_args)
         except ValueError as e:
             raise ValueError("Column '%s': %s" % (self.column_name, e))
 

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -62,16 +62,8 @@ class Field(object):
                            "columns are: %s" % (self.column_name,
                                                 list(data.keys())))
 
-        # If this Field uses a ForeignKeyWidget, also pass the row data to the
-        # widget's clean method because it might be needed for additional
-        # filtering on the related objects queryset.
-        if isinstance(self.widget, widgets.ForeignKeyWidget):
-            clean_args = (value, data)
-        else:
-            clean_args = (value,)
-
         try:
-            value = self.widget.clean(*clean_args)
+            value = self.widget.clean(value, row=data)
         except ValueError as e:
             raise ValueError("Column '%s': %s" % (self.column_name, e))
 

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -119,4 +119,4 @@ class Field(object):
         value = self.get_value(obj)
         if value is None:
             return ""
-        return self.widget.render(value)
+        return self.widget.render(value, obj)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -34,7 +34,7 @@ class Widget(object):
         """
         return value
 
-    def render(self, value):
+    def render(self, value, obj=None):
         """
         Returns an export representation of a Python value.
 
@@ -53,7 +53,7 @@ class NumberWidget(Widget):
         # 0 is not empty
         return value is None or value == ""
 
-    def render(self, value):
+    def render(self, value, obj=None):
         return value
 
 
@@ -62,7 +62,7 @@ class FloatWidget(NumberWidget):
     Widget for converting floats fields.
     """
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if self.is_empty(value):
             return None
         return float(value)
@@ -95,7 +95,7 @@ class CharWidget(Widget):
     Widget for converting text fields.
     """
 
-    def render(self, value):
+    def render(self, value, obj=None):
         return force_text(value)
 
 
@@ -106,7 +106,7 @@ class BooleanWidget(Widget):
     TRUE_VALUES = ["1", 1]
     FALSE_VALUE = "0"
 
-    def render(self, value):
+    def render(self, value, obj=None):
         if value is None:
             return ""
         return self.TRUE_VALUES[0] if value else self.FALSE_VALUE
@@ -144,7 +144,7 @@ class DateWidget(Widget):
                 continue
         raise ValueError("Enter a valid date.")
 
-    def render(self, value):
+    def render(self, value, obj=None):
         if not value:
             return ""
         try:
@@ -187,7 +187,7 @@ class DateTimeWidget(Widget):
                 continue
         raise ValueError("Enter a valid date/time.")
 
-    def render(self, value):
+    def render(self, value, obj=None):
         if not value:
             return ""
         return value.strftime(self.formats[0])
@@ -220,7 +220,7 @@ class TimeWidget(Widget):
                 continue
         raise ValueError("Enter a valid time.")
 
-    def render(self, value):
+    def render(self, value, obj=None):
         if not value:
             return ""
         return value.strftime(self.formats[0])
@@ -296,7 +296,7 @@ class ForeignKeyWidget(Widget):
         else:
             return None
 
-    def render(self, value):
+    def render(self, value, obj=None):
         if value is None:
             return ""
         return getattr(value, self.field)
@@ -334,6 +334,6 @@ class ManyToManyWidget(Widget):
             '%s__in' % self.field: ids
         })
 
-    def render(self, value):
+    def render(self, value, obj=None):
         ids = [smart_text(getattr(obj, self.field)) for obj in value.all()]
         return self.separator.join(ids)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -21,8 +21,7 @@ class Widget(object):
     :meth:`~import_export.widgets.Widget.clean` and
     :meth:`~import_export.widgets.Widget.render`.
     """
-
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         """
         Returns an appropriate Python object for an imported value.
 
@@ -74,7 +73,7 @@ class IntegerWidget(NumberWidget):
     Widget for converting integer fields.
     """
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if self.is_empty(value):
             return None
         return int(float(value))
@@ -85,7 +84,7 @@ class DecimalWidget(NumberWidget):
     Widget for converting decimal fields.
     """
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if self.is_empty(value):
             return None
         return Decimal(value)
@@ -112,7 +111,7 @@ class BooleanWidget(Widget):
             return ""
         return self.TRUE_VALUES[0] if value else self.FALSE_VALUE
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if value == "":
             return None
         return True if value in self.TRUE_VALUES else False
@@ -135,7 +134,7 @@ class DateWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return None
         for format in self.formats:
@@ -172,7 +171,7 @@ class DateTimeWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return None
         for format in self.formats:
@@ -211,7 +210,7 @@ class TimeWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return None
         for format in self.formats:
@@ -323,7 +322,7 @@ class ManyToManyWidget(Widget):
         self.field = field
         super(ManyToManyWidget, self).__init__(*args, **kwargs)
 
-    def clean(self, value):
+    def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return self.model.objects.none()
         if isinstance(value, float):

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -156,6 +156,19 @@ class ForeignKeyWidgetTest(TestCase):
     def test_render_empty(self):
         self.assertEqual(self.widget.render(None), "")
 
+    def test_clean_multi_column(self):
+        class BirthdayWidget(widgets.ForeignKeyWidget):
+            def get_queryset(self, value, row):
+                return self.model.objects.filter(
+                    birthday=row['birthday']
+                )
+        author2 = Author.objects.create(name='Foo')
+        author2.birthday = "2016-01-01"
+        author2.save()
+        birthday_widget = BirthdayWidget(Author, 'name')
+        row = {'name': "Foo", 'birthday': author2.birthday}
+        self.assertEqual(birthday_widget.clean("Foo", row), author2)
+
 
 class ManyToManyWidget(TestCase):
 


### PR DESCRIPTION
_I accidentally force-pushed/deleted the original pull request branch and as I don't have the means to reopen [the previous pull request](https://github.com/django-import-export/django-import-export/pull/420) I'm opening a new one. Please excuse this._

This pull request adds a `get_queryset()` method to `ForeignKeyWidget` and makes `fields.Field` pass row data on to the widgets so that the queryset can be narrowed down in case `ForeignKeyWidget.field` is not unique on its own.

The `obj` is exposed to `widget.export()` as a kwarg as well.

This pull request is related to the following issues: #375 #188 #378 
All tests pass on current master branch.
