### PR TITLE
Pin tablib version to not use new major version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ CLASSIFIERS = [
 install_requires = [
     'diff-match-patch',
     'Django>=2.0',
-    'tablib',
+    'tablib<1.0.0',
 ]
 
 


### PR DESCRIPTION
**Problem**

Pin should be done in setup.py, requirements/base.txt is not used when installing

**Solution**

Modify setup.py

**Acceptance Criteria**

Manual testing