### PR TITLE
Peg openpyxl dependency to 2.4.9 to avoid non-backwards compatible api change

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -230,6 +230,9 @@ class XLSX(TablibFormat):
             dataset.append(row_values)
         return dataset
 
+    def export_data(self, dataset, **kwargs):
+        return self.get_format().export_set(dataset, **kwargs)
+
 #: These are the default formats for import and export. Whether they can be
 #: used or not is depending on their implementation in the tablib library.
 DEFAULT_FORMATS = (

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -230,8 +230,6 @@ class XLSX(TablibFormat):
             dataset.append(row_values)
         return dataset
 
-    def export_data(self, dataset, **kwargs):
-        return self.get_format().export_set(dataset, **kwargs)
 
 #: These are the default formats for import and export. Whether they can be
 #: used or not is depending on their implementation in the tablib library.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 Django>=1.8
 tablib>=0.12
 diff-match-patch
-openpyxl==2.4.9
+openpyxl>=2.4,<2.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 Django>=1.8
-tablib
+tablib>=0.12
 diff-match-patch
-openpyxl
+openpyxl==2.4.9

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -118,6 +118,19 @@ class ImportExportAdminIntegrationTest(TestCase):
         self.assertTrue(response.has_header("Content-Disposition"))
         self.assertEqual(response['Content-Type'], 'text/csv')
 
+    def test_returns_xlsx_export(self):
+        response = self.client.get('/admin/core/book/export/')
+        self.assertEqual(response.status_code, 200)
+
+        data = {
+            'file_format': '2',
+            }
+        response = self.client.post('/admin/core/book/export/', data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.has_header("Content-Disposition"))
+        self.assertEqual(response['Content-Type'],
+                         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+
     def test_import_export_buttons_visible_without_add_permission(self):
         # issue 38 - Export button not visible when no add permission
         original = BookAdmin.has_add_permission


### PR DESCRIPTION
As mentioned [here](https://github.com/kennethreitz/tablib/issues/324) and [here](https://github.com/django-import-export/django-import-export/issues/762), openpyxl has changed there api for xlsx.  Currently when exporting to xlsx we receive a 500 error. 

Addresses #762 