### PR TITLE
Import data workflow docs - improve references to init_instance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -111,3 +111,4 @@ The following is a list of much appreciated contributors:
 * aniav (Ania Warzecha)
 * ababic (Andy Babic)
 * BramManuel (Bram Janssen)
+* kjpc-tech (Kyle)

--- a/docs/import_workflow.rst
+++ b/docs/import_workflow.rst
@@ -58,7 +58,7 @@ This is what happens when the method is invoked:
       initialize an object.
 
       As always, you can override the implementation of
-      :meth:`~import_export.resources.Resource.init_instance` to customized
+      :meth:`~import_export.resources.Resource.init_instance` to customize
       how the new object is created (i.e. set default values).
 
    #. :meth:`~import_export.resources.Resource.for_delete` is called to

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -254,6 +254,10 @@ class Resource(metaclass=DeclarativeMetaclass):
             field, self.__class__))
 
     def init_instance(self, row=None):
+        """
+        Initializes an object. Implemented in
+        :meth:`import_export.resources.ModelResource.init_instance`.
+        """
         raise NotImplementedError()
 
     def get_instance(self, instance_loader, row):


### PR DESCRIPTION
**Problem**

On the ['Import data workflow' section in the docs](https://django-import-export.readthedocs.io/en/latest/import_workflow.html), there are references to `init_instance` that are not clickable.

**Solution**

The PR adds a doc string to `Resource.init_instance` to make the references clickable.