### PR TITLE
JSONWidget for jsonb fields

### DIFF
--- a/docs/api_widgets.rst
+++ b/docs/api_widgets.rst
@@ -28,6 +28,9 @@ Widgets
 
 .. autoclass:: import_export.widgets.DurationWidget
    :members:
+   
+.. autoclass:: import_export.widgets.JSONWidget
+   :members:
 
 .. autoclass:: import_export.widgets.ForeignKeyWidget
    :members:

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -8,6 +8,8 @@ from django.utils.encoding import smart_text
 from django.utils.dateparse import parse_duration
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+import json
+import ast
 
 try:
     from django.utils.encoding import force_text
@@ -266,6 +268,21 @@ class SimpleArrayWidget(Widget):
 
     def render(self, value, obj=None):
         return self.separator.join(six.text_type(v) for v in value)
+
+    
+class JSONWidget(Widget):
+    """
+    Widget for a JSON object (especially required for jsonb fields in PostgreSQL database.)
+    """
+
+    def clean(self, value, row=None, *args, **kwargs):
+        val = super(JSONWidget, self).clean(value)
+        if val:
+            return ast.literal_eval(val)
+
+    def render(self, value, obj=None):
+        if value:
+            return json.dumps(value)
 
 
 class ForeignKeyWidget(Widget):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -271,3 +271,24 @@ class ManyToManyWidget(TestCase):
                          "%s,%s" % (self.cat1.pk, self.cat2.pk))
         self.assertEqual(self.widget_name.render(Category.objects),
                          u"%s,%s" % (self.cat1.name, self.cat2.name))
+
+
+class JSONWidgetTest(TestCase):
+
+    def setUp(self):
+        self.value = {"value": 23}
+        self.widget = widgets.JSONWidget()
+
+    def test_clean(self):
+        self.assertEqual(self.widget.clean('{"value": 23}'), self.value)
+
+    def test_render(self):
+        self.assertEqual(self.widget.render(self.value), '{"value": 23}')
+
+    def test_clean_none(self):
+        self.assertEqual(self.widget.clean(None), None)
+        self.assertEqual(self.widget.clean('{}'), {})
+
+    def test_render_none(self):
+        self.assertEqual(self.widget.render(None), None)
+        self.assertEqual(self.widget.render(dict()), None)


### PR DESCRIPTION
JSONWidget can be used for importing jsonb objects in the PostgreSQL DB.