### PR TITLE
Change logging level

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -486,7 +486,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             # There is no point logging a transaction error for each row
             # when only the original error is likely to be relevant
             if not isinstance(e, TransactionManagementError):
-                logging.exception(e)
+                logging.debug(e)
             tb_info = traceback.format_exc()
             row_result.errors.append(self.get_error_result_class()(e, tb_info, row))
         return row_result
@@ -540,7 +540,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             with atomic_if_using_transaction(using_transactions):
                 self.before_import(dataset, using_transactions, dry_run, **kwargs)
         except Exception as e:
-            logging.exception(e)
+            logging.debug(e)
             tb_info = traceback.format_exc()
             result.append_base_error(self.get_error_result_class()(e, tb_info))
             if raise_errors:
@@ -577,7 +577,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             with atomic_if_using_transaction(using_transactions):
                 self.after_import(dataset, result, using_transactions, dry_run, **kwargs)
         except Exception as e:
-            logging.exception(e)
+            logging.debug(e)
             tb_info = traceback.format_exc()
             result.append_base_error(self.get_error_result_class()(e, tb_info))
             if raise_errors:
@@ -701,7 +701,7 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                         try:
                             f = model._meta.get_field(attr)
                         except FieldDoesNotExist as e:
-                            logging.exception(e)
+                            logging.debug(e)
                             raise FieldDoesNotExist(
                                 "%s: %s has no field named '%s'" %
                                 (verbose_path, model.__name__, attr))

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import functools
+import logging
 import tablib
 import traceback
 from collections import OrderedDict
@@ -38,11 +39,9 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
+logger = logging.getLogger(__name__)
 # Set default logging handler to avoid "No handler found" warnings.
-import logging  # isort:skip
-from logging import NullHandler
-
-logger = logging.getLogger(__name__).addHandler(NullHandler())
+logger.addHandler(logging.NullHandler())
 
 USE_TRANSACTIONS = getattr(settings, 'IMPORT_EXPORT_USE_TRANSACTIONS', True)
 

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -42,7 +42,7 @@ except ImportError:
 import logging  # isort:skip
 from logging import NullHandler
 
-logging.getLogger(__name__).addHandler(NullHandler())
+logger = logging.getLogger(__name__).addHandler(NullHandler())
 
 USE_TRANSACTIONS = getattr(settings, 'IMPORT_EXPORT_USE_TRANSACTIONS', True)
 
@@ -486,7 +486,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             # There is no point logging a transaction error for each row
             # when only the original error is likely to be relevant
             if not isinstance(e, TransactionManagementError):
-                logging.debug(e)
+                logger.debug(e, exc_info=e)
             tb_info = traceback.format_exc()
             row_result.errors.append(self.get_error_result_class()(e, tb_info, row))
         return row_result
@@ -540,7 +540,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             with atomic_if_using_transaction(using_transactions):
                 self.before_import(dataset, using_transactions, dry_run, **kwargs)
         except Exception as e:
-            logging.debug(e)
+            logger.debug(e, exc_info=e)
             tb_info = traceback.format_exc()
             result.append_base_error(self.get_error_result_class()(e, tb_info))
             if raise_errors:
@@ -577,7 +577,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             with atomic_if_using_transaction(using_transactions):
                 self.after_import(dataset, result, using_transactions, dry_run, **kwargs)
         except Exception as e:
-            logging.debug(e)
+            logger.debug(e, exc_info=e)
             tb_info = traceback.format_exc()
             result.append_base_error(self.get_error_result_class()(e, tb_info))
             if raise_errors:
@@ -701,7 +701,7 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                         try:
                             f = model._meta.get_field(attr)
                         except FieldDoesNotExist as e:
-                            logging.debug(e)
+                            logger.debug(e, exc_info=e)
                             raise FieldDoesNotExist(
                                 "%s: %s has no field named '%s'" %
                                 (verbose_path, model.__name__, attr))


### PR DESCRIPTION
As discussed in #527 (a long time ago) I have modified the logging level from exception to debug.

What is currently happening when using django-import-export on production is that we want to show import errors to the user and we do that in django admin, but besides from these we get loads and loads of errors being reported to Sentry, which we can't really change the configuration for without extending Resource on our end and overriding how `import_data` works inside. Which as a result might disable the possibility to upgrade the library.

I am proposing changing all `logger.exceptions` to `logger.debug` as basically we only need these logging details when testing our code using django-import-export and in all other cases the consuming code should be able to handle the raised exceptions in the way it needs.

I am happy to change the PR to whatever you find valuable, as long as the logger level is lower than error, so it doesn't get reported.