### PR TITLE
updated render function for DateTimeWidget

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,3 +87,4 @@ The following is a list of much appreciated contributors:
 * jameshiew (James Hiew)
 * mgrdcm (Dan Moore)
 * korkmaz (Ahmet Korkmaz)
+* pankeshang (Pan Keshang)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -202,7 +202,7 @@ class DateTimeWidget(Widget):
             return ""
         if settings.USE_TZ and value.tzinfo is not None and \
                 value.tzinfo.utcoffset(value) is not None:
-            value = current_timezone.normalize(value)
+            value = timezone.get_current_timezone().normalize(value)
         return value.strftime(self.formats[0])
 
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -200,6 +200,9 @@ class DateTimeWidget(Widget):
     def render(self, value, obj=None):
         if not value:
             return ""
+        if settings.USE_TZ and value.tzinfo is not None and \
+                value.tzinfo.utcoffset(value) is not None:
+            value = current_timezone.normalize(value)
         return value.strftime(self.formats[0])
 
 


### PR DESCRIPTION
During export, if django is set to USE_TZ=True and the datetime object is timezone-aware, normalize it to the webisite's current timezone.
