### PR TITLE
Remove checking if DB engine supports transaction during import

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -496,13 +496,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if use_transactions is None:
             use_transactions = self.get_use_transactions()
 
-        connection = connections[DEFAULT_DB_ALIAS]
-        supports_transactions = getattr(connection.features, "supports_transactions", False)
-
-        if use_transactions and not supports_transactions:
-            raise ImproperlyConfigured
-
-        using_transactions = (use_transactions or dry_run) and supports_transactions
+        using_transactions = use_transactions or dry_run
 
         if using_transactions:
             with transaction.atomic():


### PR DESCRIPTION
PR #480 introduced proper handling of transactions during import, but with additional check if DB engine does support transactions.

When transaction is already in atomic block (for example by using `ATOMIC_REQUESTS` in Django DB conf) and `import_data` performs check if DB support transaction, in some cases (like MySQL), this check tries to call `set_autocommit`, which is forbidden in atomic block. This fix it by not using `supports_transaction` at all (it's not used in whole Django at all either, besides tests) - previously user receives `ImproperlyConfigured` exception - now `transaction.atomic` will go through silently (for example in MyISAM case) or raise another exception to user, but it'll work for all engines that support DB transactions when transaction block is already entered.