### PR TITLE
Use optimized xlsx reader

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -40,8 +40,6 @@ try:
 except ImportError:
     from django.utils.importlib import import_module
 
-from django.utils import six
-
 
 class Format(object):
     def get_title(self):
@@ -209,13 +207,16 @@ class XLSX(TablibFormat):
         """
         assert XLSX_IMPORT
         from io import BytesIO
-        xlsx_book = openpyxl.load_workbook(BytesIO(in_stream))
+        xlsx_book = openpyxl.load_workbook(BytesIO(in_stream), read_only=True)
 
         dataset = tablib.Dataset()
         sheet = xlsx_book.active
 
-        dataset.headers = [cell.value for cell in sheet.rows[0]]
-        for i in moves.range(1, len(sheet.rows)):
-            row_values = [cell.value for cell in sheet.rows[i]]
+        # obtain generator
+        rows = sheet.rows
+        dataset.headers = [cell.value for cell in next(rows)]
+
+        for row in rows:
+            row_values = [cell.value for cell in row]
             dataset.append(row_values)
         return dataset


### PR DESCRIPTION
I was wondering why it takes so long to import 4000 rows long xlsx file with only two columns, made some measurements and it turned out it takes around 150 second only to populate dataset. Found out there's [optimized way for read-only mode](http://openpyxl.readthedocs.io/en/default/optimized.html#read-only-mode) in `openpyxl`.

So here's a little enhancement to make use of it. On my machine it reduced read time to 0.5 seconds for the same file so I thought it might be useful to others.

Unit test for it is already there, let me know if you want some performance reports or something (tbh I'm not sure how to "officially" prove performance boost 😶 ).