### PR TITLE
Upgrade tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,69 +1,16 @@
 [tox]
 envlist =
-    py{27,33,34}-1.8,
-    py{27,34,35}-1.9,
-    py{27,34,35}-dev
+    py{27,33,34,35}-django{18}-tablib{dev},
+    py{27,34,35}-django{19,110}-tablib{dev},
+    py{27,34,35,36}-django{111}-tablib{dev},
+    py{34,35,36}-django{20}-tablib{dev},
 
 [testenv]
 commands=python {toxinidir}/tests/manage.py test core
-deps = openpyxl
-
-[testenv:py27-1.8]
-basepython = python2.7
-deps =
-    django==1.8
-    {[testenv]deps}
-
-[testenv:py33-1.8]
-basepython = python3.3
-deps =
-    django==1.8
-    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
-    {[testenv]deps}
-
-[testenv:py34-1.8]
-basepython = python3.4
-deps =
-    django==1.8
-    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
-    {[testenv]deps}
-
-[testenv:py27-1.9]
-basepython = python2.7
-deps =
-    django==1.9
-    {[testenv]deps}
-
-[testenv:py34-1.9]
-basepython = python3.4
-deps =
-    django==1.9
-    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
-    {[testenv]deps}
-
-[testenv:py35-1.9]
-basepython = python3.5
-deps =
-    django==1.9
-    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
-    {[testenv]deps}
-
-[testenv:py27-dev]
-basepython = python2.7
-deps =
-    https://github.com/django/django/archive/master.tar.gz
-    {[testenv]deps}
-
-[testenv:py34-dev]
-basepython = python3.4
-deps =
-    https://github.com/django/django/archive/master.tar.gz
-    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
-    {[testenv]deps}
-
-[testenv:py35-dev]
-basepython = python3.5
-deps =
-    https://github.com/django/django/archive/master.tar.gz
-    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
-    {[testenv]deps}
+deps=
+    openpyxl==2.4.11
+    tablibdev: -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django20: Django>=2.0,<2.1


### PR DESCRIPTION
Add supported Django versions
Add supported python versions
Use openpyxl==2.4.11 as 2.5.x drops support for python 3.3