### PR TITLE
Have `before_import_row` explicitly return the row

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -465,7 +465,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         Override to add additional logic. Does nothing by default.
         """
-        pass
+        return row
 
     def after_import_row(self, row, row_result, **kwargs):
         """
@@ -496,7 +496,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         row_result = self.get_row_result_class()()
         try:
-            self.before_import_row(row, **kwargs)
+            row = self.before_import_row(row, **kwargs)
             instance, new = self.get_or_init_instance(instance_loader, row)
             self.after_import_instance(instance, new, **kwargs)
             if new:


### PR DESCRIPTION
**Problem**

I think `before_import_row()` is meant to be overriden, to adjust the row before it is fed to the importer. Near as I can tell, this seems to be the best way to "rehydrate" a row.

However, the current codebase doesn't seem to actually persist your changes back to be fed into the main loop.

**Solution**

Add an explicit return from `before_import_row()`.

**Sample Usage**

This is pulled from my current project, to give an idea  of what I am trying to accomplish. If there is a better way, please let me know.

```python
from import_export import resources

class SignupResource(resources.ModelResource):
    class Meta:
        model = Signup

    def before_import_row(self, row, **kwargs):
        """Effectively `rehydrate` called on the whole row at once."""
        # lowercase keys
        row2 = OrderedDict()
        for key in row.keys():
            if key is not None:
                new_key = key.lower().replace(" ", "_")
                row2[new_key] = row[key]
        row = row2

        # adjust for headings
        if "no." in row.keys() and "number" not in row.keys():
            row["number"] = row.pop("no.")
        if "salesperson_name" in row.keys() and "affiliate" not in row.keys():
            row["affiliate"] = row.pop("salesperson_name")

        # conversion for datetimes to dates was causing the rows to mark as
        # "changed"
        for k in ["date", "start_date", "end_date"]:
            if k in row.keys() and isinstance(row[k], datetime):
                row[k] = row[k].date()

        # typecast to boolean
        if "warn" in row.keys() and row["warn"] in ["warn", "WARN"]:
            row["warn"] = True

        # explicit typecast to string
        if "account" in row.keys():
            if isinstance(row["account"], float):
                row["account"] = int(row["account"])
            if row["account"] is not None:
                row["account"] = str(row["account"])

        # clean memberships
        if "membership" in row.keys():
            row["membership"] = MembershipProviders.clean_membership(row["membership"])

        # (manually) update modified time
        row["modified"] = datetime.now()

        return super().before_import_row(row, **kwargs)
```

**Acceptance Criteria**

*Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes?*

Not yet, but if there is positive  support for this change, I'm happy to work on both a simple test and improved documentation.

**Note**

I don't know how well used this function currently is, but it may break existing workflows if (somehow) `before_import_row()` works without having an explicit return. If we're worried about this, on a return value of `None` we use `row` (effectively, the old behavior) rather than the function's return value. Otherwise, this may be a "breaking change".

**Note 2**

There are a series of similar functions listed that maybe should also be changed to provide explicit return values....