### PR TITLE
show error properly in rtl mode

### DIFF
--- a/import_export/static/import_export/import.css
+++ b/import_export/static/import_export/import.css
@@ -20,7 +20,6 @@
   pointer-events: none;
   background-color: #ffc1c1;
   padding: 14px 15px 10px;
-  left: 16px;
   top: 25px;
   margin: 0 0 20px 0;
   width: 200px;


### PR DESCRIPTION
**Problem**

What problem have you solved? Showing error message properly when admin language is rtl.

**Solution**

How did you solve the problem? Removing unnecessary style 

**Acceptance Criteria**

I checked it with lrt and rtl mode and both of them now show the error correctly

RTL Before:
![before](https://user-images.githubusercontent.com/13090047/57970480-e412bf80-7996-11e9-8223-f82fd074976c.png)
RTL After:
![after-rtl](https://user-images.githubusercontent.com/13090047/57970483-e8d77380-7996-11e9-9565-35e8170335b8.png)
LTR After:
![after-ltr](https://user-images.githubusercontent.com/13090047/57970484-ebd26400-7996-11e9-8d41-e98bdc73e5ec.png)
