### PR TITLE
Remove unnecessary calls to dict.keys()

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -62,8 +62,7 @@ class Field(object):
             value = data[self.column_name]
         except KeyError:
             raise KeyError("Column '%s' not found in dataset. Available "
-                           "columns are: %s" % (self.column_name,
-                                                list(data.keys())))
+                           "columns are: %s" % (self.column_name, list(data)))
 
         try:
             value = self.widget.clean(value, row=data)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -586,7 +586,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
     def get_export_order(self):
         order = tuple(self._meta.export_order or ())
-        return order + tuple(k for k in self.fields.keys() if k not in order)
+        return order + tuple(k for k in self.fields if k not in order)
 
     def before_export(self, queryset, *args, **kwargs):
         """

--- a/tests/core/tests/instance_loaders_tests.py
+++ b/tests/core/tests/instance_loaders_tests.py
@@ -25,7 +25,7 @@ class CachedInstanceLoaderTest(TestCase):
     def test_all_instances(self):
         self.assertTrue(self.instance_loader.all_instances)
         self.assertEqual(len(self.instance_loader.all_instances), 1)
-        self.assertEqual(list(self.instance_loader.all_instances.keys()),
+        self.assertEqual(list(self.instance_loader.all_instances),
                          [self.book.pk])
 
     def test_get_instance(self):


### PR DESCRIPTION
`iter(dict)` is identical to `iter(dict.keys())`. The call to `.keys()` is unnecessary and only adds noise. Remove these unnecessary calls.

Inspired by Lennart Regebro's presentation "Prehistoric Patterns' at PyCon 2017. Available at:

https://www.youtube.com/watch?v=V5-JH23Vk0I