### PR TITLE
Increase default chunk size to 100

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Changed the default value for ``IMPORT_EXPORT_CHUNK_SIZE`` to 100.
 
 
 2.4.0 (2020-10-05)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,44 +43,66 @@ django-import-export in your project.
 Settings
 ========
 
-You can use the following directives in your settings file:
+You can configure the following in your settings file:
 
 ``IMPORT_EXPORT_USE_TRANSACTIONS``
-    Global setting controls if resource importing should use database
-    transactions. Default is ``False``.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Controls if resource importing should use database transactions. Defaults to
+``False``. Using transactions makes imports safer as a failure during import
+won’t import only part of the data set.
+
+Can be overridden on a ``Resource`` class by setting the
+``use_transactions`` class attribute.
 
 ``IMPORT_EXPORT_SKIP_ADMIN_LOG``
-    Global setting controls if creating log entries for the admin changelist
-    should be skipped when importing resource. The `skip_admin_log` attribute
-    of `ImportMixin` is checked first, which defaults to ``None``. If not
-    found, this global option is used. This will speed up importing large
-    datasets, but will lose changing logs in the admin changelist view.
-    Default is ``False``.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set to ``True``, skips the creation of amdin log entries when importing.
+Defaults to ``False``. This can speed up importing large data sets, at the cost
+of losing an audit trail.
+
+Can be overridden on a ``ModelAdmin`` class inheriting from ``ImportMixin`` by
+setting the ``skip_admin_log`` class attribute.
 
 ``IMPORT_EXPORT_TMP_STORAGE_CLASS``
-    Global setting for the class to use to handle temporary storage of the
-    uploaded file when importing from the admin using an `ImportMixin`.  The
-    `tmp_storage_class` attribute of `ImportMixin` is checked first, which
-    defaults to ``None``. If not found, this global option is used. Default is
-    ``TempFolderStorage``.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Controls which storage class to use for storing the temporary uploaded file
+during imports. Defaults to ``import_export.tmp_storages.TempFolderStorage``.
+
+Can be overridden on a ``ModelAdmin`` class inheriting from ``ImportMixin`` by
+setting the ``tmp_storage_class`` class attribute.
 
 ``IMPORT_EXPORT_IMPORT_PERMISSION_CODE``
-    Global setting for defining user permission that is required for
-    users/groups to execute import action. Django builtin permissions are
-    ``change``, ``add``, and ``delete``. It is possible to add your own
-    permission code. Default is ``None`` which means everybody can execute
-    import action.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, lists the permission code that is required for users to perform the
+“import” action. Defaults to ``None``, which means everybody can perform
+imports.
+
+Django’s built-in permissions have the codes ``add``, ``change``, ``delete``,
+and ``view``. You can also add your own permissions.
 
 ``IMPORT_EXPORT_EXPORT_PERMISSION_CODE``
-    Global setting for defining user permission that is required for
-    users/groups to execute export action. Django builtin permissions are
-    ``change``, ``add``, and ``delete``. It is possible to add your own
-    permission code. Default is ``None`` which means everybody can execute
-    export action.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, lists the permission code that is required for users to perform the
+“export” action. Defaults to ``None``, which means everybody can perform
+exports.
+
+Django’s built-in permissions have the codes ``add``, ``change``, ``delete``,
+and ``view``. You can also add your own permissions.
 
 ``IMPORT_EXPORT_CHUNK_SIZE``
-    Global setting to define the bulk size in which data is exported. Useful
-    if memory consumption is of the essence. Can also be set per ``Resource``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An integer that defines the size of chunks when iterating a QuerySet for data
+exports. Defaults to ``100``. You may be able to save memory usage by
+decreasing it, or speed up exports by increasing it.
+
+Can be overridden on a ``Resource`` class by setting the ``chunk_size`` class
+attribute.
 
 
 Example app

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -24,14 +24,6 @@ from .results import RowResult
 from .signals import post_export, post_import
 from .tmp_storages import TempFolderStorage
 
-SKIP_ADMIN_LOG = getattr(settings, 'IMPORT_EXPORT_SKIP_ADMIN_LOG', False)
-TMP_STORAGE_CLASS = getattr(settings, 'IMPORT_EXPORT_TMP_STORAGE_CLASS',
-                            TempFolderStorage)
-
-
-if isinstance(TMP_STORAGE_CLASS, str):
-    TMP_STORAGE_CLASS = import_string(TMP_STORAGE_CLASS)
-
 
 class ImportExportMixinBase:
     def get_model_info(self):
@@ -63,15 +55,21 @@ class ImportMixin(ImportExportMixinBase):
 
     def get_skip_admin_log(self):
         if self.skip_admin_log is None:
