### PR TITLE
Fix DurationWidget handling of zero value

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -245,7 +245,7 @@ class DurationWidget(Widget):
             raise ValueError("Enter a valid duration.")
 
     def render(self, value, obj=None):
-        if not value:
+        if value is None:
             return ""
         return str(value)
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -111,8 +111,17 @@ class DurationWidgetTest(TestCase):
     def test_render_none(self):
         self.assertEqual(self.widget.render(None), "")
 
+    def test_render_zero(self):
+        self.assertEqual(self.widget.render(timedelta(0)), "0:00:00")
+
     def test_clean(self):
         self.assertEqual(self.widget.clean("1:57:00"), self.duration)
+
+    def test_clean_none(self):
+        self.assertEqual(self.widget.clean(""), None)
+
+    def test_clean_zero(self):
+        self.assertEqual(self.widget.clean("0:00:00"), timedelta(0))
 
 
 class FloatWidgetTest(TestCase):


### PR DESCRIPTION
**Problem**

https://github.com/django-import-export/django-import-export/issues/1112

> When exporting an object with a `DurationField` that has a value equivalent to `timedelta(0)`, the exported value is blank (`""`), because of the implementation of the `DurationWidget`
> 
>    ```python
> def render(self, value, obj=None):
>         if not value:
>             return ""
>         return str(value)
> ``` 
When `value == datetime.timedelta(0)`, `""` is returned.
This causes issues when re-importing exported data (and even prevents it if the `DurationField` in model class is not nullable).

**Solution**

Fixed by checking if `value is None` instead of relying on implicit conversion to boolean.

**Acceptance Criteria**

Added `test_render_zero`, `test_clean_zero` and `test_clean_none` for `DurationWidget`