### PR TITLE
Pin tablib version to not use new major version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 Django>=2.0
-tablib>=0.12
+tablib>=0.12,<1.0.0
 diff-match-patch
 openpyxl>=2.4,<2.5


### PR DESCRIPTION
**Problem**

When running the command  `django-admin migrate` that was ocurring that following error:

```python
Traceback (most recent call last):
  File "/app/.heroku/python/bin/django-admin", line 11, in <module>
    load_entry_point('Django==2.2.4', 'console_scripts', 'django-admin')()
  File "/app/.heroku/python/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/app/.heroku/python/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
    django.setup()
  File "/app/.heroku/python/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/app/.heroku/python/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
    app_config.ready()
  File "/app/.heroku/python/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
    self.module.autodiscover()
  File "/app/.heroku/python/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
    autodiscover_modules('admin', register_to=site)
  File "/app/.heroku/python/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
    import_module('%s.%s' % (app_config.name, module_to_search))
  File "/app/.heroku/python/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/src/mlentregas/distribution_center/admin.py", line 40, in <module>
    admin.site.register(DistributionCenter, DistributionCenterAdmin)
  File "/app/.heroku/python/lib/python3.7/site-packages/django/contrib/admin/sites.py", line 124, in register
    self._registry[model] = admin_class(model, self)
  File "/app/.heroku/python/lib/python3.7/site-packages/import_export/admin.py", line 497, in __init__
    formats = self.get_export_formats()
  File "/app/.heroku/python/lib/python3.7/site-packages/import_export/admin.py", line 367, in get_export_formats
    return [f for f in self.formats if f().can_export()]
  File "/app/.heroku/python/lib/python3.7/site-packages/import_export/admin.py", line 367, in <listcomp>
    return [f for f in self.formats if f().can_export()]
  File "/app/.heroku/python/lib/python3.7/site-packages/import_export/formats/base_formats.py", line 122, in can_export
    return hasattr(self.get_format(), 'export_set')
  File "/app/.heroku/python/lib/python3.7/site-packages/import_export/formats/base_formats.py", line 93, in get_format
    return import_module(self.TABLIB_MODULE)
  File "/app/.heroku/python/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/.heroku/python/lib/python3.7/site-packages/tablib/formats/_xls.py", line 8, in <module>
    import xlwt
ModuleNotFoundError: No module named 'xlwt'
```

This occurs because  the new version of `tablib` (1.0.0) implements the  PDF, XLS e other modules opitionally and breaks backward compatibility . 

**Solution**

Pinned version in requirements to not use the version 1.0.0 of `tablib`.