### PR TITLE
Remove workaround for Python 2.6 wrt OrderedDict

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import functools
 import tablib
 import traceback
+from collections import OrderedDict
 from copy import deepcopy
 
 from diff_match_patch import diff_match_patch
@@ -40,11 +41,6 @@ try:
     from django.utils.encoding import force_text
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging  # isort:skip

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -1,9 +1,6 @@
 from __future__ import unicode_literals
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
+from collections import OrderedDict
 
 from tablib import Dataset
 


### PR DESCRIPTION
`collections.OrderedDict` was added to Python starting with 2.7. As django-import-export only supports Python 2.7+ or Python 3.3+, can safely rely on the stdlib version of `OrderedDict`.