### PR TITLE
Fix potential header / row column mismatches for invalid rows in…

### DIFF
--- a/import_export/results.py
+++ b/import_export/results.py
@@ -108,11 +108,12 @@ class Result:
         self.failed_dataset.append(row_values)
 
     def append_invalid_row(self, number, row, validation_error):
-        self.invalid_rows.append(InvalidRow(
-            number=number,
-            validation_error=validation_error,
-            values=row.values(),
-        ))
+        # NOTE: value order must match diff_headers order, so that row
+        # values and column headers match in the UI when displayed
+        values = tuple(row.get(col, "---") for col in self.diff_headers)
+        self.invalid_rows.append(
+            InvalidRow(number=number, validation_error=validation_error, values=values)
+        )
 
     def increment_row_result_total(self, row_result):
         if row_result.import_type:

--- a/tests/core/tests/test_invalidrow.py
+++ b/tests/core/tests/test_invalidrow.py
@@ -21,7 +21,7 @@ class InvalidRowTest(TestCase):
         self.obj = InvalidRow(
             number=1,
             validation_error=e,
-            values={'name': 'ABC', 'birthday': '123'}
+            values=['ABC', '123']
         )
 
     def test_error_count(self):
@@ -43,7 +43,7 @@ class InvalidRowTest(TestCase):
         obj = InvalidRow(
             number=1,
             validation_error=self.non_field_errors,
-            values={}
+            values=[]
         )
         self.assertIsInstance(obj.error_dict, dict)
         self.assertIn(NON_FIELD_ERRORS, obj.error_dict)

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -364,17 +364,35 @@ class ModelResourceTest(TestCase):
             class Meta:
                 model = Author
                 clean_model_instances = True
+                export_order = ['id', 'name', 'birthday']
 
+        # create test dataset
+        # NOTE: column order is deliberately strange
+        dataset = tablib.Dataset(headers=['name', 'id'])
+        dataset.append(['123', '1'])
+
+        # run import_data()
         resource = TestResource()
-        dataset = tablib.Dataset(headers=['id', 'name'])
-        dataset.append(['', '123'])
-
         result = resource.import_data(dataset, raise_errors=False)
+
+        # check has_validation_errors()
         self.assertTrue(result.has_validation_errors())
-        self.assertEqual(result.invalid_rows[0].error_count, 1)
+
+        # check the invalid row itself
+        invalid_row = result.invalid_rows[0]
+        self.assertEqual(invalid_row.error_count, 1)
         self.assertEqual(
-            result.invalid_rows[0].field_specific_errors,
+            invalid_row.field_specific_errors,
             {'name': ["'123' is not a valid value"]}
+        )
+        # diff_header and invalid_row.values should match too
+        self.assertEqual(
+            result.diff_headers,
+            ['id', 'name', 'birthday']
+        )
+        self.assertEqual(
+            invalid_row.values,
+            ('1', '123', '---')
         )
 
     def test_known_invalid_fields_are_excluded_from_model_instance_cleaning(self):


### PR DESCRIPTION
### Problem

When a row fails to validate during import, details are added to `Result.invalid_rows` so that the row data and associated validation errors can be displayed in the UI. Currently, `row.values()` is used to convert the imported data (at this point, an `OrderedDict`) into a list of values for each item, which is what is used to [output column values for the row](https://github.com/django-import-export/django-import-export/blob/master/import_export/templates/admin/import_export/import.html#L127) in the UI. But, the column headers for that same table are [generated from `Result.diff_headers`](https://github.com/django-import-export/django-import-export/blob/master/import_export/templates/admin/import_export/import.html#L91), which are not guaranteed to be in the same order, or have the same number of items.

### Solution

The solution is to ensure that the `values` list on each item in `Result.invalid_rows` matches the order of `Result.diff_headers`. This way, the column values will always match up to the column headers in the UI.

### Acceptance Criteria

**Have you written tests?**
Yes

**Have you included screenshots of your changes if applicable?**
N/A

**Did you document your changes?**
N/A