### PR TITLE
diff word by word

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,6 +70,12 @@ You can use the following directives in your settings file:
     your own permission code. Default is ``None`` which means
     everybody can execute export action.
 
+``IMPORT_EXPORT_DIFF_BY_WORDS``
+    Global setting controls diff appearance. By setting it to ``True``,
+    diffs will be detected word by word instead of char by char.
+    Default is ``False``.
+
+
 Example app
 ===========
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,10 +70,10 @@ You can use the following directives in your settings file:
     your own permission code. Default is ``None`` which means
     everybody can execute export action.
 
-``IMPORT_EXPORT_DIFF_BY_WORDS``
-    Global setting controls diff appearance. By setting it to ``True``,
+``IMPORT_EXPORT_DIFF_BY_CHARS``
+    Global setting controls diff appearance. By setting it to ``False``,
     diffs will be detected word by word instead of char by char.
-    Default is ``False``.
+    Default is ``True``.
 
 
 Example app

--- a/import_export/diff.py
+++ b/import_export/diff.py
@@ -1,0 +1,40 @@
+def diff_lines_to_words(text1, text2):
+    # Implemented following the docs:
+    # https://github.com/google/diff-match-patch/wiki/Line-or-Word-Diffs
+    # Only one line is different from diff_linesToChars.
+    # line_end = text.find('\n', lineStart)
+    # --->
+    # line_end = text.find(' ', lineStart)
+    # Variable names are also changed to snake_case for code integrity.
+
+    line_array = []
+    line_hash = {}
+    line_array.append('')
+
+    def diff_lines_to_chars_munge(text):
+        chars = []
+        line_start = 0
+        line_end = -1
+        while line_end < len(text) - 1:
+            line_end = text.find(' ', line_start)
+            if line_end == -1:
+                line_end = len(text) - 1
+            line = text[line_start:line_end + 1]
+
+            if line in line_hash:
+                chars.append(chr(line_hash[line]))
+            else:
+                if len(line_array) == max_lines:
+                    line = text[line_start:]
+                    line_end = len(text)
+                line_array.append(line)
+                line_hash[line] = len(line_array) - 1
+                chars.append(chr(len(line_array) - 1))
+            line_start = line_end + 1
+        return "".join(chars)
+
+    max_lines = 666666
+    chars1 = diff_lines_to_chars_munge(text1)
+    max_lines = 1114111
+    chars2 = diff_lines_to_chars_munge(text2)
+    return (chars1, chars2, line_array)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -28,7 +28,7 @@ from . import widgets
 from .fields import Field
 from .instance_loaders import ModelInstanceLoader
 from .results import Error, Result, RowResult
-from .utils import atomic_if_using_transaction
+from .utils import atomic_if_using_transaction, html_diff
 
 logger = logging.getLogger(__name__)
 # Set default logging handler to avoid "No handler found" warnings.
@@ -171,9 +171,7 @@ class Diff:
         for v1, v2 in zip(self.left, self.right):
             if v1 != v2 and self.new:
                 v1 = ""
-            diff = dmp.diff_main(force_text(v1), force_text(v2))
-            dmp.diff_cleanupSemantic(diff)
-            html = dmp.diff_prettyHtml(diff)
+            html = html_diff(v1, v2, dmp)
             html = mark_safe(html)
             data.append(html)
         return data

--- a/import_export/utils.py
+++ b/import_export/utils.py
@@ -1,4 +1,8 @@
+from diff_match_patch import diff_match_patch
+
+from django.conf import settings
 from django.db import transaction
+from django.utils.encoding import force_text
 
 
 class atomic_if_using_transaction:
@@ -23,3 +27,61 @@ class atomic_if_using_transaction:
     def __exit__(self, *args):
         if self.using_transactions:
             self.context_manager.__exit__(*args)
+
+
+def diff_lines_to_words(text1, text2):
+    # Implemented following the docs:
+    # https://github.com/google/diff-match-patch/wiki/Line-or-Word-Diffs
+    # Only one line is different from diff_linesToChars.
+    # line_end = text.find('\n', lineStart)
+    # --->
+    # line_end = text.find(' ', lineStart)
+    # Variable names are also changed to snake_case for code integrity.
+
+    line_array = []
+    line_hash = {}
+    line_array.append('')
+
+    def diff_lines_to_chars_munge(text):
+        chars = []
+        line_start = 0
+        line_end = -1
+        while line_end < len(text) - 1:
+            line_end = text.find(' ', line_start)
+            if line_end == -1:
+                line_end = len(text) - 1
+            line = text[line_start:line_end + 1]
+
+            if line in line_hash:
+                chars.append(chr(line_hash[line]))
+            else:
+                if len(line_array) == maxLines:
+                    line = text[line_start:]
+                    line_end = len(text)
+                line_array.append(line)
+                line_hash[line] = len(line_array) - 1
+                chars.append(chr(len(line_array) - 1))
+            line_start = line_end + 1
+        return "".join(chars)
+
+    maxLines = 666666
+    chars1 = diff_lines_to_chars_munge(text1)
+    maxLines = 1114111
+    chars2 = diff_lines_to_chars_munge(text2)
+    return (chars1, chars2, line_array)
+
+
+def html_diff(value1, value2, dmp=None):
+    dmp = dmp or diff_match_patch()
+
+    value1 = force_text(value1)
+    value2 = force_text(value2)
+    if getattr(settings, 'IMPORT_EXPORT_DIFF_BY_WORDS', False):
+        a = diff_lines_to_words(value1, value2)
+        diff = dmp.diff_main(a[0], a[1], False)
+        dmp.diff_charsToLines(diff, a[2])
+    else:
+        diff = dmp.diff_main(value1, value2)
+
+    dmp.diff_cleanupSemantic(diff)
+    return dmp.diff_prettyHtml(diff)

