### PR TITLE
Fix DurationWidget handling of zero value

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -236,7 +236,7 @@ class DurationWidget(Widget):
     """
 
     def clean(self, value, row=None, *args, **kwargs):
-        if not value:
+        if value is None:
             return None
 
         try:
@@ -245,7 +245,7 @@ class DurationWidget(Widget):
             raise ValueError("Enter a valid duration.")
 
     def render(self, value, obj=None):
-        if not value:
+        if value is None:
             return ""
         return str(value)
 


### PR DESCRIPTION
**Problem**

https://github.com/django-import-export/django-import-export/issues/1112

> When exporting an object with a DurationField that has a value equivalent to timedelta(0), the exported value is blank (""), because of the implementation of the DurationWidget
> 
>    ```pytthon
> def render(self, value, obj=None):
>         if not value:
>             return ""
>         return str(value)
> ``` 
When `value == datetime.timedelta(0)`, `""` is returned.
This causes issues when re-importing exported data if the DurationField is not nullable.

**Solution**

Fix by checking if `value is None` instead of relying on implicit conversion to boolean.