### PR TITLE
Error in converting exceptions to strings

### DIFF
--- a/import_export/results.py
+++ b/import_export/results.py
@@ -53,7 +53,7 @@ class Result(object):
 
     def append_failed_row(self, row, error):
         row_values = [v for (k, v) in row.items()]
-        row_values.append(error.error.message)
+        row_values.append(str(error.error))
         self.failed_dataset.append(row_values)
 
     def increment_row_result_total(self, row_result):


### PR DESCRIPTION
Unless I'm misunderstanding something, the `Exception` class' `message` attribute has been removed in python 2.7/3.0 (at least according to https://www.python.org/dev/peps/pep-0352/#retracted-ideas).

Exceptions should now be converted to strings using `str()`.

This caused an error for me when when a `ValueError` was caught during a dry run with `collect_failed_rows=True`. I'm running Python 3.4.3.