### PR TITLE
Replace dict(<list_comprehension>) pattern with dict comprehension

### DIFF
--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -55,9 +55,10 @@ class CachedInstanceLoader(ModelInstanceLoader):
             "%s__in" % self.pk_field.attribute: ids
             })
 
-        self.all_instances = dict([
-            (self.pk_field.get_value(instance), instance)
-            for instance in qs])
+        self.all_instances = {
+            self.pk_field.get_value(instance): instance
+            for instance in qs
+        }
 
     def get_instance(self, row):
         return self.all_instances.get(self.pk_field.clean(row))


### PR DESCRIPTION
Dictionary comprehension has been available since Python 2.7. As django-import-export only supports Python 2.7+ or Python 3.3+, can take advantage of newer, rich Python features.

See Python PEP-0274 for additional details:

https://www.python.org/dev/peps/pep-0274/