### PR TITLE
Add missing space to description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
 setup(
     name="django-import-export",
     description="Django application and library for importing and exporting"
-                "data with included admin integration.",
+                " data with included admin integration.",
     long_description=readme,
     version=VERSION,
     author="Informatika Mihelac",


### PR DESCRIPTION

**Problem**

The package description is missing a white space. The description is currently showing as `Django application and library for importing and exportingdata with included admin integration.`

**Solution**
Added white space

**Acceptance Criteria**

The description is showing correctly as `Django application and library for importing and exporting data with included admin integration.`