### PR TITLE
Fix an issue where selected import format ignored if multile action forms presented on the page

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -545,7 +545,14 @@ class ExportActionMixin(ExportMixin):
         """
         Exports the selected rows using file_format.
         """
-        export_format = request.POST.get('file_format')
+        # There can be multiple action forms on the page (at the top
+        # and bottom of the change list, for example). Get the action
+        # whose button was pushed.
+        try:
+            action_index = int(request.POST.get('index', 0))
+            export_format = request.POST.getlist('file_format')[action_index]
+        except (IndexError, ValueError):
+            export_format = None
 
         if not export_format:
             messages.warning(request, _('You must select an export format.'))


### PR DESCRIPTION
**Problem**

When an admin page has both `actions_on_bottom` and `actions_on_top` set to `True` the selected data format is ignored and _You must select an export format_ displayed to the user.
