### PR TITLE
An attempt to improve DOM performance

### DIFF
--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -11,6 +11,17 @@
 {% endblock %}
 
 {% block content %}
+  <script type="text/javascript">
+    // Append stylesheet to hide table
+    var sheet = document.createElement('style');
+    sheet.id = "table_hider";
+    sheet.innerHTML = "table.import-preview { display:none; }";
+    document.head.appendChild(sheet);
+    // Remove style upon finish of dom content loading (does not include img, since imgs can can load slowly)
+    document.addEventListener('DOMContentLoaded', function() {
+      document.head.removeChild(document.getElementById("table_hider"));
+    }, false);
+  </script>
 
   {% if confirm_form %}
     <form action="{% url opts|admin_urlname:"process_import" %}" method="POST">

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -17,7 +17,7 @@
     sheet.id = "table_hider";
     sheet.innerHTML = "table.import-preview { display:none; }";
     document.head.appendChild(sheet);
-    // Remove style upon finish of dom content loading (does not include img, since imgs can can load slowly)
+    // Remove style upon finish of dom content loading (does not include img, since imgs can load slowly)
     document.addEventListener('DOMContentLoaded', function() {
       document.head.removeChild(document.getElementById("table_hider"));
     }, false);


### PR DESCRIPTION
**Problem**

Issue [#932](https://github.com/django-import-export/django-import-export/issues/932)

**Solution**

The additional script added at the start of the content block inserts a stylesheet that hides the "import-preview" table. Once the DOM has finished loading, the event listener triggers, removing the stylesheet and showing the table.

Users that have disabled JS wouldn't be affected by this, since all style changes were made inside JS, which wouldn't occur for them.