### PR TITLE
Catching ObjectDoesNotExist exception and re-raise ValueError in ForeignKey widget

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -8,6 +8,7 @@ from django.utils.encoding import smart_text, force_text
 from django.utils.dateparse import parse_duration
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import ugettext_lazy as _
 import json
 import ast
 
@@ -349,7 +350,10 @@ class ForeignKeyWidget(Widget):
     def clean(self, value, row=None, *args, **kwargs):
         val = super(ForeignKeyWidget, self).clean(value)
         if val:
-            return self.get_queryset(value, row, *args, **kwargs).get(**{self.field: val})
+            try:
+                return self.get_queryset(value, row, *args, **kwargs).get(**{self.field: val})
+            except ObjectDoesNotExist:
+                raise ValueError(_("Select a valid choice. That choice is not one of the available choices."))
         else:
             return None
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -217,6 +217,11 @@ class ForeignKeyWidgetTest(TestCase):
         row = {'name': "Foo", 'birthday': author2.birthday}
         self.assertEqual(birthday_widget.clean("Foo", row), author2)
 
+    def test_clean_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.widget.clean(2)
+
+
 
 class ManyToManyWidget(TestCase):
 


### PR DESCRIPTION
Related issue: #852

By default, the get method of queryset returns ObjectDoesNotExist exception. To make it more user-friendly to handle this error, the ForeignKey widget would ideally return ValueError.