### PR TITLE
Strip whitespace when looking up ManyToMany fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,3 +90,4 @@ The following is a list of much appreciated contributors:
 * petrmifek
 * ryan-copperleaf (Ryan O’Hara)
 * gatsinski (Hristo Gatsinski)
+* raghavsethi (Raghav Sethi)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -376,7 +376,7 @@ class ManyToManyWidget(Widget):
             ids = [int(value)]
         else:
             ids = value.split(self.separator)
-        ids = filter(None, ids)
+        ids = filter(None, [i.strip() for i in ids])
         return self.model.objects.filter(**{
             '%s__in' % self.field: ids
         })

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -209,6 +209,20 @@ class ManyToManyWidget(TestCase):
         self.assertIn(self.cat1, cleaned_data)
         self.assertIn(self.cat2, cleaned_data)
 
+    def test_clean_field(self):
+        value = "%s,%s" % (self.cat1.name, self.cat2.name)
+        cleaned_data = self.widget_name.clean(value)
+        self.assertEqual(len(cleaned_data), 2)
+        self.assertIn(self.cat1, cleaned_data)
+        self.assertIn(self.cat2, cleaned_data)
+
+    def test_clean_field_spaces(self):
+        value = "%s, %s" % (self.cat1.name, self.cat2.name)
+        cleaned_data = self.widget_name.clean(value)
+        self.assertEqual(len(cleaned_data), 2)
+        self.assertIn(self.cat1, cleaned_data)
+        self.assertIn(self.cat2, cleaned_data)
+
     def test_clean_typo(self):
         value = "%s," % self.cat1.pk
         cleaned_data = self.widget.clean(value)


### PR DESCRIPTION
This makes imports more robust when users enter whitespaces after
commas.