### PR TITLE
Update import of reverse for django 2.x

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -13,7 +13,6 @@ from django.contrib import messages
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
 from django.contrib.contenttypes.models import ContentType
 from django.http import HttpResponseRedirect, HttpResponse
-from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.template.defaultfilters import pluralize
 from django.utils.decorators import method_decorator
@@ -38,6 +37,10 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
 SKIP_ADMIN_LOG = getattr(settings, 'IMPORT_EXPORT_SKIP_ADMIN_LOG', False)
 TMP_STORAGE_CLASS = getattr(settings, 'IMPORT_EXPORT_TMP_STORAGE_CLASS',
                             TempFolderStorage)


### PR DESCRIPTION
According to https://docs.djangoproject.com/en/1.11/ref/urlresolvers/:

> In older versions, these functions are located in django.core.urlresolvers. Importing from the old location will continue to work until Django 2.0.