### PR TITLE
Initialize Decimal with text value, fix #1035

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -85,7 +85,7 @@ class DecimalWidget(NumberWidget):
     def clean(self, value, row=None, *args, **kwargs):
         if self.is_empty(value):
             return None
-        return Decimal(value)
+        return Decimal(force_text(value))
 
 
 class CharWidget(Widget):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -145,6 +145,7 @@ class DecimalWidgetTest(TestCase):
 
     def test_clean(self):
         self.assertEqual(self.widget.clean("11.111"), self.value)
+        self.assertEqual(self.widget.clean(11.111), self.value)
 
     def test_render(self):
         self.assertEqual(self.widget.render(self.value), self.value)


### PR DESCRIPTION
**Problem**

As [per doc](https://docs.python.org/3/library/decimal.html):

```python
>>> Decimal('3.14')
Decimal('3.14')
>>> Decimal(3.14)
Decimal('3.140000000000000124344978758017532527446746826171875')
```

When Decimal field is initialized from import it gets float value. See updated test case for details (it will fail without this fix).

**Solution**

Force Decimal initialization with text value.

**Acceptance Criteria**

Test case updated, no documentation changes required.