### PR TITLE
Changed `get_instance()` return val

### DIFF
--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -30,7 +30,10 @@ class ModelInstanceLoader(BaseInstanceLoader):
             for key in self.resource.get_import_id_fields():
                 field = self.resource.fields[key]
                 params[field.attribute] = field.clean(row)
-            return self.get_queryset().get(**params)
+            if params:
+                return self.get_queryset().get(**params)
+            else:
+                return None
         except self.resource._meta.model.DoesNotExist:
             return None
 


### PR DESCRIPTION
When `import_id_fields` is empty, `get_instance()` should return None. Previously it would return an object if queryset contained a single object -- qs.get() with no args returns an obj for queryset of length=1.