### PR TITLE
Make import diff view only show headers for user visible fields

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -451,7 +451,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         Diff representation headers.
         """
-        return self.get_export_headers()
+        return self.get_user_visible_headers()
 
     def before_import(self, dataset, using_transactions, dry_run, **kwargs):
         """
@@ -693,6 +693,11 @@ class Resource(metaclass=DeclarativeMetaclass):
     def get_export_headers(self):
         headers = [
             force_str(field.column_name) for field in self.get_export_fields()]
+        return headers
+
+    def get_user_visible_headers(self):
+        headers = [
+            force_str(field.column_name) for field in self.get_user_visible_fields()]
         return headers
 
     def get_user_visible_fields(self):


### PR DESCRIPTION
**Problem**

The diff view was showing only data columns that were defined by `get_user_visible_fields` but the column headers were not constrained by `get_user_visible_fields`.

**Solution**

Added get_user_visible_headers which uses `get_user_visible_fields`, and changed `get_diff_headers` to use it.

**Acceptance Criteria**

I have not written tests.  Happy to if other maintainers deem necessary!