### PR TITLE
MIDDLEWARE_CLASSES django setting removed in 2.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,3 +92,4 @@ The following is a list of much appreciated contributors:
 * gatsinski (Hristo Gatsinski)
 * raghavsethi (Raghav Sethi)
 * jdufresne (Jon Dufresne)
+* trik (Marco Marche)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 0.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed middleware settings in test app for Django 2.x (#696)
 
 
 0.6.1 (2017-12-04)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,7 +24,7 @@ STATIC_URL = '/static/'
 
 SECRET_KEY = '2n6)=vnp8@bu0om9d05vwf7@=5vpn%)97-!d*t4zq1mku%0-@j'
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -32,6 +32,9 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+# For backwards compatibility for Django 1.8
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 TEMPLATES = [
     {


### PR DESCRIPTION
fixes #696