### PR TITLE
Stale bot config

### DIFF
--- a/.github/.stale.yml
+++ b/.github/.stale.yml
@@ -1,0 +1,40 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+ markComment: >
+   This pull request has been automatically marked as stale because it has not had
+   recent activity. It will be closed if no further activity occurs. Thank you
+   for your contributions.


### PR DESCRIPTION
**Problem**
What problem have you solved?

The number of inactive issues and PR are far too many to manage at the moment.  

**Solution**
How did you solve the problem?

From the [probot site](https://github.com/probot/stale#is-closing-stale-issues-really-a-good-idea):

> In an ideal world with infinite resources, there would be no need for this app.
> 
> But in any successful software project, there's always more work to do than people to do it. As more and more work piles up, it becomes paralyzing. Just making decisions about what work should and shouldn't get done can exhaust all available resources. In the experience of the maintainers of this app—and the hundreds of other projects and organizations that use it—focusing on issues that are actively affecting humans is an effective method for prioritizing work.
> 
> To some, a robot trying to close stale issues may seem inhospitable or offensive to contributors. But the alternative is to disrespect them by setting false expectations and implicitly ignoring their work. This app makes it explicit: if work is not progressing, then it's stale. A comment is all it takes to keep the conversation alive.

**Screenshots**
If applicable, add screenshots to help explain your solution.

**Acceptance Criteria**
Please make sure you meet the following.

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing unit tests pass on Travis with my changes