### PR TITLE
Fix: Account for field column names when skipping get_instance() 

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -258,12 +258,13 @@ class Resource(metaclass=DeclarativeMetaclass):
 
     def get_instance(self, instance_loader, row):
         """
-        If all 'import_id_fields' are present in the dataset, calls
-        the :doc:`InstanceLoader <api_instance_loaders>`. Otherwise,
-        returns `None`.
+        If all columns corresponding to fields in the 'import_id_fields'
+        Meta attribute are present in the dataset, calls the
+        :doc:`InstanceLoader <api_instance_loaders>`. Otherwise, returns
+        `None`.
         """
-        for field_name in self.get_import_id_fields():
-            if field_name not in row:
+        for column_name in self.get_import_id_column_names():
+            if column_name not in row:
                 return
         return instance_loader.get_instance(row)
 
@@ -904,6 +905,12 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         """
         """
         return self._meta.import_id_fields
+
+    def get_import_id_column_names(self):
+        return tuple(
+            self.fields[fieldname].column_name or fieldname
+            for fieldname in self.get_import_id_fields()
+        )
 
     def get_queryset(self):
         """

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -287,6 +287,28 @@ class ModelResourceTest(TestCase):
             # instance_loader.get_instance() should NOT have been called
             mocked_method.assert_not_called()
 
+    def test_get_instance_when_id_field_has_custom_column_name(self):
+
+        class TestResource(resources.ModelResource):
+            pk = fields.Field(attribute="id", column_name='PrimaryKey', widget=widgets.IntegerWidget())
+
+            class Meta:
+                model = Book
+                fields = ('pk', 'name', 'author_email', 'price')
+                import_id_fields = ('pk',)
+
+        resource = TestResource()
+
+        # construct a dataset with a "PrimaryKey" column
+        dataset = tablib.Dataset(headers=['PrimaryKey', 'name'])
+        # Use the pk of an existing object
+        dataset.append([str(self.book.pk), 'New name'])
+
+        # resource.get_instance() should return the existing object
+        instance_loader = resource._meta.instance_loader_class(resource)
+        result = resource.get_instance(instance_loader, dataset.dict[0])
+        self.assertEqual(result, self.book)
+
     def test_get_export_headers(self):
         headers = self.resource.get_export_headers()
         self.assertEqual(headers, ['published_date', 'id', 'name', 'author',


### PR DESCRIPTION
**Problem**

As @dhorlick mentioned on PR #996, the current solution doesn't account for `import_id_fields` containing names of fields that have a `column_name` set. If they do, `Resource.get_instance()` should check rows for the presence columns matching that instead of the field name.

**Solution**

See code changes (they are simple / self-explanatory)

**Acceptance Criteria**

Tests have been altered to show that field column names are taken into account