### PR TITLE
add row_number parameter to before_import_row, after_import_row

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -134,6 +134,7 @@ Changelog
 - Removed support for Django < 2.0
 - Removed support for Python < 3.5
 - feat: Support for Postgres JSONb Field (#904)
+- add row_number parameter to before_import_row(), after_import_instance() and after_import_row()
 
 1.2.0 (2019-01-10)
 ------------------


### PR DESCRIPTION
and after_import_instance

**Problem**

I was trying to report import progress to user but I didn't have access to row numbers.

**Solution**

Simply added the row row number to the parameters of the functions `before_import_row()`, `after_import_row()` and `after_import_instance()`

**Acceptance Criteria**

The change is simple and straightforward. It shouldn't brake anything, if the user did implement those functions as documented with `**kwargs` parameter. Otherwise he would need to add the new parameter.