### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+.PHONY: clean-pyc clean-build release docs help
+.PHONY: lint test coverage test-codecov
+.DEFAULT_GOAL := help
+RUN_TEST_COMMAND=`PYTHONPATH=".:tests:$PYTHONPATH" django-admin.py test core --settings=settings`
+help:
+	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | sort | awk -F ':.*?## ' 'NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
+
+clean: clean-build clean-pyc clean-tests
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr *.egg-info
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+
+clean-tests: ## remove pytest artifacts
+	rm -fr .pytest_cache/
+	rm -fr htmlcov/
+	rm -fr django-import-export/
+
+lint: ## check style with isort
+	isort --check-only
+
+test: ## run tests quickly with the default Python
+	$(RUN_TEST_COMMAND)
+
+messages: ## generate locale file translations
+	cd import_export && django-admin.py makemessages && cd ..
+
+coverage: ## generates codecov report
+	coverage run --omit='setup.py,tests/*' --source=. tests/manage.py test core --settings=
+	coverage report
+
+sdist: clean ## package
+	python setup.py sdist
+	ls -l dist
+
+release: clean install-deploy-requirements sdist ## package and upload a release
+	fullrelease
+
+install-base-requirements: ## install package requirements
+	pip install -r requirements/base.txt
+
+install-test-requirements: ## install requirements for testing
+	pip install -r requirements/test.txt
+
+install-deploy-requirements:  ## install requirements for deployment
+	pip install -r requirements/deploy.txt
+
+install-docs-requirements:  ## install requirements for docs
+	pip install -r requirements/docs.txt
+
+install-requirements: install-base-requirements install-test-requirements install-deploy-requirements install-docs-requirements
+
+build-html-doc: ## builds the project documentation in HTML format
+	DJANGO_SETTINGS_MODULE=tests.settings make html -C docs
+	open docs/_build/html/index.html

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,0 +1,2 @@
+wheel
+zest.releaser

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,0 @@
--r base.txt
-sphinx
-sphinx-rtd-theme
-mysqlclient
-psycopg2
-wheel

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 isort
 psycopg2
 mysqlclient
+coveralls


### PR DESCRIPTION
**Problem**

Lots of commands, and they are quite difficult to remember.

**Solution**

Makefile


```
$ make help    
  build-html-doc            builds the project documentation in HTML format
  clean-build               remove build artifacts
  clean-pyc                 remove Python file artifacts
  clean-tests               remove pytest artifacts
  coverage                  generates codecov report
  install-base-requirements install package requirements
  install-deploy-requirements install requirements for deployment
  install-docs-requirements install requirements for docs
  install-test-requirements install requirements for testing
  lint                      check style with isort
  messages                  generate locale file translations
  release                   package and upload a release
  sdist                     package
  test                      run tests quickly with the default Python
```
