### PR TITLE
Added Some Tweaks to Speed up ImportMixin.import_action

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -270,7 +270,7 @@ class ImportMixin(ImportExportMixinBase):
             # first read the contents of the file into memory
             # warning, big files may exceed memory
             data = bytes()
-            for chunk in import_file.chunks():
+            for chunk in import_file.chunks(4000000):
                 data += chunk
 
             # then write the content to temporary storage as it may be

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -277,7 +277,7 @@ class ImportMixin(ImportExportMixinBase):
             # then read the file, using the proper format-specific mode
             # warning, big files may exceed memory
             try:
-                data = tmp_storage.read(input_format.get_read_mode())
+                data = import_file.read()
                 if not input_format.is_binary() and self.from_encoding:
                     data = force_text(data, self.from_encoding)
                 dataset = input_format.create_dataset(data)


### PR DESCRIPTION
I was suffering from execution times like 80 seconds when using MediaStorage (i.e. django-s3-storage) in combination with files bigger than 100 MB. I was able to bring the execution time down to 8 seconds by adding two small changes:

- Don't read the uploaded file's contents from the (possibly remote) temporary storage as long as they are available locally.
- Increase the chunk size to 4 MB (probably even better would be to set it accordingly to the uploaded file's size).

BTW: Thanks for the great package. You saved me hours of work! :-)