### PR TITLE
Add universal wheel support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE
+
 [zest.releaser]
+create-wheel = yes
 python-file-with-version = import_export/__init__.py


### PR DESCRIPTION
As django-import-export is a pure Python package (no C code), it can be packaged as a universal wheel. Enable this in setup.cfg. Also configure zest to build the wheel by default.

For information on using wheels see:

http://pythonwheels.com/

For information on the wheel specification see PEP-0427:

https://www.python.org/dev/peps/pep-0427/

For information on creating wheels with zest see:

https://zestreleaser.readthedocs.io/en/latest/uploading.html#uploading-wheels