### PR TITLE
Collect failed rows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="Django>=1.10,<1.11"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 install:
   - pip install -q $DJANGO
@@ -20,6 +21,8 @@ matrix:
   exclude:
     - python: "3.3"
       env: DJANGO="Django>=1.9,<1.10"
+    - python: "3.3"
+      env: DJANGO="Django>=1.10,<1.11"
     - python: "3.3"
       env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
     - python: "3.5"

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -179,7 +179,7 @@ class ImportMixin(ImportExportMixinBase):
                 }
                 content_type_id = ContentType.objects.get_for_model(self.model).pk
                 for row in result:
-                    if row.import_type != row.IMPORT_TYPE_SKIP:
+                    if row.import_type != row.IMPORT_TYPE_ERROR and row.import_type != row.IMPORT_TYPE_SKIP:
                         LogEntry.objects.log_action(
                             user_id=request.user.pk,
                             content_type_id=content_type_id,

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -473,7 +473,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         return row_result
 
     def import_data(self, dataset, dry_run=False, raise_errors=False,
-                    use_transactions=None, **kwargs):
+                    use_transactions=None, collect_failed_rows=False, **kwargs):
         """
         Imports data from ``tablib.Dataset``. Refer to :doc:`import_workflow`
         for a more complete description of the whole import process.
@@ -483,8 +483,11 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         :param raise_errors: Whether errors should be printed to the end user
             or raised regularly.
 
-        :param use_transactions: If ``True`` import process will be processed
-            inside transaction.
+        :param use_transactions: If ``True`` the import process will be processed
+            inside a transaction.
+
+        :param collect_failed_rows: If ``True`` the import process will collect
+            failed rows.
 
         :param dry_run: If ``dry_run`` is set, or an error occurs, if a transaction
             is being used, it will be rolled back.
@@ -503,18 +506,13 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
         if using_transactions:
             with transaction.atomic():
-                return self.import_data_inner(dataset, dry_run, raise_errors, using_transactions, **kwargs)
-        return self.import_data_inner(dataset, dry_run, raise_errors, using_transactions, **kwargs)
+                return self.import_data_inner(dataset, dry_run, raise_errors, using_transactions, collect_failed_rows, **kwargs)
+        return self.import_data_inner(dataset, dry_run, raise_errors, using_transactions, collect_failed_rows, **kwargs)
 
-    def import_data_inner(self, dataset, dry_run, raise_errors, using_transactions, **kwargs):
+    def import_data_inner(self, dataset, dry_run, raise_errors, using_transactions, collect_failed_rows, **kwargs):
         result = self.get_result_class()()
         result.diff_headers = self.get_diff_headers()
-        result.totals = OrderedDict([(RowResult.IMPORT_TYPE_NEW, 0),
-                                     (RowResult.IMPORT_TYPE_UPDATE, 0),
-                                     (RowResult.IMPORT_TYPE_DELETE, 0),
-                                     (RowResult.IMPORT_TYPE_SKIP, 0),
-                                     (RowResult.IMPORT_TYPE_ERROR, 0),
-                                     ('total', len(dataset))])
+        result.total_rows = len(dataset)
 
         if using_transactions:
             # when transactions are used we want to create/update/delete object
@@ -526,7 +524,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         except Exception as e:
             logging.exception(e)
             tb_info = traceback.format_exc()
-            result.base_errors.append(self.get_error_result_class()(e, tb_info))
+            result.append_base_error(self.get_error_result_class()(e, tb_info))
             if raise_errors:
                 if using_transactions:
                     savepoint_rollback(sp1)
@@ -535,18 +533,18 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         instance_loader = self._meta.instance_loader_class(self, dataset)
 
         # Update the total in case the dataset was altered by before_import()
-        result.totals['total'] = len(dataset)
+        result.total_rows = len(dataset)
 
         for row in dataset.dict:
             row_result = self.import_row(row, instance_loader, using_transactions, dry_run, **kwargs)
+            result.increment_row_result_total(row_result)
             if row_result.errors:
-                result.totals[row_result.IMPORT_TYPE_ERROR] += 1
+                if collect_failed_rows:
+                    result.append_failed_row(row)
                 if raise_errors:
                     if using_transactions:
                         savepoint_rollback(sp1)
                     raise row_result.errors[-1].error
-            else:
-                result.totals[row_result.import_type] += 1
             if (row_result.import_type != RowResult.IMPORT_TYPE_SKIP or
                     self._meta.report_skipped):
                 result.append_row_result(row_result)
@@ -556,7 +554,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         except Exception as e:
             logging.exception(e)
             tb_info = traceback.format_exc()
-            result.base_errors.append(self.get_error_result_class()(e, tb_info))
+            result.append_base_error(self.get_error_result_class()(e, tb_info))
             if raise_errors:
                 if using_transactions:
                     savepoint_rollback(sp1)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -536,6 +536,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         # Update the total in case the dataset was altered by before_import()
         result.total_rows = len(dataset)
 
+        if collect_failed_rows:
+            result.failed_dataset.headers = dataset.headers
+
         for row in dataset.dict:
             row_result = self.import_row(row, instance_loader, using_transactions, dry_run, **kwargs)
             result.increment_row_result_total(row_result)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -427,8 +427,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         :param dry_run: If ``dry_run`` is set, or error occurs, transaction
             will be rolled back.
         """
