### PR TITLE
Fix for tox failing when run locally

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,19 @@
 [tox]
 envlist =
-    py{35,36,37}-django{20,21,22,30,master}-tablib{dev,stable}
+       {py35,py36,py37}-django20-tablib{dev,stable},
+       {py35,py36,py37}-django21-tablib{dev,stable},
+       {py35,py36,py37}-django22-tablib{dev,stable},
+       {py36,py37,py38}-django30-tablib{dev,stable},
+       {py36,py37,py38}-djangomaster-tablib{dev,stable},
 
 [testenv]
-commands=python {toxinidir}/tests/manage.py test core
-deps=
-    openpyxl
+commands = python {toxinidir}/tests/manage.py test core
+deps =
     tablibdev: -egit+https://github.com/jazzband/tablib.git#egg=tablib
     tablibstable: tablib
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
-    django30: Django>=3.0
+    django30: Django>=3.0,<3.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
+    -rrequirements/test.txt


### PR DESCRIPTION
**Problem**

If you run tox locally with `tox -r`, then it will fail with:
```
NameError: name 'data_field' is not defined
```
This is because the test migration [` 0004_bookwithchapters.py`](https://github.com/django-import-export/django-import-export/blob/master/tests/core/migrations/0004_bookwithchapters.py) references `JSONField` and `ArrayField` which is postgres specific fields.  Hence `psycopg2` is a dependency.

Additionally, the `envlist` in tox.ini was too permissive, and meant that Django 3.0 was being tested against python 3.5, which is only supported by Django 2.*.  

**Solution**

- include a reference to `requirements/test.txt` in tox.ini
- Reformat the `envlist` to correctly reference python / django versions

**Acceptance Criteria**

- I have tested this successfully locally.
- Travis build should run successfully.