### PR TITLE
Adds meta flag 'skip_diff' to enable skipping of diff operations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -112,3 +112,4 @@ The following is a list of much appreciated contributors:
 * ababic (Andy Babic)
 * BramManuel (Bram Janssen)
 * kjpc-tech (Kyle)
+* Matthew Hegarty

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -1215,15 +1215,17 @@ class SkipDiffTest(TestCase):
     """
     def setUp(self):
         class _BookResource(resources.ModelResource):
+
             class Meta:
                 model = Book
                 skip_diff = True
+
         self.resource = _BookResource()
         self.dataset = tablib.Dataset(headers=['id', 'name', 'birthday'])
         self.dataset.append(['', 'A.A.Milne', '1882test-01-18'])
 
     def test_skip_diff(self, mock_diff, mock_deep_copy):
-        result = self.resource.import_data(self.dataset, raise_errors=False)
+        self.resource.import_data(self.dataset, raise_errors=False)
         mock_diff.return_value.compare_with.assert_not_called()
         mock_diff.return_value.as_html.assert_not_called()
         mock_deep_copy.assert_not_called()
@@ -1231,15 +1233,15 @@ class SkipDiffTest(TestCase):
     def test_skip_diff_for_delete_new_resource(self, mock_diff, mock_deep_copy):
         class BookResource(resources.ModelResource):
 
-            def for_delete(self, row, instance):
-                return True
-
             class Meta:
                 model = Book
                 skip_diff = True
 
+            def for_delete(self, row, instance):
+                return True
+
         resource = BookResource()
-        result = resource.import_data(self.dataset, raise_errors=False)
+        resource.import_data(self.dataset, raise_errors=False)
         mock_diff.return_value.compare_with.assert_not_called()
         mock_diff.return_value.as_html.assert_not_called()
         mock_deep_copy.assert_not_called()
@@ -1248,19 +1250,19 @@ class SkipDiffTest(TestCase):
         book = Book.objects.create()
         class BookResource(resources.ModelResource):
 
+            class Meta:
+                model = Book
+                skip_diff = True
+
             def get_or_init_instance(self, instance_loader, row):
                 return book, False
 
             def for_delete(self, row, instance):
                 return True
 
-            class Meta:
-                model = Book
-                skip_diff = True
-
         resource = BookResource()
 
-        result = resource.import_data(self.dataset, raise_errors=False, dry_run=True)
+        resource.import_data(self.dataset, raise_errors=False, dry_run=True)
         mock_diff.return_value.compare_with.assert_not_called()
         mock_diff.return_value.as_html.assert_not_called()
         mock_deep_copy.assert_not_called()

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -1207,11 +1207,12 @@ class ManyRelatedManagerDiffTest(TestCase):
                          expected_value)
 
 
-@mock.patch("copy.deepcopy")
 @mock.patch("import_export.resources.Diff", spec=True)
 class SkipDiffTest(TestCase):
     """
     Tests that the meta attribute 'skip_diff' means that no diff operations are called.
+    'copy.deepcopy' cannot be patched at class level because it causes interferes with
+    ``resources.Resource.__init__()``.
     """
     def setUp(self):
         class _BookResource(resources.ModelResource):
@@ -1224,13 +1225,14 @@ class SkipDiffTest(TestCase):
         self.dataset = tablib.Dataset(headers=['id', 'name', 'birthday'])
         self.dataset.append(['', 'A.A.Milne', '1882test-01-18'])
 
-    def test_skip_diff(self, mock_diff, mock_deep_copy):
-        self.resource.import_data(self.dataset, raise_errors=False)
-        mock_diff.return_value.compare_with.assert_not_called()
-        mock_diff.return_value.as_html.assert_not_called()
-        mock_deep_copy.assert_not_called()
+    def test_skip_diff(self, mock_diff):
+        with mock.patch("copy.deepcopy") as mock_deep_copy:
+            self.resource.import_data(self.dataset)
+            mock_diff.return_value.compare_with.assert_not_called()
+            mock_diff.return_value.as_html.assert_not_called()
+            mock_deep_copy.assert_not_called()
 
-    def test_skip_diff_for_delete_new_resource(self, mock_diff, mock_deep_copy):
+    def test_skip_diff_for_delete_new_resource(self, mock_diff):
         class BookResource(resources.ModelResource):
 
             class Meta:
@@ -1241,12 +1243,13 @@ class SkipDiffTest(TestCase):
                 return True
 
         resource = BookResource()
-        resource.import_data(self.dataset, raise_errors=False)
-        mock_diff.return_value.compare_with.assert_not_called()
-        mock_diff.return_value.as_html.assert_not_called()
-        mock_deep_copy.assert_not_called()
+        with mock.patch("copy.deepcopy") as mock_deep_copy:
+            resource.import_data(self.dataset)
+            mock_diff.return_value.compare_with.assert_not_called()
+            mock_diff.return_value.as_html.assert_not_called()
+            mock_deep_copy.assert_not_called()
 
-    def test_skip_diff_for_delete_existing_resource(self, mock_diff, mock_deep_copy):
+    def test_skip_diff_for_delete_existing_resource(self, mock_diff):
         book = Book.objects.create()
         class BookResource(resources.ModelResource):
 
@@ -1262,7 +1265,22 @@ class SkipDiffTest(TestCase):
 
         resource = BookResource()
 
-        resource.import_data(self.dataset, raise_errors=False, dry_run=True)
-        mock_diff.return_value.compare_with.assert_not_called()
-        mock_diff.return_value.as_html.assert_not_called()
-        mock_deep_copy.assert_not_called()
+        with mock.patch("copy.deepcopy") as mock_deep_copy:
+            resource.import_data(self.dataset, dry_run=True)
+            mock_diff.return_value.compare_with.assert_not_called()
+            mock_diff.return_value.as_html.assert_not_called()
+            mock_deep_copy.assert_not_called()
+
+    def test_skip_row_returns_false_when_skip_diff_is_true(self, mock_diff):
+        class BookResource(resources.ModelResource):
+
+            class Meta:
+                model = Book
+                skip_unchanged = True
+                skip_diff = True
+
+        resource = BookResource()
+
+        with mock.patch('import_export.resources.Resource.get_import_fields') as mock_get_import_fields:
+            resource.import_data(self.dataset, dry_run=True)
+            self.assertEqual(2, mock_get_import_fields.call_count)


### PR DESCRIPTION
**Problem**

When importing a large number of rows (using this [patch](https://github.com/django-import-export/django-import-export/issues/939#issuecomment-509435531)), disabling the diff operation results in ~30% improvement in import time.

**Solution**

This PR involves adding a meta attribute to the Resource, which gives the option of disabling diffing operations.  The default value is `False` meaning existing behaviour is unchanged unless the flag is explicitly set to `True`.

**Acceptance Criteria**

There is a new TestCase in `test_resources.py` which uses patches to verify that `diff` and `copy` functions are not called.

The flag is documented in `resources.py`.
 