### PR TITLE
[Docs] Formatting and example improvements

### DIFF
--- a/docs/api_admin.rst
+++ b/docs/api_admin.rst
@@ -2,7 +2,8 @@
 Admin
 =====
 
-For instructions on how to use the models and mixins in this module, please refer to :ref:`admin-integration`.
+For instructions on how to use the models and mixins in this module, please
+refer to :ref:`admin-integration`.
 
 .. automodule:: import_export.admin
    :members:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -89,7 +89,8 @@ Or the ``exclude`` option to blacklist fields::
             model = Book
             exclude = ('imported', )
 
-An explicit order for exporting fields can be set using the ``export_order`` option::
+An explicit order for exporting fields can be set using the ``export_order``
+option::
 
     class BookResource(resources.ModelResource):
 
@@ -98,7 +99,8 @@ An explicit order for exporting fields can be set using the ``export_order`` opt
             fields = ('id', 'name', 'author', 'price',)
             export_order = ('id', 'price', 'author', 'name')
 
-The default field for object identification is ``id``, you can optionally set which fields are used as the ``id`` when importing::
+The default field for object identification is ``id``, you can optionally set
+which fields are used as the ``id`` when importing::
 
     class BookResource(resources.ModelResource):
 
@@ -107,8 +109,8 @@ The default field for object identification is ``id``, you can optionally set wh
             import_id_fields = ('isbn',)
             fields = ('isbn', 'name', 'author', 'price',)
 
-When defining :class:`~import_export.resources.ModelResource` fields it is possible to follow
-model relationships::
+When defining :class:`~import_export.resources.ModelResource` fields it is
+possible to follow model relationships::
 
     class BookResource(resources.ModelResource):
 
@@ -121,10 +123,11 @@ model relationships::
     Following relationship fields sets ``field`` as readonly, meaning
     this field will be skipped when importing data.
 
-By default all records will be imported, even if no changes are detected.
-This can be changed setting the ``skip_unchanged`` option. Also, the ``report_skipped`` option
-controls whether skipped records appear in the import ``Result`` object, and if using the admin
-whether skipped records will show in the import preview page::
+By default all records will be imported, even if no changes are detected. This
+can be changed setting the ``skip_unchanged`` option. Also, the
+``report_skipped`` option controls whether skipped records appear in the import
+``Result`` object, and if using the admin whether skipped records will show in
+the import preview page::
 
     class BookResource(resources.ModelResource):
 
@@ -238,7 +241,9 @@ to create a default :class:`~import_export.resources.ModelResource`.
 The ModelResource class created this way is equal to the one shown in the
 example in section :ref:`base-modelresource`.
 
-In fifth line a :class:`~tablib.Dataset` with columns ``id`` and ``name``, and one book entry, are created. A field for a primary key field (in this case, ``id``) always needs to be present.
+In fifth line a :class:`~tablib.Dataset` with columns ``id`` and ``name``, and
+one book entry, are created. A field for a primary key field (in this case,
+``id``) always needs to be present.
 
 In the rest of the code we first pretend to import data using
 :meth:`~import_export.resources.Resource.import_data` and ``dry_run`` set,
@@ -274,7 +279,8 @@ that have their column ``delete`` set to ``1``::
 Signals
 =======
 
-To hook in the import export workflow, you can connect to ``post_import``, ``post_export`` signals::
+To hook in the import export workflow, you can connect to ``post_import``,
+``post_export`` signals::
 
     from django.dispatch import receiver
     from import_export.signals import post_import, post_export
@@ -348,7 +354,9 @@ objects selected on the change list page::
 
    A screenshot of the change view with Import and Export as an admin action.
 
-Note that to use the :class:`~import_export.admin.ExportMixin` or :class:`~import_export.admin.ExportActionMixin`, you must declare this mixin **before** ``admin.ModelAdmin``::
+Note that to use the :class:`~import_export.admin.ExportMixin` or
+:class:`~import_export.admin.ExportActionMixin`, you must declare this mixin
+**before** ``admin.ModelAdmin``::
 
     # app/admin.py
     from django.contrib import admin
