### PR TITLE
Use modern setuptools in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 
 VERSION = __import__("import_export").__version__


### PR DESCRIPTION
As recommended by Python docs, use setuptools not distutils. See:

https://docs.python.org/3/library/distutils.html

> Most Python users will not want to use this module directly, but
> instead use the cross-version tools maintained by the Python Packaging
> Authority. In particular, setuptools is an enhanced alternative to
> distutils ...

setuptools is necessary for features like python_requires.