### PR TITLE
Add documentation and changelog links on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ setup(
     license='BSD License',
     platforms=['OS Independent'],
     url="https://github.com/django-import-export/django-import-export",
+    project_urls={
+        "Documentation": "https://django-import-export.readthedocs.io/en/stable/",
+        "Changelog": "https://django-import-export.readthedocs.io/en/stable/changelog.html",
+    },
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=install_requires,


### PR DESCRIPTION
**Problem**

Fast access to docs and changelog.

**Solution**

These appear on the sidebar and provide neat, somewhat standard shortcuts to useful places. cf. [scout-apm](https://pypi.org/project/scout-apm/) , as defined in https://github.com/scoutapp/scout_apm_python/blob/631f2432f643d256ad5ab7ff6b8f7b95b14231f5/setup.py#L44

**Acceptance Criteria**

Ran `python setup.py check`.