### PR TITLE
Add support for extra fields through methods on resource class.

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -201,4 +201,10 @@ class ResourceField(Field):
                          "export_%s" % self.attribute,
                          None)
 
+        if hasattr(self.resource, self.attribute):
+            field = getattr(self.resource, self.attribute)
+
+            if field.widget:
+                return field.widget.clean(method(obj))
+
         return method(obj)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -188,9 +188,18 @@ class Diff(object):
         return data
 
     def _export_resource_fields(self, resource, instance):
-        return [getattr(instance, f.column_name,
-                resource.export_field(f, instance)) if instance else ""
-                for f in resource.get_user_visible_fields()]
+        fields = []
+        for f in resource.get_user_visible_fields():
+            if instance:
+                try:
+                    value = getattr(instance, f.column_name)
+                except:
+                    fields.append(resource.export_field(f, instance))
+                else:
+                    fields.append(value)
+            else:
+                fields.append("")
+        return fields
 
 
 class Resource(six.with_metaclass(DeclarativeMetaclass)):


### PR DESCRIPTION
Really small change which adds support for simple extra fields without custom field classes, everything works as classic model attributes.

```
    class MyModelResource(ModelReource):

        def export_myextra_field(self, obj):

            return obj.related.value

        def save_myextra_field(self, obj, data):
            # optional

            RelatedObject.create(**data)
            RelatedObject1.create(**data)

        def get_myextra_field_name(self):
            # optional

            return "ColumnName"
```
