### PR TITLE
Update demo app urls

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,17 +1,16 @@
 from core import views
 
-from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import path
+from django.views.generic import RedirectView
 
 admin.autodiscover()
 
-
-
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^export/category/', views.CategoryExportView.as_view(),
-        name='export-category'),
+    path('', RedirectView.as_view(url='/admin/'), name="admin-site"),
+    path('admin/', admin.site.urls),
+    path('export/category/', views.CategoryExportView.as_view(), name='export-category'),
 ]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
**Problem**

1. When running the test app, you get a 404 if you browse to http://localhost:8000/ - which is not user friendly.

2.  The URLs used the [`url()`](https://docs.djangoproject.com/en/2.2/ref/urls/#url) function which is likely to be deprecated in a future Django release.

**Solution**

1. I added a [`RedirectView`](https://docs.djangoproject.com/en/3.0/ref/class-based-views/base/#redirectview) to redirect from the root path to 'admin/'

2. Switched to use [`path()`](https://docs.djangoproject.com/en/2.2/ref/urls/#path) syntax

**Acceptance Criteria**

Ran existing test suite and tested manually.