### PR TITLE
Run isort with "black" profile

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -1,5 +1,6 @@
-import tablib
 from importlib import import_module
+
+import tablib
 
 
 class Format:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1,13 +1,12 @@
 import functools
 import logging
-import tablib
 import traceback
 from collections import OrderedDict
 from copy import deepcopy
 
-from diff_match_patch import diff_match_patch
-
 import django
+import tablib
+from diff_match_patch import diff_match_patch
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.management.color import no_style
@@ -20,7 +19,7 @@ from django.db.transaction import (
     atomic,
     savepoint,
     savepoint_commit,
-    savepoint_rollback
+    savepoint_rollback,
 )
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
-from tablib import Dataset
 
 from django.core.exceptions import NON_FIELD_ERRORS
+from tablib import Dataset
 
 
 class Error:

--- a/import_export/templatetags/import_export_tags.py
+++ b/import_export/templatetags/import_export_tags.py
@@ -1,5 +1,4 @@
 from diff_match_patch import diff_match_patch
-
 from django import template
 
 register = template.Library()

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,12 +6,4 @@ create-wheel = yes
 python-file-with-version = import_export/__init__.py
 
 [isort]
-known_django=django
-skip=docs,migrations
-sections=FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
-default_section=THIRDPARTY
-extra_standard_library=tablib
-known_first_party=import_export
-multi_line_output=3
-line_length=100
-indent=4
+profile = black

--- a/tests/bulk/import_book.py
+++ b/tests/bulk/import_book.py
@@ -10,13 +10,12 @@ Each run is profiled for duration and peak memory usage.
 When testing deletes, duration and memory usage has to be tested separately.
 This can be done by simply commenting out the relevant call in profile()
 """
-import tablib
 import time
 from functools import wraps
 
-from memory_profiler import memory_usage
-
 import django
+import tablib
+from memory_profiler import memory_usage
 
 from import_export import resources
 from import_export.instance_loaders import CachedInstanceLoader

--- a/tests/core/migrations/0001_initial.py
+++ b/tests/core/migrations/0001_initial.py
@@ -1,7 +1,7 @@
 import core.models
+import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
-import django.db.models.deletion
 
 
 class Migration(migrations.Migration):

--- a/tests/core/migrations/0005_addparentchild.py
+++ b/tests/core/migrations/0005_addparentchild.py
@@ -1,5 +1,5 @@
-from django.db import migrations, models
 import django.db.models.deletion
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/tests/core/migrations/0007_auto_20180628_0411.py
+++ b/tests/core/migrations/0007_auto_20180628_0411.py
@@ -1,6 +1,6 @@
+import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
-import django.db.models.deletion
 
 
 class Migration(migrations.Migration):

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -1,16 +1,15 @@
 import os.path
 from datetime import datetime
-from tablib import Dataset
 
 from core.admin import AuthorAdmin, BookAdmin, BookResource, CustomBookAdmin
 from core.models import Author, Book, Category, EBook, Parent
-
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.testcases import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
+from tablib import Dataset
 
 from import_export.formats.base_formats import DEFAULT_FORMATS
 

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -1,9 +1,9 @@
 import os
-from tablib.core import UnsupportedFormat
 from unittest import mock
 
 from django.test import TestCase
 from django.utils.encoding import force_str
+from tablib.core import UnsupportedFormat
 
 from import_export.formats import base_formats
 

--- a/tests/core/tests/test_instance_loaders.py
+++ b/tests/core/tests/test_instance_loaders.py
@@ -1,7 +1,5 @@
 import tablib
-
 from core.models import Book
-
 from django.test import TestCase
 
 from import_export import instance_loaders, resources

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -1,5 +1,4 @@
 from core.models import Category
-
 from django.test.testcases import TestCase
 from django.urls import reverse
 

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -1,5 +1,4 @@
 import json
-import tablib
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import date
@@ -7,6 +6,7 @@ from decimal import Decimal
 from unittest import mock, skip, skipIf, skipUnless
 
 import django
+import tablib
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -31,7 +31,7 @@ from ..models import (
     Role,
     WithDefault,
     WithDynamicDefault,
-    WithFloatField
+    WithFloatField,
 )
 
 if django.VERSION[0] >= 3:

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 
 import pytz
 from core.models import Author, Category
-
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,4 @@
 from core import views
-
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import path


### PR DESCRIPTION
**Problem + Solution**

isort 5 added built-in configuration profiles: https://pycqa.github.io/isort/docs/configuration/profiles/ . The "black" format is compatible with the [black formatter](https://github.com/psf/black), which is becoming the "de facto" code formatting style for Python, and will be adopted by Django per [DEP 8](https://github.com/django/deps/blob/master/accepted/0008-black.rst), once Black is no longer beta software.

Adopting the same style here helps with consistency and comprehensibility for contributors. I was a little confused by the existing config that sorted `tablib` with standard library packages, since it's not from there.


**Acceptance Criteria**

`tox -e isort` passes with new configuration.