### PR TITLE
Add support for the Django DurationField with DurationWidget.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ local_settings.py
 docs/_build
 build/
 dist/
+/django-import-export/
 *.egg-info/
 .tox/
 .idea/

--- a/AUTHORS
+++ b/AUTHORS
@@ -85,3 +85,4 @@ The following is a list of much appreciated contributors:
 * adamcharnock (Adam Charnock)
 * paveltyavin (Pavel)
 * jameshiew (James Hiew)
+* mgrdcm (Dan Moore)

--- a/docs/api_widgets.rst
+++ b/docs/api_widgets.rst
@@ -26,6 +26,9 @@ Widgets
 .. autoclass:: import_export.widgets.DateTimeWidget
    :members:
 
+.. autoclass:: import_export.widgets.DurationWidget
+   :members:
+
 .. autoclass:: import_export.widgets.ForeignKeyWidget
    :members:
 

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -747,6 +747,8 @@ class ModelResource(six.with_metaclass(ModelDeclarativeMetaclass, Resource)):
             result = widgets.DateWidget
         elif internal_type in ('TimeField', ):
             result = widgets.TimeWidget
+        elif internal_type in ('DurationField', ):
+            result = widgets.DurationWidget
         elif internal_type in ('FloatField',):
             result = widgets.FloatWidget
         elif internal_type in ('IntegerField', 'PositiveIntegerField',

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -12,6 +12,12 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
+try:
+    from django.utils.dateparse import parse_duration
+except ImportError:
+    # Duration fields were added in Django 1.8
+    pass
+
 
 class Widget(object):
     """
@@ -228,6 +234,29 @@ class TimeWidget(Widget):
         if not value:
             return ""
         return value.strftime(self.formats[0])
+
+
+class DurationWidget(Widget):
+    """
+    Widget for converting time duration fields.
+    """
+
+    def clean(self, value, row=None, *args, **kwargs):
+        if not value:
+            return None
+
+        try:
+            return parse_duration(value)
+        except NameError:
+            # Duration fields were added in Django 1.8
+            raise RuntimeError("Duration parsing not supported.")
+        except (ValueError, TypeError):
+            raise ValueError("Enter a valid duration.")
+
+    def render(self, value, obj=None):
+        if not value:
+            return ""
+        return str(value)
 
 
 class SimpleArrayWidget(Widget):

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from decimal import Decimal
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
+from unittest import SkipTest
 
 from django.test.utils import override_settings
 from django.test import TestCase
@@ -105,6 +106,29 @@ class TimeWidgetTest(TestCase):
 
     def test_clean(self):
         self.assertEqual(self.widget.clean("20:15:00"), self.time)
+
+
+class DurationWidgetTest(TestCase):
+
+    def setUp(self):
+
+        try:
+            from django.utils.dateparse import parse_duration
+        except ImportError:
+            # Duration fields were added in Django 1.8
+            raise SkipTest
+
+        self.duration = timedelta(hours=1, minutes=57, seconds=0)
+        self.widget = widgets.DurationWidget()
+
+    def test_render(self):
+        self.assertEqual(self.widget.render(self.duration), "1:57:00")
+
+    def test_render_none(self):
+        self.assertEqual(self.widget.render(None), "")
+
+    def test_clean(self):
+        self.assertEqual(self.widget.clean("1:57:00"), self.duration)
 
 
 class DecimalWidgetTest(TestCase):


### PR DESCRIPTION
Django 1.8 added the [DurationField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#durationfield) which allows storing of a time duration (a Python [timedelta](https://docs.python.org/2/library/datetime.html#datetime.timedelta)).

Since there's no standard built-in parsing of `timedelta`, I'm tying this to Django's `DurationField` and using the [parse_duration](https://docs.djangoproject.com/en/1.10/ref/utils/#django.utils.dateparse.parse_duration) helper.  This means it won't be supported on Django < 1.8, but this change handles that by ignoring them.

_Also adding `/django-import-export/` to gitignore because the tests create files there._