### PR TITLE
Removed 'requirements' section from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,18 +41,6 @@ Features:
 * Free software: BSD license
 * PyPI: https://pypi.org/project/django-import-export/
 
-Requirements
-------------
-
-* Python 3.5+
-* Django 2.0+
-* tablib 0.14+
-
-django-import-export requires Python 3.5 and Django 2.0 or newer. See the 1.x
-branch for older Python and Django versions where fixes for security issues and
-critical errors continue to be released for all officially supported Django
-versions.
-
 Example app
 -----------
 


### PR DESCRIPTION
**Problem**

Project requirements were defined in README.rst.  This is unnecessary because the requirements are enforced in [`setup.py`](https://github.com/django-import-export/django-import-export/blob/master/setup.py#L25).  See https://github.com/django-import-export/django-import-export/pull/1079

**Solution**

Removed this section entirely.

**Acceptance Criteria**

Simple text change so review should be acceptable.