+        row_result = self.get_row_result_class()()
+        row_result.import_type = RowResult.IMPORT_TYPE_ERROR
         try:
-            row_result = self.get_row_result_class()()
             self.before_import_row(row, **kwargs)
             instance, new = self.get_or_init_instance(instance_loader, row)
             self.after_import_instance(instance, new, **kwargs)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -537,14 +537,14 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         result.total_rows = len(dataset)
 
         if collect_failed_rows:
-            result.failed_dataset.headers = dataset.headers
+            result.add_dataset_headers(dataset.headers)
 
         for row in dataset.dict:
             row_result = self.import_row(row, instance_loader, using_transactions, dry_run, **kwargs)
             result.increment_row_result_total(row_result)
             if row_result.errors:
                 if collect_failed_rows:
-                    result.append_failed_row(row)
+                    result.append_failed_row(row, row_result.errors[0])
                 if raise_errors:
                     if using_transactions:
                         savepoint_rollback(sp1)

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     from django.utils.datastructures import SortedDict as OrderedDict
 
+from tablib import Dataset
+
 
 class Error(object):
     def __init__(self, error, traceback=None, row=None):
@@ -32,7 +34,7 @@ class Result(object):
         self.base_errors = []
         self.diff_headers = []
         self.rows = []  # RowResults
-        self.failed_rows = []
+        self.failed_dataset = Dataset()
         self.totals = OrderedDict([(RowResult.IMPORT_TYPE_NEW, 0),
                                    (RowResult.IMPORT_TYPE_UPDATE, 0),
                                    (RowResult.IMPORT_TYPE_DELETE, 0),
@@ -47,7 +49,8 @@ class Result(object):
         self.base_errors.append(error)
 
     def append_failed_row(self, row):
-        self.failed_rows.append(row)
+        row_values = [v for (k, v) in row.items()]
+        self.failed_dataset.append(row_values)
 
     def increment_row_result_total(self, row_result):
         if row_result.import_type:

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -48,8 +48,12 @@ class Result(object):
     def append_base_error(self, error):
         self.base_errors.append(error)
 
-    def append_failed_row(self, row):
+    def add_dataset_headers(self, headers):
+        self.failed_dataset.headers = headers + ["Error"]
+
+    def append_failed_row(self, row, error):
         row_values = [v for (k, v) in row.items()]
+        row_values.append(error.error.message)
         self.failed_dataset.append(row_values)
 
     def increment_row_result_total(self, row_result):

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -1,8 +1,12 @@
 from __future__ import unicode_literals
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
+
 
 class Error(object):
-
     def __init__(self, error, traceback=None, row=None):
         self.error = error
         self.traceback = traceback
@@ -23,14 +27,31 @@ class RowResult(object):
 
 
 class Result(object):
-
     def __init__(self, *args, **kwargs):
-        super(Result, self).__init__(*args, **kwargs)
+        super(Result, self).__init__()
         self.base_errors = []
-        self.rows = []
+        self.diff_headers = []
+        self.rows = []  # RowResults
+        self.failed_rows = []
+        self.totals = OrderedDict([(RowResult.IMPORT_TYPE_NEW, 0),
+                                   (RowResult.IMPORT_TYPE_UPDATE, 0),
+                                   (RowResult.IMPORT_TYPE_DELETE, 0),
+                                   (RowResult.IMPORT_TYPE_SKIP, 0),
+                                   (RowResult.IMPORT_TYPE_ERROR, 0)])
+        self.total_rows = 0
 
     def append_row_result(self, row_result):
         self.rows.append(row_result)
+
+    def append_base_error(self, error):
+        self.base_errors.append(error)
+
+    def append_failed_row(self, row):
+        self.failed_rows.append(row)
+
+    def increment_row_result_total(self, row_result):
+        if row_result.import_type:
+            self.totals[row_result.import_type] += 1
 
     def row_errors(self):
         return [(i + 1, row.errors)

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -730,7 +730,6 @@ class PostgresTests(TransactionTestCase):
             [u'id', u'user', u'Error']
         )
         self.assertEqual(len(result.failed_dataset), 1)
-        self.assertEqual(len(result.failed_dataset), 1)
         self.assertEqual(
             result.failed_dataset.dict[0]['Error'],
             'NOT NULL constraint failed: core_profile.user_id'

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -730,10 +730,7 @@ class PostgresTests(TransactionTestCase):
             [u'id', u'user', u'Error']
         )
         self.assertEqual(len(result.failed_dataset), 1)
-        self.assertEqual(
-            result.failed_dataset.dict[0]['Error'],
-            'NOT NULL constraint failed: core_profile.user_id'
-        )
+        # We can't check the error message because it's package- and version-dependent
 
 
 if VERSION >= (1, 8) and 'postgresql' in settings.DATABASES['default']['ENGINE']:


### PR DESCRIPTION
With transactionality restored, add a flag to tell `process_import()` to collect rows that fail to import in a `Dataset`. We use this to save the failed rows to a file, and then allow the user to download the file to see what rows failed, and with what error message.