### PR TITLE
Downgrade tablib to 0.12.1 so python 2.7 and Django 1.8 env works with import action

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Requirements
 
 * Python 2.7+ or Python 3.3+
 * Django 1.8+
-* tablib (dev or 0.9.11)
+* tablib (0.12.1 - 0.13+ not supported)
 
 Example app
 -----------
@@ -68,6 +68,6 @@ As most projects, we try to follow PEP8_ as closely as possible. Please bear
 in mind that most pull requests will be rejected without proper unit testing.
 
 .. _`PEP8`: https://www.python.org/dev/peps/pep-0008/
-.. _`tablib`: https://github.com/kennethreitz/tablib
+.. _`tablib`: https://github.com/kennethreitz/tablib/tree/v0.12.1
 .. _`the repository`: https://github.com/django-import-export/django-import-export/
 .. _AUTHORS: https://github.com/django-import-export/django-import-export/blob/master/AUTHORS

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 Django>=1.8
-tablib>=0.12
+tablib==0.12.1
 diff-match-patch
 openpyxl>=2.4,<2.5


### PR DESCRIPTION
**Problem**
Error encountered while trying to read file CSV with python 2.7 [#957 ](https://github.com/django-import-export/django-import-export/issues/957)

**Solution**
Downgrade tablib to 0.12.1

**Acceptance Criteria**
Doc updated with good dependencies  