### PR TITLE
Travis tests for Python 3.6 on Django >= 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 env:
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"
@@ -38,5 +39,13 @@ matrix:
       env: DJANGO="Django>=1.6,<1.7"
     - python: "3.5"
       env: DJANGO="Django>=1.7,<1.8"
+    - python: "3.6"
+      env: DJANGO="Django>=1.6,<1.7"
+    - python: "3.6"
+      env: DJANGO="Django>=1.7,<1.8"
+    - python: "3.6"
+      env: DJANGO="Django>=1.8,<1.9"
+    - python: "3.6"
+      env: DJANGO="Django>=1.9,<1.10"
   allow_failures:
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,7 @@ matrix:
       env: DJANGO="Django>=1.8,<1.9"
     - python: "3.6"
       env: DJANGO="Django>=1.9,<1.10"
+    - python: "3.6"
+      env: DJANGO="Django>=1.10,<1.11"
   allow_failures:
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"


### PR DESCRIPTION
Django 1.11 and newer support Python 3.6.