### PR TITLE
Add link to django-import-export-celery in docs

### DIFF
--- a/docs/celery.rst
+++ b/docs/celery.rst
@@ -1,0 +1,5 @@
+===========
+Using celery to perform imports
+===========
+
+You can use the 3rd party `django-import-export-celery <https://github.com/auto-mat/django-import-export-celery>`_ application to process long imports in celery.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ and exporting data with included admin integration.
    installation
    getting_started
    import_workflow
+   celery
    changelog
 
 .. toctree::


### PR DESCRIPTION
**Problem**

What problem have you solved?

Long running imports time out.

**Solution**

How did you solve the problem?

Moved long running imports to celery

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes?  