### PR TITLE
Update doc links to the stable version, update rtfd to .io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ django-import-export
     :target: https://pypi.python.org/pypi/django-import-export
     :alt: Downloads per month on PyPi
 
-.. image:: http://readthedocs.org/projects/django-import-export/badge/?version=latest
-    :target: http://django-import-export.rtfd.org
+.. image:: http://readthedocs.org/projects/django-import-export/badge/?version=stable
+    :target: http://django-import-export.readthedocs.io/en/stable/
     :alt: Docmentation
 
 django-import-export is a Django application and library for importing
@@ -37,7 +37,7 @@ Features:
 .. image:: docs/_static/images/django-import-export-change.png
 
 
-* Documentation: https://django-import-export.readthedocs.org/en/latest/
+* Documentation: http://django-import-export.readthedocs.io/en/stable/
 * GitHub: https://github.com/django-import-export/django-import-export/
 * Free software: BSD license
 * PyPI: https://pypi.python.org/pypi/django-import-export/


### PR DESCRIPTION
The links to read the docs are currently pointing to the latest version, currently 98 commits ahead of the latest release. Some hooks have been added (e.g. `before_import_row` on the `Resource`) and are therefore documented but not present in the latest version installable with `pip`.

Suggest to update the links in README to the stable one. Also to be updated in the repository description.

I also updated the URLs according to their [blog post from the 27th April](https://blog.readthedocs.com/securing-subdomains/):

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.