### PR TITLE
Fix exception import for Django 3

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -7,11 +7,11 @@ from copy import deepcopy
 
 from diff_match_patch import diff_match_patch
 
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.management.color import no_style
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel
 from django.db.models.query import QuerySet
 from django.db.transaction import (
@@ -29,6 +29,12 @@ from .fields import Field
 from .instance_loaders import ModelInstanceLoader
 from .results import Error, Result, RowResult
 from .utils import atomic_if_using_transaction
+
+if django.VERSION[0] >= 3:
+    from django.core.exceptions import FieldDoesNotExist
+else:
+    from django.db.models.fields import FieldDoesNotExist
+
 
 logger = logging.getLogger(__name__)
 # Set default logging handler to avoid "No handler found" warnings.

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -6,11 +6,11 @@ from datetime import date
 from decimal import Decimal
 from unittest import mock, skip, skipUnless
 
+import django
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import DatabaseError, IntegrityError
 from django.db.models import Count
-from django.db.models.fields import FieldDoesNotExist
 from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
@@ -31,6 +31,12 @@ from ..models import (
     WithDynamicDefault,
     WithFloatField
 )
+
+if django.VERSION[0] >= 3:
+    from django.core.exceptions import FieldDoesNotExist
+else:
+    from django.db.models.fields import FieldDoesNotExist
+
 
 
 class MyResource(resources.Resource):


### PR DESCRIPTION
**Problem**

Imports fail for the current master because the exception `FieldDoesNotExist` has been moved.

**Solution**

Made import conditional on the Django version.

**Acceptance Criteria**

CI tests should stop failing for the Django master