### PR TITLE
The function was missing ":"

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -420,7 +420,7 @@ Customize forms::
 
 Customize ``ModelAdmin``::
 
-    class CustomBookAdmin(ImportMixin, admin.ModelAdmin)
+    class CustomBookAdmin(ImportMixin, admin.ModelAdmin):
         resource_class = BookResource
 
         def get_import_form(self):


### PR DESCRIPTION
before >> `def get_form_kwargs(self, form, *args, **kwargs)`
after >>> `def get_form_kwargs(self, form, *args, **kwargs):`

**Problem**

syntax error

**Solution**

just added ":" at the end if of  `get_form_kwargs()` function