@@ -357,24 +365,36 @@ Note that to use the :class:`~import_export.admin.ExportMixin` or :class:`~impor
     class BookAdmin(ExportActionMixin, admin.ModelAdmin):
         pass
 
-Note that :class:`~import_export.admin.ExportActionMixin` is declared first in the example above!
+Note that :class:`~import_export.admin.ExportActionMixin` is declared first in
+the example above!
 
 
 Importing
 ---------
 
-It is also possible to enable data import via standard Django admin interface. To do this subclass :class:`~import_export.admin.ImportExportModelAdmin` or use one of the available mixins, i.e.
-:class:`~import_export.admin.ImportMixin`, or :class:`~import_export.admin.ImportExportMixin`. Customizations are, of course, possible.
+It is also possible to enable data import via standard Django admin interface.
+To do this subclass :class:`~import_export.admin.ImportExportModelAdmin` or use
+one of the available mixins, i.e. :class:`~import_export.admin.ImportMixin`, or
+:class:`~import_export.admin.ImportExportMixin`. Customizations are, of course,
+possible.
 
 
 Customize admin import forms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to modify default import forms used in the model admin. For example, to add an additional field in the import form, subclass and extend the :class:`~import_export.forms.ImportForm` (note that you may want to also consider :class:`~import_export.forms.ConfirmImportForm` as importing is a two-step process).
+It is possible to modify default import forms used in the model admin. For
+example, to add an additional field in the import form, subclass and extend the
+:class:`~import_export.forms.ImportForm` (note that you may want to also
+consider :class:`~import_export.forms.ConfirmImportForm` as importing is a
+two-step process).
 
-To use the customized form(s), overload :class:`~import_export.admin.ImportMixin` respective methods, i.e. :meth:`~import_export.admin.ImportMixin.get_import_form`, and also :meth:`~import_export.admin.ImportMixin.get_confirm_import_form` if need be.
+To use the customized form(s), overload
+:class:`~import_export.admin.ImportMixin` respective methods, i.e.
+:meth:`~import_export.admin.ImportMixin.get_import_form`, and also
+:meth:`~import_export.admin.ImportMixin.get_confirm_import_form` if need be.
 
-For example, imagine you want to import books for a specific author. You can extend the import forms to include ``author`` field to select the author from.
+For example, imagine you want to import books for a specific author. You can
+extend the import forms to include ``author`` field to select the author from.
 
 Customize forms::
 
@@ -412,9 +432,14 @@ Customize ``ModelAdmin``::
 
     admin.site.register(Book, CustomBookAdmin)
 
-To further customize admin imports, consider modifying the following :class:`~import_export.admin.ImportMixin` methods: :meth:`~import_export.admin.ImportMixin.get_form_kwargs`, :meth:`~import_export.admin.ImportMixin.get_import_resource_kwargs`, :meth:`~import_export.admin.ImportMixin.get_import_data_kwargs`.
+To further customize admin imports, consider modifying the following
+:class:`~import_export.admin.ImportMixin` methods:
+:meth:`~import_export.admin.ImportMixin.get_form_kwargs`,
+:meth:`~import_export.admin.ImportMixin.get_import_resource_kwargs`,
+:meth:`~import_export.admin.ImportMixin.get_import_data_kwargs`.
 
-Using the above methods it is possible to customize import form initialization as well as importing customizations.
+Using the above methods it is possible to customize import form initialization
+as well as importing customizations.
 
 
 .. seealso::

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -172,12 +172,12 @@ Other fields that don't exist in the target model may be added::
         Available field types and options.
 
 
-Advanced data manipulation
-==========================
+Advanced data manipulation on export
+====================================
 
 Not all data can be easily extracted from an object/model attribute.
 In order to turn complicated data model into a (generally simpler) processed
-data structure, ``dehydrate_<fieldname>`` method should be defined::
+data structure on export, ``dehydrate_<fieldname>`` method should be defined::
 
     from import_export.fields import Field
 
@@ -189,6 +189,14 @@ data structure, ``dehydrate_<fieldname>`` method should be defined::
 
         def dehydrate_full_title(self, book):
             return '%s by %s' % (book.name, book.author.name)
+
+In this case, the export looks like this:
+
+    >>> from app.admin import BookResource
+    >>> dataset = BookResource().export()
+    >>> print(dataset.csv)
+    full_title,id,name,author,author_email,imported,published,price,categories
+    Some book by 1,2,Some book,1,,0,2012-12-05,8.85,1
 
 
 Customize widgets

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -206,7 +206,7 @@ A :class:`~import_export.resources.ModelResource` creates a field with a
 default widget for a given field type. If the widget should be initialized
 with different arguments, set the ``widgets`` dict.
 
-In this example widget, the ``published`` field is overriden to use a
+In this example widget, the ``published`` field is overridden to use a
 different date format. This format will be used both for importing
 and exporting resource.
 

--- a/docs/import_workflow.rst
+++ b/docs/import_workflow.rst
@@ -2,9 +2,10 @@
 Import data workflow
 ====================
 
-This document describes the import data workflow in detail, with hooks that enable
-customization of the import process. The central aspect of the import process is a resource's
-:meth:`~import_export.resources.Resource.import_data` method which is explained below.
+This document describes the import data workflow in detail, with hooks that
+enable customization of the import process. The central aspect of the import
+process is a resource's :meth:`~import_export.resources.Resource.import_data`
+method which is explained below.
 
 .. function:: import_data(dataset, dry_run=False, raise_errors=False)
 
@@ -28,19 +29,24 @@ This is what happens when the method is invoked:
 #. First, a new :class:`~import_export.results.Result` instance, which holds
    errors and other information gathered during the import, is initialized.
 
-   Then, an :class:`~import_export.instance_loaders.InstanceLoader` responsible for loading existing instances
-   is intitalized. A different :class:`~import_export.instance_loaders.BaseInstanceLoader` can be specified via
-   :class:`~import_export.resources.ResourceOptions`'s ``instance_loader_class`` attribute.
-   A :class:`~import_export.instance_loaders.CachedInstanceLoader` can be used to
-   reduce number of database queries.
-   See the `source <https://github.com/django-import-export/django-import-export/blob/master/import_export/instance_loaders.py>`_ for available implementations.
+   Then, an :class:`~import_export.instance_loaders.InstanceLoader` responsible
+   for loading existing instances is intitalized. A different
+   :class:`~import_export.instance_loaders.BaseInstanceLoader` can be specified
+   via :class:`~import_export.resources.ResourceOptions`'s
+   ``instance_loader_class`` attribute. A
+   :class:`~import_export.instance_loaders.CachedInstanceLoader` can be used to
+   reduce number of database queries. See the `source
+   <https://github.com/django-import-export/django-import-export/blob/master/import_export/instance_loaders.py>`_
+   for available implementations.
 
 #. The :meth:`~import_export.resources.Resource.before_import` hook is called.
    By implementing this method in your resource, you can customize the import process.
 
