### PR TITLE
Do not use tablib version 0.12.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 Django>=1.5
-tablib
+tablib<0.12
 diff-match-patch
 openpyxl

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 Django>=1.5
-tablib<0.12
+tablib!=0.12.0
 diff-match-patch
 openpyxl


### PR DESCRIPTION
Since 0.12 tablib [requires pandas](https://github.com/kennethreitz/tablib/blob/v0.12.0/requirements.txt#L9).
It's a bit overkill to setup pandas and other scientific dependancies for import/export functionality