### PR TITLE
Add custom headers

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -124,6 +124,11 @@ class ResourceOptions(object):
     Controls if the result reports skipped rows Default value is True
     """
 
+    custom_headers = []
+    """
+    Controls what custom headers should be applied
+    """
+
 
 class DeclarativeMetaclass(type):
 
@@ -607,7 +612,11 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
     def get_export_headers(self):
         headers = [
-            force_text(field.column_name) for field in self.get_export_fields()]
+             self._meta.custom_headers[field.column_name]
+             if field.column_name in self._meta.custom_headers
+             else force_text(field.column_name)
+             for field in self.get_export_fields()
+        ]
         return headers
 
     def get_user_visible_fields(self):


### PR DESCRIPTION
This one is kind of related to #546 but instead switching between default name and verbose name, here I add the option of defining custom headers. I understand that it would be impossible to import the data back by using the import feature but it will be useful when you only need to export the data with some custom headers.

Before I had to override `get_export_headers` method and to declare my custom headers dictionary there and I don't like the idea at all because the method isn't described in the API documentation and this is a sign it shouldn't be modified just like that.

I thought about adding the custom header in a different ways but they all require more changes and this one is the simplest solution as far as I know.

I'm already using this kind of custom header settings in several projects where the data is being often exported and it works perfectly (what could possibly go wrong with such a small change) and I decided it will be a good idea to share this feature with the community.

Tests should be added, but I'll wait to hear other opinions before writing some.
