### PR TITLE
Fix system check warning in tests

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -42,6 +42,7 @@ TEMPLATES = [
             'context_processors': (
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
             ),
         },
     },


### PR DESCRIPTION
**Problem**

Django 3.1’s new admin side bar has added a system check warning at the start of the test run:

```
Creating test database for alias 'default'...
System check identified some issues:

WARNINGS:
?: (admin.W411) 'django.template.context_processors.request' must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin navigation sidebar.

System check identified 1 issue (0 silenced).
...
```

**Solution**

This PR fixes it by following the hint.

**Acceptance Criteria**

No system check warning at the start of the test run.