### PR TITLE
Exapnd valid values for BooleanWidget

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,8 +5,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Deal with importing a BooleanField that actually has `True`, `False`, and
+  `None` values. (#1071)
 
 2.0.1 (2020-01-15)
 ------------------

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -100,12 +100,43 @@ class CharWidget(Widget):
 class BooleanWidget(Widget):
     """
     Widget for converting boolean fields.
+
+    The widget assumes that ``True``, ``False``, and ``None`` are all valid
+    values, as to match Django's `BooleanField
+    <https://docs.djangoproject.com/en/dev/ref/models/fields/#booleanfield>`_.
+    That said, whether the database/Django will actually accept NULL values
+    will depend on if you have set ``null=True`` on that Django field.
+
+    While the BooleanWidget is set up to accept as input common variations of
+    "True" and "False" (and "None"), you may need to munge less common values
+    to ``True``/``False``/``None``. Probably the easiest way to do this is to
+    override the :func:`~import_export.resources.Resource.before_import_row`
+    function of your Resource class. A short example::
+
+        from import_export import fields, resources, widgets
+
+        class BooleanExample(resources.ModelResource):
+            warn = fields.Field(widget=widget.BooleanWidget)
+
+            def before_row_import(self, row, **kwargs):
+                if "warn" in row.keys():
+                    # munge "warn" to "True"
+                    if row["warn"] in ["warn", "WARN"]:
+                        row["warn"] = True
+
+                return super().before_import_row(row, **kwargs)
     """
     TRUE_VALUES = ["1", 1, True, "true", "TRUE", "True"]
-    FALSE_VALUES = ["0", False, "false", "FALSE", "False"]
+    FALSE_VALUES = ["0", 0, False, "false", "FALSE", "False"]
     NULL_VALUES = ["", None, "null", "NULL", "none", "NONE", "None"]
 
     def render(self, value, obj=None):
+        """
+        On export, ``True`` is represented as ``1``, ``False`` as ``0``, and
+        ``None``/NULL as a empty string.
+
+        Note that these values are also used on the import confirmation view.
+        """
         if value in self.NULL_VALUES:
             return ""
         return self.TRUE_VALUES[0] if value else self.FALSE_VALUES[0]

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -101,16 +101,17 @@ class BooleanWidget(Widget):
     """
     Widget for converting boolean fields.
     """
-    TRUE_VALUES = ["1", 1]
-    FALSE_VALUE = "0"
+    TRUE_VALUES = ["1", 1, True, "true", "TRUE", "True"]
+    FALSE_VALUES = ["0", False, "false", "FALSE", "False"]
+    NULL_VALUES = ["", None, "null", "NULL", "none", "NONE", "None"]
 
     def render(self, value, obj=None):
-        if value is None:
+        if value in self.NULL_VALUES:
             return ""
-        return self.TRUE_VALUES[0] if value else self.FALSE_VALUE
+        return self.TRUE_VALUES[0] if value else self.FALSE_VALUES[0]
 
     def clean(self, value, row=None, *args, **kwargs):
-        if value == "":
+        if value in self.NULL_VALUES:
             return None
         return True if value in self.TRUE_VALUES else False
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -19,9 +19,26 @@ class BooleanWidgetTest(TestCase):
     def test_clean(self):
         self.assertTrue(self.widget.clean("1"))
         self.assertTrue(self.widget.clean(1))
+        self.assertTrue(self.widget.clean("TRUE"))
+        self.assertTrue(self.widget.clean("True"))
+        self.assertTrue(self.widget.clean("true"))
+
+        self.assertFalse(self.widget.clean("0"))
+        self.assertFalse(self.widget.clean(0))
+        self.assertFalse(self.widget.clean("FALSE"))
+        self.assertFalse(self.widget.clean("False"))
+        self.assertFalse(self.widget.clean("false"))
+
         self.assertEqual(self.widget.clean(""), None)
+        self.assertEqual(self.widget.clean("NONE"), None)
+        self.assertEqual(self.widget.clean("None"), None)
+        self.assertEqual(self.widget.clean("none"), None)
+        self.assertEqual(self.widget.clean("NULL"), None)
+        self.assertEqual(self.widget.clean("null"), None)
 
     def test_render(self):
+        self.assertEqual(self.widget.render(True), "1")
+        self.assertEqual(self.widget.render(False), "0")
         self.assertEqual(self.widget.render(None), "")
 
 


### PR DESCRIPTION
Deals better with NULL/None values, which are now (Django 2.2) permitted in the regular fields.BooleanField (fields.NullBooleanField has been deprecated). Importing a field with TRUE/FALSE/NULL was otherwise failing (via turning all the NULL's into FALSE's).

**Problem**

The Boolean widget (which is used to diff an re-import) wasn't dealing with Null/None/Empty values, and instead casting them as "0" (i.e. `False`)

**Solution**

Explicitly add `""` (an empty string) and `None` as "None values".

**Acceptance Criteria**

*Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes?*

No additional tests. No screenshot. I've added it to the Changelog (under v2.0.2).