### PR TITLE
support for using model field verbose_name

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -124,6 +124,11 @@ class ResourceOptions(object):
     Controls if the result reports skipped rows Default value is True
     """
 
+    verbose_name = False
+    """
+    Controls if column name used from Django's model verbose_name attribute. Default value is False
+    """
+
 
 class DeclarativeMetaclass(type):
 
@@ -779,11 +784,15 @@ class ModelResource(six.with_metaclass(ModelDeclarativeMetaclass, Resource)):
         Returns a Resource Field instance for the given Django model field.
         """
 
+        column_name = field_name
+        if self._meta.verbose_name:
+            column_name = django_field.verbose_name
+
         FieldWidget = self.widget_from_django_field(django_field)
         widget_kwargs = self.widget_kwargs_for_field(field_name)
         field = Field(
             attribute=field_name,
-            column_name=field_name,
+            column_name=column_name,
             widget=FieldWidget(**widget_kwargs),
             readonly=readonly,
             default=django_field.default,


### PR DESCRIPTION
add support for using verbose_name instead of the default models field name attribute
controllable via flag in Resource Meta via verbose_name flag (default False)