### PR TITLE
Fix bug with spaces in export filename, pass request and queryset

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -42,7 +42,7 @@ class ImportExportMixinBase:
 class ImportMixin(ImportExportMixinBase):
     """
     Import mixin.
-    
+
     This is intended to be mixed with django.contrib.admin.ModelAdmin
     https://docs.djangoproject.com/en/2.1/ref/contrib/admin/#modeladmin-objects
     """
@@ -346,7 +346,7 @@ class ImportMixin(ImportExportMixinBase):
 class ExportMixin(ImportExportMixinBase):
     """
     Export mixin.
-    
+
     This is intended to be mixed with django.contrib.admin.ModelAdmin
     https://docs.djangoproject.com/en/2.1/ref/contrib/admin/#modeladmin-objects
     """
@@ -406,7 +406,7 @@ class ExportMixin(ImportExportMixinBase):
         """
         return [f for f in self.formats if f().can_export()]
 
-    def get_export_filename(self, file_format):
+    def get_export_filename(self, request, queryset, file_format):
         date_str = datetime.now().strftime('%Y-%m-%d')
         filename = "%s-%s.%s" % (self.model.__name__,
                                  date_str,
@@ -481,8 +481,8 @@ class ExportMixin(ImportExportMixinBase):
             export_data = self.get_export_data(file_format, queryset, request=request)
             content_type = file_format.get_content_type()
             response = HttpResponse(export_data, content_type=content_type)
-            response['Content-Disposition'] = 'attachment; filename=%s' % (
-                self.get_export_filename(file_format),
+            response['Content-Disposition'] = 'attachment; filename="%s"' % (
+                self.get_export_filename(request, queryset, file_format),
             )
 
             post_export.send(sender=None, model=self.model)
@@ -558,8 +558,8 @@ class ExportActionMixin(ExportMixin):
             export_data = self.get_export_data(file_format, queryset, request=request)
             content_type = file_format.get_content_type()
             response = HttpResponse(export_data, content_type=content_type)
-            response['Content-Disposition'] = 'attachment; filename=%s' % (
-                self.get_export_filename(file_format),
+            response['Content-Disposition'] = 'attachment; filename="%s"' % (
+                self.get_export_filename(request, queryset, file_format),
             )
             return response
     export_admin_action.short_description = _(

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -80,7 +80,7 @@ class ExportViewFormMixin(ExportViewMixin, FormView):
             response = HttpResponse(export_data, content_type=content_type)
         except TypeError:
             response = HttpResponse(export_data, mimetype=content_type)
-        response['Content-Disposition'] = 'attachment; filename=%s' % (
+        response['Content-Disposition'] = 'attachment; filename="%s"' % (
             self.get_export_filename(file_format),
         )
 

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -1,4 +1,5 @@
 import os.path
+from datetime import datetime
 from tablib import Dataset
 
 from core.admin import AuthorAdmin, BookAdmin, BookResource, CustomBookAdmin
@@ -111,10 +112,15 @@ class ImportExportAdminIntegrationTest(TestCase):
         data = {
             'file_format': '0',
             }
+        date_str = datetime.now().strftime('%Y-%m-%d')
         response = self.client.post('/admin/core/book/export/', data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.has_header("Content-Disposition"))
         self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertEqual(
+            response['Content-Disposition'],
+            'attachment; filename="Book-{}.csv"'.format(date_str)
+        )
 
     def test_returns_xlsx_export(self):
         response = self.client.get('/admin/core/book/export/')
@@ -342,6 +348,11 @@ class ExportActionAdminIntegrationTest(TestCase):
         self.assertContains(response, self.cat1.name, status_code=200)
         self.assertNotContains(response, self.cat2.name, status_code=200)
         self.assertTrue(response.has_header("Content-Disposition"))
+        date_str = datetime.now().strftime('%Y-%m-%d')
+        self.assertEqual(
+            response['Content-Disposition'],
+            'attachment; filename="Category-{}.csv"'.format(date_str)
+        )
 
     def test_export_no_format_selected(self):
         data = {


### PR DESCRIPTION
**Problem**

There was a bug when export filename contained a space, it was truncated. For example:
`foo bar.csv` resulted just in `foo` filename being served as file.
Also I've found a lack of request instance and queryset while preparing filename. It may also be needed by somebody else, so I've added it.