### PR TITLE
Scale back stale bots time to stale

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,3 @@
----
-name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
----
-
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,12 +1,3 @@
----
-name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
----
-
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,12 @@
----
-name: Pull Request
-about: Create a PR to contribute
-title: ''
-labels: ''
-assignees: ''
-
----
-
 **Problem**
+
 What problem have you solved?
 
-
 **Solution**
+
 How did you solve the problem?
 
-**Screenshots**
-If applicable, add screenshots to help explain your solution.
-
 **Acceptance Criteria**
-Please make sure you meet the following.
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] New and existing unit tests pass on Travis with my changes
+Have you written tests? Have you included screenshots of your changes if applicable?
+Did you document your changes? 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.


### PR DESCRIPTION
**Problem**

Stale bot is pretty aggressive. And the PR/issue templates were a bit confusing.

**Solution**

- scale back stale bot to >90 days.
- simplify the templates

**Acceptance Criteria**

N/A as it is a chore.