### PR TITLE
Add Django as requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ CLASSIFIERS = [
 ]
 
 install_requires = [
-    'tablib',
     'diff-match-patch',
+    'django>=1.5',
+    'tablib',
 ]
 
 setup(


### PR DESCRIPTION
As django is imported by the library and is a hard runtime requirement, it should be listed as a requirement in setup.py for completeness.