### PR TITLE
Remove python2 compatibility decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ env:
 matrix:
   exclude:
     - python: "3.5"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.5"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
 install:
   - pip install -q $DJANGO
   - pip install tablib==0.12.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,19 @@ python:
   - "3.6"
   - "3.7"
 env:
+  - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=postgres
+  - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=sqlite
+  - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=postgres
+  - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=sqlite
+  - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
+  - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
   global:
     - IMPORT_EXPORT_POSTGRESQL_USER=postgres
     - IMPORT_EXPORT_POSTGRESQL_PASSWORD=
   matrix:
-    - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=postgres
-    - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=sqlite
-    - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=postgres
-    - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=sqlite
-    - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
-    - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
-#    exclude:
-#      - python: "3.5"
-#        env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+    exclude:
+      - python: "3.5"
+        env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
 install:
   - pip install -q $DJANGO
   - pip install tablib==0.12.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ env:
     - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=sqlite
     - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
     - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
+#    exclude:
+#      - python: "3.5"
+#        env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
 install:
   - pip install -q $DJANGO
   - pip install tablib==0.12.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,20 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=postgres
-  - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=sqlite
-  - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=postgres
-  - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=sqlite
-  - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
-  - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
   global:
     - IMPORT_EXPORT_POSTGRESQL_USER=postgres
     - IMPORT_EXPORT_POSTGRESQL_PASSWORD=
   matrix:
-    exclude:
-      - python: "3.5"
-        env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+    - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=postgres
+    - DJANGO="Django>=2.0,<2.1" IMPORT_EXPORT_TEST_TYPE=sqlite
+    - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=postgres
+    - DJANGO="Django>=2.1,<2.2" IMPORT_EXPORT_TEST_TYPE=sqlite
+    - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
+    - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
+matrix:
+  exclude:
+    - python: "3.5"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
 install:
   - pip install -q $DJANGO
   - pip install tablib==0.12.1
@@ -32,6 +33,4 @@ script:
    - isort --check-only
 after_success:
   - coveralls
-matrix:
-  allow_failures:
-    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -3,10 +3,8 @@ import string
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class Author(models.Model):
     name = models.CharField(max_length=100)
     birthday = models.DateTimeField(auto_now_add=True)
@@ -24,7 +22,6 @@ class Author(models.Model):
             raise ValidationError({'name': "'123' is not a valid value"})
 
 
-@python_2_unicode_compatible
 class Category(models.Model):
     name = models.CharField(
         max_length=100,
@@ -35,7 +32,6 @@ class Category(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Book(models.Model):
     name = models.CharField('Book name', max_length=100)
     author = models.ForeignKey(Author, blank=True, null=True, on_delete=models.CASCADE)
@@ -51,7 +47,6 @@ class Book(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Parent(models.Model):
     name = models.CharField(max_length=100)
 
@@ -59,7 +54,6 @@ class Parent(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Child(models.Model):
     parent = models.ForeignKey(Parent, on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
@@ -89,9 +83,11 @@ class WithDefault(models.Model):
     name = models.CharField('Default', max_length=75, blank=True,
                             default='foo_bar')
 
+
 def random_name():
     chars = string.ascii_lowercase
     return ''.join(random.SystemRandom().choice(chars) for _ in range(100))
+
 
 class WithDynamicDefault(models.Model):
 


### PR DESCRIPTION
**Problem**
What problem have you solved?

The `python_2_unicode_compatible` decorator has been removed from the master for a [Django 3.0 release](https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis).

And as a result it keeps breaking my other pipelines 😞  

**Solution**
How did you solve the problem?

Removed the usage

**Screenshots**
If applicable, add screenshots to help explain your solution.

**Acceptance Criteria**
Please make sure you meet the following.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing unit tests pass on Travis with my changes