### PR TITLE
Add ExportActionMixin

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -428,10 +428,9 @@ class ImportExportModelAdmin(ImportExportMixin, admin.ModelAdmin):
     """
 
 
-class ExportActionModelAdmin(ExportMixin, admin.ModelAdmin):
+class ExportActionMixin(ExportMixin):
     """
-    Subclass of ModelAdmin with export functionality implemented as an
-    admin action.
+    Mixin with export functionality implemented as an admin action.
     """
 
     # Don't use custom change list template.
@@ -450,7 +449,7 @@ class ExportActionModelAdmin(ExportMixin, admin.ModelAdmin):
                 choices.append((str(i), f().get_title()))
 
         self.action_form = export_action_form_factory(choices)
-        super(ExportActionModelAdmin, self).__init__(*args, **kwargs)
+        super(ExportActionMixin, self).__init__(*args, **kwargs)
 
     def export_admin_action(self, request, queryset):
         """
@@ -478,6 +477,13 @@ class ExportActionModelAdmin(ExportMixin, admin.ModelAdmin):
 
     class Media:
         js = ['import_export/action_formats.js']
+
+
+class ExportActionModelAdmin(ExportActionMixin, admin.ModelAdmin):
+    """
+    Subclass of ModelAdmin with export functionality implemented as an
+    admin action.
+    """
 
 
 class ImportExportActionModelAdmin(ImportMixin, ExportActionModelAdmin):


### PR DESCRIPTION
I already have a class inheriting from `ModelAdmin` but I want to use the `ExportActionModelAdmin` logic. So I think it would be better to transform it into a Mixin and still provide the `ExportActionModelAdmin` for more flexibility.