-#. Each row of the to-be-imported dataset is processed according to the following steps:
+#. Each row of the to-be-imported dataset is processed according to the
+   following steps:
 
-   #. The :meth:`~import_export.resources.Resource.before_import_row` hook is called to allow for row data to be modified before it is imported
+   #. The :meth:`~import_export.resources.Resource.before_import_row` hook is
+   called to allow for row data to be modified before it is imported
 
    #. :meth:`~import_export.resources.Resource.get_or_init_instance` is called
       with current :class:`~import_export.instance_loaders.BaseInstanceLoader`
@@ -55,8 +61,10 @@ This is what happens when the method is invoked:
       :meth:`~import_export.resources.Resource.init_instance` to customized
       how the new object is created (i.e. set default values).
 
-   #. :meth:`~import_export.resources.Resource.for_delete` is called to determine if the passed ``instance``
-      should be deleted. In this case, the import process for the current row is stopped at this point.
+   #. :meth:`~import_export.resources.Resource.for_delete` is called to
+      determine if the passed ``instance``
+      should be deleted. In this case, the import process for the current row
+      is stopped at this point.
 
    #. If the instance was not deleted in the previous step,
       :meth:`~import_export.resources.Resource.import_obj` is called with the
@@ -85,8 +93,8 @@ This is what happens when the method is invoked:
       :meth:`~import_export.resources.Resource.save_instance` is called and
       actually saves the instance when ``dry_run`` is not set.
 
