### PR TITLE
show error properly in rtl mode

### DIFF
--- a/import_export/static/import_export/import.css
+++ b/import_export/static/import_export/import.css
@@ -20,7 +20,6 @@
   pointer-events: none;
   background-color: #ffc1c1;
   padding: 14px 15px 10px;
-  left: 16px;
   top: 25px;
   margin: 0 0 20px 0;
   width: 200px;


### PR DESCRIPTION
**Problem**

What problem have you solved? Showing error message properly when admin language is rtl.

**Solution**

How did you solve the problem? Removing unnecessary style

**Acceptance Criteria**

I checked it with lrt and rtl mode and both of them now show the error correctly

RTL Before:
![before](https://user-images.githubusercontent.com/13090047/57973233-16ceaf00-79bb-11e9-9729-dbafabbc9574.png)

RTL After:
![after-rtl](https://user-images.githubusercontent.com/13090047/57973234-1d5d2680-79bb-11e9-9fb7-5b67ed1f0c1a.png)

LTR After:
![after-ltr](https://user-images.githubusercontent.com/13090047/57973237-251ccb00-79bb-11e9-9e5c-2f45df51475c.png)