-            return SKIP_ADMIN_LOG
+            return getattr(settings, 'IMPORT_EXPORT_SKIP_ADMIN_LOG', False)
         else:
             return self.skip_admin_log
 
     def get_tmp_storage_class(self):
         if self.tmp_storage_class is None:
-            return TMP_STORAGE_CLASS
+            tmp_storage_class = getattr(
+                settings, 'IMPORT_EXPORT_TMP_STORAGE_CLASS', TempFolderStorage,
+            )
         else:
-            return self.tmp_storage_class
+            tmp_storage_class = self.tmp_storage_class
+
+        if isinstance(tmp_storage_class, str):
+            tmp_storage_class = import_string(tmp_storage_class)
+        return tmp_storage_class
 
     def has_import_permission(self, request):
         """

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -41,9 +41,6 @@ logger = logging.getLogger(__name__)
 # Set default logging handler to avoid "No handler found" warnings.
 logger.addHandler(logging.NullHandler())
 
-USE_TRANSACTIONS = getattr(settings, 'IMPORT_EXPORT_USE_TRANSACTIONS', True)
-CHUNK_SIZE = getattr(settings, 'IMPORT_EXPORT_CHUNK_SIZE', 1)
-
 
 def get_related_model(field):
     if hasattr(field, 'related_model'):
@@ -126,10 +123,10 @@ class ResourceOptions:
 
     chunk_size = None
     """
-    Controls the chunk_size argument of Queryset.iterator or, 
+    Controls the chunk_size argument of Queryset.iterator or,
     if prefetch_related is used, the per_page attribute of Paginator.
     """
-    
+
     skip_diff = False
     """
     Controls whether or not an instance should be diffed following import.
@@ -159,8 +156,8 @@ class ResourceOptions:
     force_init_instance = False
     """
     If True, this parameter will prevent imports from checking the database for existing instances.
-    Enabling this parameter is a performance enhancement if your import dataset is guaranteed to 
-    contain new instances. 
+    Enabling this parameter is a performance enhancement if your import dataset is guaranteed to
+    contain new instances.
     """
 
 
@@ -278,13 +275,13 @@ class Resource(metaclass=DeclarativeMetaclass):
 
     def get_use_transactions(self):
         if self._meta.use_transactions is None:
-            return USE_TRANSACTIONS
+            return getattr(settings, 'IMPORT_EXPORT_USE_TRANSACTIONS', True)
         else:
             return self._meta.use_transactions
 
     def get_chunk_size(self):
         if self._meta.chunk_size is None:
-            return CHUNK_SIZE
+            return getattr(settings, 'IMPORT_EXPORT_CHUNK_SIZE', 100)
         else:
             return self._meta.chunk_size
 

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -344,7 +344,7 @@ class ModelResourceTest(TestCase):
         qs = Book.objects.all()
         with mock.patch.object(qs, "iterator") as mocked_method:
             list(self.resource.iter_queryset(qs))
-            mocked_method.assert_called_once_with(chunk_size=1)
+            mocked_method.assert_called_once_with(chunk_size=100)
 
     def test_iter_queryset_prefetch_unordered(self):
         qsu = Book.objects.prefetch_related("categories").all()
@@ -357,9 +357,9 @@ class ModelResourceTest(TestCase):
     def test_iter_queryset_prefetch_ordered(self):
         qs = Book.objects.prefetch_related("categories").order_by('pk').all()
         with mock.patch("import_export.resources.Paginator", autospec=True) as p:
-            p.return_value = Paginator(qs, 1)
+            p.return_value = Paginator(qs, 100)
             list(self.resource.iter_queryset(qs))
-            p.assert_called_once_with(qs, 1)
+            p.assert_called_once_with(qs, 100)
 
     def test_iter_queryset_prefetch_chunk_size(self):
         class B(BookResource):


### PR DESCRIPTION
Fixes #1174. I've increased the default chunk size from 1 to 100, which should increase performance for most use cases.

Whilst doing this, I noticed that settings were being accessed at import times. This is not a recommended approach - settings are somewhat-mutable through tools like [`@override_settings`](https://docs.djangoproject.com/en/3.0/topics/testing/tools/#django.test.override_settings) so should only be read off the settings object. To this end, I've pushed all settings reads down into the functions that need them. This has had the beneficial side effect that the class-level `tmp_storage_class` attribute can also be a string to import, which might help prevent certain import loops.

I then rewrote the settings documentation. Mostly I aimed to standardize and clarify the language, and explain the class-level overrides for all of them well. I also turned them into section headings, which gives them a clearer appearance, and fixed some accidental use of single-backticks where double backticks were intended for code highlighting.
