### PR TITLE
Move actions definition to ExportActionMixin

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -565,8 +565,6 @@ class ExportActionMixin(ExportMixin):
     export_admin_action.short_description = _(
         'Export selected %(verbose_name_plural)s')
 
-    actions = [export_admin_action]
-
     class Media:
         js = ['import_export/action_formats.js']
 
@@ -576,6 +574,8 @@ class ExportActionModelAdmin(ExportActionMixin, admin.ModelAdmin):
     Subclass of ModelAdmin with export functionality implemented as an
     admin action.
     """
+
+    actions = admin.ModelAdmin.actions + [export_admin_action]
 
 
 class ImportExportActionModelAdmin(ImportMixin, ExportActionModelAdmin):

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -565,6 +565,8 @@ class ExportActionMixin(ExportMixin):
     export_admin_action.short_description = _(
         'Export selected %(verbose_name_plural)s')
 
+    actions = admin.ModelAdmin.actions + [export_admin_action]
+
     class Media:
         js = ['import_export/action_formats.js']
 
@@ -574,8 +576,6 @@ class ExportActionModelAdmin(ExportActionMixin, admin.ModelAdmin):
     Subclass of ModelAdmin with export functionality implemented as an
     admin action.
     """
-
-    actions = admin.ModelAdmin.actions + [export_admin_action]
 
 
 class ImportExportActionModelAdmin(ImportMixin, ExportActionModelAdmin):


### PR DESCRIPTION
New way of handling admin actions

**Problem**

From Django 2.2 admin actions are no longer collected from base ModelAdmin classes
https://docs.djangoproject.com/en/2.2/releases/2.2/#admin-actions-are-no-longer-collected-from-base-modeladmin-classes

**Solution**

Use new suggested way of adding admin actions

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 