### PR TITLE
Allow tablib to provide format availability

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,10 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for tablib >= 1.0 (#1061)
+
+- Add ability to install a subset of tablib supported formats and save some
+  automatic dependency installations (needs tablib >= 1.0)
 
 
 2.0.1 (2020-01-15)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,6 +7,13 @@ can be installed with standard Python tools like ``pip`` or ``easy_install``::
 
     $ pip install django-import-export
 
+This will automatically install many formats supported by tablib. If you need
+additional formats like ``cli`` or ``Pandas DataFrame``, you should install the
+appropriate tablib dependencies (e.g. ``pip install tablib[pandas]``). Read
+more on the `tablib format documentation page`_.
+
+.. tablib format documentation page: https://tablib.readthedocs.io/en/stable/formats/
+
 Alternatively, you can install the git repository directly to obtain the
 development version::
 

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -63,6 +63,10 @@ class Format:
         # https://www.iana.org/assignments/media-types/media-types.xhtml
         return 'application/octet-stream'
 
+    @classmethod
+    def is_available(cls):
+        return True
+
     def can_import(self):
         return False
 
@@ -81,10 +85,19 @@ class TablibFormat(Format):
         try:
             # Available since tablib 1.0
             from tablib.formats import registry
-            key = self.TABLIB_MODULE.split('.')[-1].replace('_', '')
-            return registry.get_format(key)
         except ImportError:
             return import_module(self.TABLIB_MODULE)
+        else:
+            key = self.TABLIB_MODULE.split('.')[-1].replace('_', '')
+            return registry.get_format(key)
+
+    @classmethod
+    def is_available(cls):
+        try:
+            cls().get_format()
+        except (tablib.core.UnsupportedFormat, ImportError):
+            return False
+        return True
 
     def get_title(self):
         return self.get_format().title
@@ -205,7 +218,7 @@ class XLSX(TablibFormat):
 
 #: These are the default formats for import and export. Whether they can be
 #: used or not is depending on their implementation in the tablib library.
-DEFAULT_FORMATS = (
+DEFAULT_FORMATS = [fmt for fmt in (
     CSV,
     XLS,
     XLSX,
@@ -214,4 +227,4 @@ DEFAULT_FORMATS = (
     JSON,
     YAML,
     HTML,
-)
+) if fmt.is_available()]

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -1,27 +1,5 @@
 import tablib
-import warnings
 from importlib import import_module
-
-try:
-    import xlrd
-    XLS_IMPORT = True
-except ImportError:
-    warnings.warn(
-        "'xls' support not available, please install the xlrd package.",
-        ImportWarning
-    )
-    XLS_IMPORT = False
-
-
-try:
-    import openpyxl
-    XLSX_IMPORT = True
-except ImportError:
-    warnings.warn(
-        "'xlsx' support not available, please install the openpyxl package.",
-        ImportWarning
-    )
-    XLSX_IMPORT = False
 
 
 class Format:
@@ -170,14 +148,11 @@ class XLS(TablibFormat):
     TABLIB_MODULE = 'tablib.formats._xls'
     CONTENT_TYPE = 'application/vnd.ms-excel'
 
-    def can_import(self):
-        return XLS_IMPORT
-
     def create_dataset(self, in_stream):
         """
         Create dataset from first sheet.
         """
-        assert XLS_IMPORT
+        import xlrd
         xls_book = xlrd.open_workbook(file_contents=in_stream)
         dataset = tablib.Dataset()
         sheet = xls_book.sheets()[0]
@@ -192,15 +167,12 @@ class XLSX(TablibFormat):
     TABLIB_MODULE = 'tablib.formats._xlsx'
     CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 
-    def can_import(self):
-        return XLSX_IMPORT
-
     def create_dataset(self, in_stream):
         """
         Create dataset from first sheet.
         """
-        assert XLSX_IMPORT
         from io import BytesIO
+        import openpyxl
         xlsx_book = openpyxl.load_workbook(BytesIO(in_stream), read_only=True)
 
         dataset = tablib.Dataset()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 Django>=2.0
-tablib[all]>=0.14
+tablib[html,ods,xls,xlsx,yaml]>=0.14
 diff-match-patch
 openpyxl>=2.4,<2.5

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ CLASSIFIERS = [
 install_requires = [
     'diff-match-patch',
     'Django>=2.0',
-    'tablib[all]>=0.14.0',
+    'tablib[html,ods,xls,xlsx,yaml]>=0.14.0',
 ]
 
 

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -12,6 +12,8 @@ from django.test.testcases import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
 
+from import_export.formats.base_formats import DEFAULT_FORMATS
+
 
 class ImportExportAdminIntegrationTest(TestCase):
 
@@ -126,9 +128,11 @@ class ImportExportAdminIntegrationTest(TestCase):
         response = self.client.get('/admin/core/book/export/')
         self.assertEqual(response.status_code, 200)
 
-        data = {
-            'file_format': '2',
-            }
+        for i, f in enumerate(DEFAULT_FORMATS):
+            if f().get_title() == 'xlsx':
+                xlsx_index = i
+                break
+        data = {'file_format': str(xlsx_index)}
         response = self.client.post('/admin/core/book/export/', data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.has_header("Content-Disposition"))

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -1,9 +1,25 @@
 import os
+from tablib.core import UnsupportedFormat
+from unittest import mock
 
 from django.test import TestCase
 from django.utils.encoding import force_str
 
 from import_export.formats import base_formats
+
+
+class FormatTest(TestCase):
+
+    @mock.patch('import_export.formats.base_formats.HTML.get_format', side_effect=ImportError)
+    def test_format_non_available1(self, mocked):
+        self.assertFalse(base_formats.HTML.is_available())
+
+    @mock.patch('import_export.formats.base_formats.HTML.get_format', side_effect=UnsupportedFormat)
+    def test_format_non_available2(self, mocked):
+        self.assertFalse(base_formats.HTML.is_available())
+
+    def test_format_available(self):
+        self.assertTrue(base_formats.CSV.is_available())
 
 
 class XLSTest(TestCase):


### PR DESCRIPTION
This allows to install django-import-export with a subset of all tablib
available formats.