-      There are two hook methods (that by default do nothing) giving you the option to customize the
-      import process:
+      There are two hook methods (that by default do nothing) giving you the
+      option to customize the import process:
 
         * :meth:`~import_export.resources.Resource.before_save_instance`
         * :meth:`~import_export.resources.Resource.after_save_instance`
@@ -108,7 +116,8 @@ This is what happens when the method is invoked:
 
       If either the row was not skipped or the
       :class:`~import_export.resources.Resource` is configured to report
-      skipped rows, the :class:`~import_export.results.RowResult` is appended to the :class:`~import_export.results.Result`
+      skipped rows, the :class:`~import_export.results.RowResult` is appended
+      to the :class:`~import_export.results.Result`
 
    #. The :meth:`~import_export.resources.Resource.after_import_row` hook is called
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@
 Django import / export
 ======================
 
-django-import-export is a Django application and library for importing
-and exporting data with included admin integration.
+django-import-export is a Django application and library for importing and
+exporting data with included admin integration.
 
 **Features:**
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,7 +28,8 @@ let Django collect its static files.
 
     $ python manage.py collectstatic
 
-All prerequisites are set up! See :doc:`getting_started` to learn how to use django-import-export in your project.
+All prerequisites are set up! See :doc:`getting_started` to learn how to use
+django-import-export in your project.
 
 
 
@@ -42,38 +43,39 @@ You can use the following directives in your settings file:
     transactions. Default is ``False``.
 
 ``IMPORT_EXPORT_SKIP_ADMIN_LOG``
-    Global setting controls if creating log entries for
-    the admin changelist should be skipped when importing resource.
-    The `skip_admin_log` attribute of `ImportMixin` is checked first,
-    which defaults to ``None``. If not found, this global option is used.
-    This will speed up importing large datasets, but will lose
-    changing logs in the admin changelist view.  Default is ``False``.
+    Global setting controls if creating log entries for the admin changelist
+    should be skipped when importing resource. The `skip_admin_log` attribute
+    of `ImportMixin` is checked first, which defaults to ``None``. If not
+    found, this global option is used. This will speed up importing large
+    datasets, but will lose changing logs in the admin changelist view.
+    Default is ``False``.
 
 ``IMPORT_EXPORT_TMP_STORAGE_CLASS``
-    Global setting for the class to use to handle temporary storage
-    of the uploaded file when importing from the admin using an
-    `ImportMixin`.  The `tmp_storage_class` attribute of `ImportMixin`
-    is checked first, which defaults to ``None``. If not found, this
-    global option is used. Default is ``TempFolderStorage``.
+    Global setting for the class to use to handle temporary storage of the
+    uploaded file when importing from the admin using an `ImportMixin`.  The
+    `tmp_storage_class` attribute of `ImportMixin` is checked first, which
+    defaults to ``None``. If not found, this global option is used. Default is
+    ``TempFolderStorage``.
 
 ``IMPORT_EXPORT_IMPORT_PERMISSION_CODE``
     Global setting for defining user permission that is required for
-    users/groups to execute import action. Django builtin permissions
-    are ``change``, ``add``, and ``delete``. It is possible to add
-    your own permission code. Default is ``None`` which means
-    everybody can execute import action.
+    users/groups to execute import action. Django builtin permissions are
+    ``change``, ``add``, and ``delete``. It is possible to add your own
+    permission code. Default is ``None`` which means everybody can execute
+    import action.
 
 ``IMPORT_EXPORT_EXPORT_PERMISSION_CODE``
     Global setting for defining user permission that is required for
-    users/groups to execute export action. Django builtin permissions
-    are ``change``, ``add``, and ``delete``. It is possible to add
-    your own permission code. Default is ``None`` which means
-    everybody can execute export action.
+    users/groups to execute export action. Django builtin permissions are
+    ``change``, ``add``, and ``delete``. It is possible to add your own
+    permission code. Default is ``None`` which means everybody can execute
+    export action.
 
 Example app
 ===========
 
-There's an example application that showcases what django-import-export can do. You can run it via::
+There's an example application that showcases what django-import-export can do.
+You can run it via::
 
     cd tests
     ./manage.py runserver


### PR DESCRIPTION
Reflow the documentation to an 80 character line limit.

Add a few notes on how `dehydrate_<fieldname>()` works.