--- a/import_export/utils.py
+++ b/import_export/utils.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.db import transaction
 from django.utils.encoding import force_text
 
+from .diff import diff_lines_to_words
+
 
 class atomic_if_using_transaction:
     """Context manager wraps `atomic` if `using_transactions`.
@@ -29,59 +31,17 @@ class atomic_if_using_transaction:
             self.context_manager.__exit__(*args)
 
 
-def diff_lines_to_words(text1, text2):
-    # Implemented following the docs:
-    # https://github.com/google/diff-match-patch/wiki/Line-or-Word-Diffs
-    # Only one line is different from diff_linesToChars.
-    # line_end = text.find('\n', lineStart)
-    # --->
-    # line_end = text.find(' ', lineStart)
-    # Variable names are also changed to snake_case for code integrity.
-
-    line_array = []
-    line_hash = {}
-    line_array.append('')
-
-    def diff_lines_to_chars_munge(text):
-        chars = []
-        line_start = 0
-        line_end = -1
-        while line_end < len(text) - 1:
-            line_end = text.find(' ', line_start)
-            if line_end == -1:
-                line_end = len(text) - 1
-            line = text[line_start:line_end + 1]
-
-            if line in line_hash:
-                chars.append(chr(line_hash[line]))
-            else:
-                if len(line_array) == maxLines:
-                    line = text[line_start:]
-                    line_end = len(text)
-                line_array.append(line)
-                line_hash[line] = len(line_array) - 1
-                chars.append(chr(len(line_array) - 1))
-            line_start = line_end + 1
-        return "".join(chars)
-
-    maxLines = 666666
-    chars1 = diff_lines_to_chars_munge(text1)
-    maxLines = 1114111
-    chars2 = diff_lines_to_chars_munge(text2)
-    return (chars1, chars2, line_array)
-
-
 def html_diff(value1, value2, dmp=None):
     dmp = dmp or diff_match_patch()
 
     value1 = force_text(value1)
     value2 = force_text(value2)
-    if getattr(settings, 'IMPORT_EXPORT_DIFF_BY_WORDS', False):
+    if getattr(settings, 'IMPORT_EXPORT_DIFF_BY_CHARS', True):
+        diff = dmp.diff_main(value1, value2)
+    else:
         a = diff_lines_to_words(value1, value2)
         diff = dmp.diff_main(a[0], a[1], False)
         dmp.diff_charsToLines(diff, a[2])
-    else:
-        diff = dmp.diff_main(value1, value2)
 
     dmp.diff_cleanupSemantic(diff)
     return dmp.diff_prettyHtml(diff)

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -293,7 +293,7 @@ class ModelResourceTest(TestCase):
                          'other </ins><span>book</span>')
         self.assertFalse(html[headers.index('author_email')])
 
-    @override_settings(IMPORT_EXPORT_DIFF_BY_WORDS=True)
+    @override_settings(IMPORT_EXPORT_DIFF_BY_CHARS=False)
     def test_get_diff_by_word(self):
         self.book.price = Decimal('10.25')
         diff = Diff(self.resource, self.book, False)


### PR DESCRIPTION
**Problem**

After changing numbers in dataset and importing them, diff is viewed char by char instead of word by word.
 
**Solution**

I used [diff_match_patch](https://github.com/google/diff-match-patch/wiki/Line-or-Word-Diffs) approach to handle this solution.

**Acceptance Criteria**

I have written tests and docs. Also, since I use a setting variable to use word diff, there should be not any compatibility issue.

IMPORT_EXPRORT_DIFF_BY_WORDS = False  (defualt):
![1](https://user-images.githubusercontent.com/13090047/57973387-7ded6300-79bd-11e9-8f3f-22e1222c8d4f.png)

IMPORT_EXPRORT_DIFF_BY_WORDS = True:
![2](https://user-images.githubusercontent.com/13090047/57973389-83e34400-79bd-11e9-85ce-ae985b7ebe4c.png)
 