### PR TITLE
JSONWidget updated with null value fix

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -1,4 +1,3 @@
-import ast
 import json
 from datetime import date, datetime
 from decimal import Decimal
@@ -272,12 +271,19 @@ class SimpleArrayWidget(Widget):
 class JSONWidget(Widget):
     """
     Widget for a JSON object (especially required for jsonb fields in PostgreSQL database.)
+
+    :param value: Defaults to JSON format.
+    The widget covers two cases: Proper JSON string with double quotes, else it
+    tries to use single quotes and then convert it to proper JSON.
     """
 
     def clean(self, value, row=None, *args, **kwargs):
         val = super().clean(value)
         if val:
-            return ast.literal_eval(val)
+            try:
+                return json.loads(val)
+            except json.decoder.JSONDecodeError:
+                return json.loads(val.replace("'", "\""))
 
     def render(self, value, obj=None):
         if value:

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -278,10 +278,15 @@ class JSONWidgetTest(TestCase):
     def test_render(self):
         self.assertEqual(self.widget.render(self.value), '{"value": 23}')
 
+    def test_clean_single_quoted_string(self):
+        self.assertEqual(self.widget.clean("{'value': 23}"), self.value)
+        self.assertEqual(self.widget.clean("{'value': null}"), {'value': None})
+
     def test_clean_none(self):
         self.assertEqual(self.widget.clean(None), None)
-        self.assertEqual(self.widget.clean('{}'), {})
+        self.assertEqual(self.widget.clean('{"value": null}'), {'value': None})
 
     def test_render_none(self):
         self.assertEqual(self.widget.render(None), None)
         self.assertEqual(self.widget.render(dict()), None)
+        self.assertEqual(self.widget.render({"value": None}), '{"value": null}')


### PR DESCRIPTION
**Problem**

JSONWidget gives error when there are null values due to ast.literal_eval which fails to evaluate null as values.

**Solution**

By default, now it will use json to loads and dumps. However if the json string has single quotes instead of double, it will first replace the single quotes to double quotes and then loads.

**Acceptance Criteria**

Tests have included for such cases.