### PR TITLE
Optional instance validation / surfacing of validation errors in preview

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -292,7 +292,7 @@ class ImportMixin(ImportExportMixinBase):
 
             context['result'] = result
 
-            if not result.has_errors():
+            if not result.has_errors() and not result.has_validation_errors():
                 context['confirm_form'] = ConfirmImportForm(initial={
                     'import_file_name': tmp_storage.name,
                     'original_file_name': import_file.name,

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -278,9 +278,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
     def validate_row_instance(self, instance, row_result):
         """
-        If the ``validate_row_intances`` option is True, validates the instance
-        created for a specific row (by calling its ``full_clean()`` method),
-        and adds any resulting validation errors to ``result_row``.
+        If the ``validate_row_instances`` option is True, validates the
+        instance created for a specific row (by calling its ``full_clean()``
+        method), and adds any resulting validation errors to ``row_result``.
         """
         if self._meta.validate_row_instances:
             try:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -286,6 +286,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             try:
                 instance.full_clean()
             except ValidationError as e:
+                row_result.import_type = RowResult.IMPORT_TYPE_INVALID
                 row_result.validation_errors = e.message_dict
 
     def save_instance(self, instance, using_transactions=True, dry_run=False):

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -276,7 +276,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         else:
             return (self.init_instance(row), True)
 
-    def validate_row_instance(self, instance, row_result):
+    def validate_row_instance(self, instance, row_result, exclude_fields=None, validate_unique=True):
         """
         If the ``validate_row_instances`` option is True, validates the
         instance created for a specific row (by calling its ``full_clean()``
@@ -284,7 +284,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         """
         if self._meta.validate_row_instances:
             try:
-                instance.full_clean()
+                instance.full_clean(exclude=exclude_fields, validate_unique=validate_unique)
             except ValidationError as e:
                 row_result.import_type = RowResult.IMPORT_TYPE_INVALID
                 row_result.validation_errors = e.message_dict

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -120,7 +120,7 @@ class ResourceOptions(object):
 
     validate_row_instances = False
     """
-    Controls whether instance.full_clean() is called during the import
+    Controls whether ``instance.full_clean()`` is called during the import
     process to identify potential validation errors for each (non skipped) row.
     The default value is False.
     """

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -118,6 +118,13 @@ class ResourceOptions(object):
     Controls if the result reports skipped rows Default value is True
     """
 
+    validate_row_instances = False
+    """
+    Controls whether instance.full_clean() is called during the import
+    process to identify potential validation errors for each (non skipped) row.
+    The default value is False.
+    """
+
 
 class DeclarativeMetaclass(type):
 

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 
+from django.core.exceptions import NON_FIELD_ERRORS
+
 from tablib import Dataset
 
 
@@ -21,8 +23,30 @@ class RowResult(object):
 
     def __init__(self):
         self.errors = []
+        self.validation_errors = {}
         self.diff = None
         self.import_type = None
+
+    @property
+    def field_validation_errors(self):
+        """Returns a dictionary of field-specific validation errors for this row."""
+        return {
+            key: value for key, value in self.validation_errors.items()
+            if key != NON_FIELD_ERRORS
+        }
+
+    @property
+    def non_field_validation_errors(self):
+        """Returns a tuple of non field-specific validation errors for this row."""
+        return self.validation_errors.get(NON_FIELD_ERRORS, ())
+
+    @property
+    def validation_error_count(self):
+        """Returns the total number of validation errors for this row."""
+        count = 0
+        for error_list in self.validation_errors.values():
+            count += len(error_list)
+        return count
 
 
 class Result(object):

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -61,7 +61,8 @@ class Result(object):
                                    (RowResult.IMPORT_TYPE_UPDATE, 0),
                                    (RowResult.IMPORT_TYPE_DELETE, 0),
                                    (RowResult.IMPORT_TYPE_SKIP, 0),
-                                   (RowResult.IMPORT_TYPE_ERROR, 0)])
+                                   (RowResult.IMPORT_TYPE_ERROR, 0),
+                                   (RowResult.IMPORT_TYPE_INVALID, 0)])
         self.total_rows = 0
 
     def append_row_result(self, row_result):

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -20,6 +20,7 @@ class RowResult(object):
     IMPORT_TYPE_DELETE = 'delete'
     IMPORT_TYPE_SKIP = 'skip'
     IMPORT_TYPE_ERROR = 'error'
+    IMPORT_TYPE_INVALID = 'invalid'
 
     def __init__(self):
         self.errors = []

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -86,7 +86,17 @@ class Result(object):
                 for i, row in enumerate(self.rows) if row.errors]
 
     def has_errors(self):
+        """Returns a boolean indicating whether the import process resulted in
+        any critical (non-validation) errors for this result."""
         return bool(self.base_errors or self.row_errors())
+
+    def has_validation_errors(self):
+        """Returns a boolean indicating whether the import process resulted in
+        any validation errors for this result."""
+        for row in self.rows:
+            if row.validation_errors:
+                return True
+        return False
 
     def __iter__(self):
         return iter(self.rows)

--- a/import_export/static/import_export/import.css
+++ b/import_export/static/import_export/import.css
@@ -21,7 +21,7 @@
   left: 10px;
   top: 100%;
   margin: -5px 0 20px 0;
-  width: 260px;
+  width: 245px;
   z-index: 1;
 }
 

--- a/import_export/static/import_export/import.css
+++ b/import_export/static/import_export/import.css
@@ -1,0 +1,58 @@
+.import-preview .import-type {
+  position: relative;
+}
+
+.validation-error-count {
+  display: inline-block;
+  background-color: #e40000;
+  border-radius: 6px;
+  color: white;
+  font-weight: bold;
+  padding: 3px 6px 4px;
+  margin: -3px 0;
+}
+
+.validation-error-container {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  background-color: #ffc1c1;
+  padding: 12px 15px 10px;
+  left: 10px;
+  top: 100%;
+  margin: -5px 0 20px 0;
+  width: 260px;
+  z-index: 1;
+}
+
+.import-preview td:hover .validation-error-container {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.validation-error-list {
+  margin: 0;
+  padding: 0;
+}
+
+.validation-error-list li {
+  list-style: none;
+  margin: 0;
+}
+
+.validation-error-list > li > ul {
+  margin: 8px 0;
+  padding: 0;
+}
+
+.validation-error-list > li > ul > li {
+  border-left: 2px solid #e40000;
+  padding: 2px 0 2px 10px;
+  margin: 0 0 2px;
+}
+
+.validation-error-field-label {
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 0.9em;
+}

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -100,7 +100,7 @@
           {% trans "Delete" %}
         {% elif row.import_type == 'update' %}
           {% trans "Update" %}
-        {% elif row.import_type == 'invalid '%}
+        {% elif row.import_type == 'invalid' %}
           {% trans "Invalid" %}
           <span class="validation-error-count">{{ row.validation_error_count }}</span> 
               <div class="validation-error-container">

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -3,6 +3,8 @@
 {% load admin_urls %}
 {% load import_export_tags %}
 
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "import_export/import.css" %}" />{% endblock %}
+
 {% block breadcrumbs_last %}
 {% trans "Import" %}
 {% endblock %}
@@ -77,7 +79,7 @@
   <h2>
     {% trans "Preview" %}
   </h2>
-  <table>
+  <table class="import-preview">
     <thead>
       <tr>
         <th></th>
@@ -88,7 +90,7 @@
     </thead>
     {% for row in result.rows %}
     <tr>
-      <td>
+      <td class="import-type">
         {% if row.import_type == 'new' %}
           {% trans "New" %}
         {% elif row.import_type == 'skip' %}
@@ -97,6 +99,33 @@
           {% trans "Delete" %}
         {% elif row.import_type == 'update' %}
           {% trans "Update" %}
+        {% elif row.import_type == 'invalid '%}
+          {% trans "Invalid" %}
+          <span class="validation-error-count">{{ row.validation_error_count }}</span> 
+              <div class="validation-error-container">
+                <ul class="validation-error-list">
+                  {% for field_name, error_list in row.field_validation_errors.items %}
+                    <li>
+                        <span class="validation-error-field-label">{{ field_name }}</span>
+                        <ul>
+                          {% for error in error_list %}
+                            <li>{{ error }}</li>
+                          {% endfor %}
+                        </ul>
+                    </li>
+                  {% endfor %}
+                  {% if row.non_field_validation_errors %}
+                    <li>
+                      <span class="validation-error-field-label">{% trans "Non field specific" %}</span>
+                      <ul>
+                        {% for error in row.non_field_validation_errors %}
+                          <li>{{ error }}</li>
+                        {% endfor %}
+                      </ul>
+                    </li>
+                  {% endif %}
+                </ul>
+              </div>
         {% endif %}
       </td>
       {% for field in row.diff %}

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load admin_urls %}
 {% load import_export_tags %}
+{% load static %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "import_export/import.css" %}" />{% endblock %}
 


### PR DESCRIPTION
Hi @bmihelac,

Here's where I've got to so far. I thought it would be good to get some feedback before getting stuck into writing new tests, but the current ones are passing, so at least nothing is broken :)

When enabled, validation errors surface themselves in the preview table like so:

![screenshot 2018-11-02 at 15 35 37](https://user-images.githubusercontent.com/7779588/47925456-186cd580-deb6-11e8-9d54-b7d1756d3641.png)

The errors are hidden visually at first, then become visible when you hover over a row's first column, in such a way that it doesn't hide any of the values for the current row. It's pretty crude, but it's a starting point. Some examples:

![screenshot 2018-11-02 at 15 35 42](https://user-images.githubusercontent.com/7779588/47925533-523ddc00-deb6-11e8-8120-359a3203026f.png)
![screenshot 2018-11-02 at 15 35 53](https://user-images.githubusercontent.com/7779588/47925534-523ddc00-deb6-11e8-82b6-3b2c4cff1620.png)

Anyone wanting to give this a whirl for themselves should be able to install from git using:

`pip install git+https://github.com/ababic/django-import-export.git@modelresource-validation-error-handling`

Any/all feedback welcome :)