### PR TITLE
Travis import error: no module named settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,7 @@ install:
   - pip install -r requirements/test.txt
   - pip install coveralls
 script:
-   - python -Wall -m coverage run --omit='setup.py' --source=. tests/manage.py test core --settings=
+   - PYTHONPATH=".:tests:$PYTHONPATH" python -Wall -m coverage run --omit='setup.py' --source=. tests/manage.py test core --settings=
    - isort --check-only
 after_success:
   - coveralls
-


### PR DESCRIPTION
**Problem**

Travis started showing errors `ImportError: No module named 'settings'`

**Solution**

Use same export as when running tests script

**Acceptance Criteria**

All good after applying this