### PR TITLE
custom js for action form also handles grappelli

### DIFF
--- a/import_export/static/import_export/action_formats.js
+++ b/import_export/static/import_export/action_formats.js
@@ -1,12 +1,22 @@
 (function($) {
   $(document).on('ready', function() {
-    $('select[name="action"]', '#changelist-form').on('change', function() {
-      if ($(this).val() == 'export_admin_action') {
-        $('select[name="file_format"]', '#changelist-form').parent().show();
+    var $actionsSelect, $formatsElement;
+    if ($('body').hasClass('grp-change-list')) {
+        // using grappelli
+        $actionsSelect = $('#grp-changelist-form select[name="action"]');
+        $formatsElement = $('#grp-changelist-form select[name="file_format"]');
+    } else {
+        // using default admin
+        $actionsSelect = $('#changelist-form select[name="action"]');
+        $formatsElement = $('#changelist-form select[name="file_format"]').parent();
+    }
+    $actionsSelect.on('change', function() {
+      if ($(this).val() === 'export_admin_action') {
+        $formatsElement.show();
       } else {
-        $('select[name="file_format"]', '#changelist-form').parent().hide();
+        $formatsElement.hide();
       }
     });
-    $('select[name="action"]', '#changelist-form').change();
+    $actionsSelect.change();
   });
 })(django.jQuery);


### PR DESCRIPTION
`ExportActionModelAdmin` works fine with Django-Grappelli except for one little detail: on valila admin, there is a little jQuery snippet that toggles visibility of the added `file_format` field. Because Grappelli uses different CSS classes and IDs, this toggling does not occur.

This in vanila admin:
![select_experiment_to_change___django_site_admin](https://user-images.githubusercontent.com/1173748/34428757-47da7aec-ec50-11e7-926a-7b844d024d3d.png)

... looks like this in grapppelli:
![screenshot_29_12_2017__04_24](https://user-images.githubusercontent.com/1173748/34428767-57dccd3c-ec50-11e7-8a38-6b72092e2027.png)

... but in the default state looks like this:
![screenshot_29_12_2017__04_24](https://user-images.githubusercontent.com/1173748/34428781-666d6528-ec50-11e7-9c60-b9c2e054a9ca.png)

Changes in this PR enable grappelli to benefit from the existing feature in the same way that vanila django-admin does, by hiding the second dropdown in grappelli until the "export" action is selected. Original functionality in vanila admin is not affected.

----

Contributing guidelines... yes I have read them. Cannot comply to most of the requirements there because they assume changes to Python code. Please let me know if I should comply to some. Happy to. Also happy if this gets merged in as is :)

>In order to be merged into django-import-export, contributions must have the following:
>
> * A solid patch that:
>   * is clear.
>   * works across all supported versions of Python/Django.
>   * follows the existing style of the code base (mostly PEP-8).
>   * comments included as needed to explain why the code functions as it does
> * A test case that demonstrates the previous flaw that now passes with the included patch.
> * If it adds/changes a public API, it must also include documentation for those changes.
> * Must be appropriately licensed (see Philosophy).
> * Adds yourself to the AUTHORS file.
If your contribution lacks any of these things, they will have to be added by a core contributor before being merged into django-import-export proper, which may take substantial time for the all-volunteer team to get to.
