### PR TITLE
Convert exception to string using six.text_type(error.error) instead of using error.error.message

### DIFF
--- a/import_export/results.py
+++ b/import_export/results.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import six
+
 try:
     from collections import OrderedDict
 except ImportError:
@@ -53,7 +55,7 @@ class Result(object):
 
     def append_failed_row(self, row, error):
         row_values = [v for (k, v) in row.items()]
-        row_values.append(error.error.message)
+        row_values.append(six.text_type(error.error))
         self.failed_dataset.append(row_values)
 
     def increment_row_result_total(self, row_result):


### PR DESCRIPTION
Same as #526 but uses six.text_type() instead of str()