### PR TITLE
Fix admin integration tests for the new "Import finished..." message

### DIFF
--- a/tests/core/tests/admin_integration_tests.py
+++ b/tests/core/tests/admin_integration_tests.py
@@ -11,7 +11,7 @@ from django.contrib.admin.models import LogEntry
 from tablib import Dataset
 
 from core.admin import BookAdmin, AuthorAdmin, BookResource
-from core.models import Category, Parent
+from core.models import Category, Parent, Book
 
 
 class ImportExportAdminIntegrationTest(TestCase):
@@ -64,7 +64,10 @@ class ImportExportAdminIntegrationTest(TestCase):
         response = self.client.post('/admin/core/book/process_import/', data,
                                     follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, _('Import finished, with 1 new book'))
+        self.assertContains(response, 
+            _(u'Import finished, with {} new and {} updated {}.').format(
+                1, 0, Book._meta.verbose_name_plural)
+        )
 
     @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
     def test_import_mac(self):
@@ -98,7 +101,10 @@ class ImportExportAdminIntegrationTest(TestCase):
         response = self.client.post('/admin/core/book/process_import/', data,
                                     follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, _('Import finished, with 1 new book'))
+        self.assertContains(response, 
+            _(u'Import finished, with {} new and {} updated {}.').format(
+                1, 0, Book._meta.verbose_name_plural)
+        )
 
     def test_export(self):
         response = self.client.get('/admin/core/book/export/')


### PR DESCRIPTION
Fixing the admin integration test broken by changing the format of the "Import finished with..." status message in admin integration. Hopefully this is a proper approach for that particular test case. Thanks.