### PR TITLE
add option to have multiple resource classes in ModelAdmin

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,11 @@ accommodate these changes.
 - Use 'create' flag instead of instance.pk (#1362)
    - ``import_export.resources.save_instance()`` now takes an additional mandatory argument: `is_create`.
      If you have over-ridden `save_instance()` in your own code, you will need to add this new argument.#
+
+- Add support for multiple resources in ModelAdmin. (#1223)
+  - The `*Mixin.resource_class` accepting single resource has been deprecated (will work for few next versions) and
+    the new `*Mixin.resource_classes` accepting subscriptable type (list, tuple, ...) has been added.
+  - Same applies to all of the `get_resource_class`, `get_import_resource_class` and `get_export_resource_class` methods.
      
 Enhancements
 ############

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -336,7 +336,7 @@ mixins (:class:`~import_export.admin.ImportMixin`,
     from import_export.admin import ImportExportModelAdmin
 
     class BookAdmin(ImportExportModelAdmin):
-        resource_class = BookResource
+        resource_classes = [BookResource]
 
     admin.site.register(Book, BookAdmin)
 
@@ -351,6 +351,13 @@ mixins (:class:`~import_export.admin.ImportMixin`,
 .. figure:: _static/images/django-import-export-import-confirm.png
 
    A screenshot of the confirm import view.
+
+
+.. warning::
+
+    The `resource_class` parameter was deprecated in `django-import-export` 3.0.
+    Assign list or tuple with Resource(s) to `resource_classes` parameter now.
+
 
 
 Exporting via admin action
@@ -431,7 +438,7 @@ Customize forms::
 Customize ``ModelAdmin``::
 
     class CustomBookAdmin(ImportMixin, admin.ModelAdmin):
-        resource_class = BookResource
+        resource_classes = [BookResource]
 
         def get_import_form(self):
             return CustomImportForm
@@ -460,7 +467,49 @@ Using the above methods it is possible to customize import form initialization
 as well as importing customizations.
 
 
+.. warning::
+
+    The `resource_class` parameter was deprecated in `django-import-export` 3.0.
+    Assign list or tuple with Resource(s) to `resource_classes` parameter now.
+
+
 .. seealso::
 
     :doc:`/api_admin`
         available mixins and options.
+
+Using multiple resources
+------------------------
+
+It is possible to set multiple resources both to import and export `ModelAdmin` classes.
+The `ImportMixin`, `ExportMixin`, `ImportExportMixin` and `ImportExportModelAdmin` classes accepts
+subscriptable type (list, tuple, ...) as `resource_classes` parameter.
+The subscriptable could also be returned from one of the
+`get_resource_classes()`, `get_import_resource_classes()`, `get_export_resource_classes()` classes.
+
+If there are multiple resources, the resource chooser appears in import/export admin form.
+The displayed name of the resource can be changed through the `name` parameter of the `Meta` class.
+
+
+Use multiple resources::
+
+    from import_export import resources
+    from core.models import Book
+
+
+    class BookResource(resources.ModelResource):
+
+        class Meta:
+            model = Book
+
+
+    class BookNameResource(resources.ModelResource):
+
+        class Meta:
+            model = Book
+            fields = ['id', 'name']
+            name = "Export/Import only book names"
+
+
+    class CustomBookAdmin(ImportMixin, admin.ModelAdmin):
+        resource_classes = [BookResource, BookNameResource]

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -119,7 +119,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     def process_dataset(self, dataset, confirm_form, request, *args, **kwargs):
 
         res_kwargs = self.get_import_resource_kwargs(request, form=confirm_form, *args, **kwargs)
-        resource = self.get_import_resource_class()(**res_kwargs)
+        resource = self.choose_import_resource_class(confirm_form)(**res_kwargs)
 
         imp_kwargs = self.get_import_data_kwargs(request, form=confirm_form, *args, **kwargs)
         return resource.import_data(dataset,
@@ -238,6 +238,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         form_type = self.get_import_form()
         form_kwargs = self.get_form_kwargs(form_type, *args, **kwargs)
         form = form_type(import_formats,
+                         self.get_import_resource_classes(),
                          request.POST or None,
                          request.FILES or None,
                          **form_kwargs)
@@ -265,7 +266,8 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
             # prepare kwargs for import data, if needed
             res_kwargs = self.get_import_resource_kwargs(request, form=form, *args, **kwargs)
-            resource = self.get_import_resource_class()(**res_kwargs)
+            resource = self.choose_import_resource_class(form)(**res_kwargs)
+            resources = [resource]
 
             # prepare additional kwargs for import_data, if needed
             imp_kwargs = self.get_import_data_kwargs(request, form=form, *args, **kwargs)
@@ -282,20 +284,25 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     'import_file_name': tmp_storage.name,
                     'original_file_name': import_file.name,
                     'input_format': form.cleaned_data['input_format'],
+                    'resource': request.POST.get('resource', ''),
                 }
                 confirm_form = self.get_confirm_import_form()
                 initial = self.get_form_kwargs(form=form, **initial)
                 context['confirm_form'] = confirm_form(initial=initial)
         else:
             res_kwargs = self.get_import_resource_kwargs(request, form=form, *args, **kwargs)
-            resource = self.get_import_resource_class()(**res_kwargs)
+            resource_classes = self.get_import_resource_classes()
+            resources = [resource_class(**res_kwargs) for resource_class in resource_classes]
 
         context.update(self.admin_site.each_context(request))
 
         context['title'] = _("Import")
         context['form'] = form
         context['opts'] = self.model._meta
-        context['fields'] = [f.column_name for f in resource.get_user_visible_fields()]
+        context['fields_list'] = [
+            (resource.get_display_name(), [f.column_name for f in resource.get_user_visible_fields()])
+            for resource in resources
+        ]
 
         request.current_app = self.admin_site.name
         return TemplateResponse(request, [self.import_template_name],
@@ -405,14 +412,16 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             raise PermissionDenied
 
         formats = self.get_export_formats()
-        form = ExportForm(formats, request.POST or None)
+        form = ExportForm(formats, self.get_export_resource_classes(), request.POST or None)
         if form.is_valid():
             file_format = formats[
                 int(form.cleaned_data['file_format'])
             ]()
 
             queryset = self.get_export_queryset(request)
-            export_data = self.get_export_data(file_format, queryset, request=request, encoding=self.to_encoding)
+            export_data = self.get_export_data(
+                file_format, queryset, request=request, encoding=self.to_encoding, export_form=form,
+            )
             content_type = file_format.get_content_type()
             response = HttpResponse(export_data, content_type=content_type)
             response['Content-Disposition'] = 'attachment; filename="%s"' % (

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -5,7 +5,25 @@ from django.contrib.admin.helpers import ActionForm
 from django.utils.translation import gettext_lazy as _
 
 
-class ImportForm(forms.Form):
+class ImportExportFormBase(forms.Form):
+    resource = forms.ChoiceField(
+        label=_('Resource'),
+        choices=(),
+        required=False,
+    )
+
+    def __init__(self, resources=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if resources and len(resources) > 1:
+            resource_choices = []
+            for i, resource in enumerate(resources):
+                resource_choices.append((i, resource.get_display_name()))
+            self.fields['resource'].choices = resource_choices
+        else:
+            del self.fields['resource']
+
+
+class ImportForm(ImportExportFormBase):
     import_file = forms.FileField(
         label=_('File to import')
         )
@@ -29,6 +47,7 @@ class ConfirmImportForm(forms.Form):
     import_file_name = forms.CharField(widget=forms.HiddenInput())
     original_file_name = forms.CharField(widget=forms.HiddenInput())
     input_format = forms.CharField(widget=forms.HiddenInput())
+    resource = forms.CharField(widget=forms.HiddenInput(), required=False)
 
     def clean_import_file_name(self):
         data = self.cleaned_data['import_file_name']
@@ -36,7 +55,7 @@ class ConfirmImportForm(forms.Form):
         return data
 
 
-class ExportForm(forms.Form):
+class ExportForm(ImportExportFormBase):
     file_format = forms.ChoiceField(
         label=_('Format'),
         choices=(),

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.http import HttpResponse
 from django.utils.timezone import now
 from django.views.generic.edit import FormView
@@ -11,22 +13,65 @@ from .signals import post_export
 class BaseImportExportMixin:
     formats = base_formats.DEFAULT_FORMATS
     resource_class = None
+    resource_classes = []
 
-    def get_resource_class(self):
-        if not self.resource_class:
-            return modelresource_factory(self.model)
-        return self.resource_class
+    def check_resource_classes(self, resource_classes):
+        if resource_classes and not hasattr(resource_classes, '__getitem__'):
+            raise Exception("The resource_classes field type must be subscriptable (list, tuple, ...)")
+
+    def get_resource_classes(self):
+        """ Return subscriptable type (list, tuple, ...) containing resource classes """
+        if self.resource_classes and self.resource_class:
+            raise Exception("Only one of 'resource_class' and 'resource_classes' can be set")
+        if hasattr(self, 'get_resource_class'):
+            warnings.warn(
+                "The 'get_resource_class()' method has been deprecated. "
+                "Please implement the new 'get_resource_classes()' method",
+                DeprecationWarning,
+            )
+            return self.get_resource_class()
+        if self.resource_class:
+            warnings.warn(
+                "The 'resource_class' field has been deprecated. "
+                "Please implement the new 'resource_classes' field",
+                DeprecationWarning,
+            )
+        if not self.resource_classes and not self.resource_class:
+            return [modelresource_factory(self.model)]
+        if self.resource_classes:
+            return self.resource_classes
+        return [self.resource_class]
 
     def get_resource_kwargs(self, request, *args, **kwargs):
         return {}
 
+    def get_resource_index(self, form):
+        resource_index = 0
+        if form and 'resource' in form.cleaned_data:
+            try:
+                resource_index = int(form.cleaned_data['resource'])
+            except ValueError:
+                pass
+        return resource_index
+
 
 class BaseImportMixin(BaseImportExportMixin):
-    def get_import_resource_class(self):
+
+    def get_import_resource_classes(self):
         """
-        Returns ResourceClass to use for import.
+        Returns ResourceClass subscriptable (list, tuple, ...) to use for import.
         """
-        return self.get_resource_class()
+        if hasattr(self, 'get_import_resource_class'):
+            warnings.warn(
+                "The 'get_import_resource_class()' method has been deprecated. "
+                "Please implement the new 'get_import_resource_classes()' method",
+                DeprecationWarning,
+            )
+            return [self.get_import_resource_class()]
+
+        resource_classes = self.get_resource_classes()
+        self.check_resource_classes(resource_classes)
+        return resource_classes
 
     def get_import_formats(self):
         """
@@ -36,6 +81,10 @@ class BaseImportMixin(BaseImportExportMixin):
 
     def get_import_resource_kwargs(self, request, *args, **kwargs):
         return self.get_resource_kwargs(request, *args, **kwargs)
+
+    def choose_import_resource_class(self, form):
+        resource_index = self.get_resource_index(form)
+        return self.get_import_resource_classes()[resource_index]
 
 
 class BaseExportMixin(BaseImportExportMixin):
@@ -47,18 +96,33 @@ class BaseExportMixin(BaseImportExportMixin):
         """
         return [f for f in self.formats if f().can_export()]
 
-    def get_export_resource_class(self):
+    def get_export_resource_classes(self):
         """
-        Returns ResourceClass to use for export.
+        Returns ResourceClass subscriptable (list, tuple, ...) to use for export.
         """
-        return self.get_resource_class()
+        if hasattr(self, 'get_export_resource_class'):
+            warnings.warn(
+                "The 'get_export_resource_class()' method has been deprecated. "
+                "Please implement the new 'get_export_resource_classes()' method",
+                DeprecationWarning,
+            )
+            return [self.get_export_resource_class()]
+
+        resource_classes = self.get_resource_classes()
+        self.check_resource_classes(resource_classes)
+        return resource_classes
+
+    def choose_export_resource_class(self, form):
+        resource_index = self.get_resource_index(form)
+        return self.get_export_resource_classes()[resource_index]
 
     def get_export_resource_kwargs(self, request, *args, **kwargs):
         return self.get_resource_kwargs(request, *args, **kwargs)
 
     def get_data_for_export(self, request, queryset, *args, **kwargs):
-        resource_class = self.get_export_resource_class()
-        return resource_class(**self.get_export_resource_kwargs(request, *args, **kwargs))\
+        export_form = kwargs.pop('export_form', None)
+        return self.choose_export_resource_class(export_form)\
+            (**self.get_export_resource_kwargs(request, *args, **kwargs))\
             .export(queryset, *args, **kwargs)
 
     def get_export_filename(self, file_format):

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1174,6 +1174,12 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
                 finally:
                     cursor.close()
 
+    @classmethod
+    def get_display_name(cls):
+        if hasattr(cls._meta, 'name'):
+            return cls._meta.name
+        return cls.__name__
+
 
 def modelresource_factory(model, resource_class=ModelResource):
     """

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -29,7 +29,16 @@
 
       <p>
         {% trans "This importer will import the following fields: " %}
-        <code>{{ fields|join:", " }}</code>
+        {% if fields_list|length <= 1 %}
+           <code>{{ fields_list.0.1|join:", " }}</code>
+        {% else %}
+           <dl>
+              {% for resource, fields in fields_list %}
+                  <dt>{{ resource }}</dt>
+                  <dd><code>{{ fields|join:", " }}</code></dd>
+              {% endfor %}
+           </dl>
+        {% endif %}
       </p>
 
       <fieldset class="module aligned">

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -20,10 +20,18 @@ class BookResource(ModelResource):
         return self.fields['name'].clean(row) == ''
 
 
+class BookNameResource(ModelResource):
+
+    class Meta:
+        model = Book
+        fields = ['id', 'name']
+        name = "Export/Import only book names"
+
+
 class BookAdmin(ImportExportMixin, admin.ModelAdmin):
     list_display = ('name', 'author', 'added')
     list_filter = ['categories', 'author']
-    resource_class = BookResource
+    resource_classes = [BookResource, BookNameResource]
 
 
 class CategoryAdmin(ExportActionModelAdmin):

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -89,6 +89,51 @@ class ImportExportAdminIntegrationTest(TestCase):
                 1, 0, Book._meta.verbose_name_plural)
         )
 
+    @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
+    def test_import_second_resource(self):
+        Book.objects.create(id=1)
+
+        # GET the import form
+        response = self.client.get('/admin/core/book/import/')
+        self.assertContains(response, "Export/Import only book names")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/import_export/import.html')
+        self.assertContains(response, 'form action=""')
+
+        # POST the import form
+        input_format = '0'
+        filename = os.path.join(
+            os.path.dirname(__file__),
+            os.path.pardir,
+            'exports',
+            'books.csv')
+        with open(filename, "rb") as f:
+            data = {
+                'input_format': input_format,
+                'import_file': f,
+                'resource': 1,
+            }
+            response = self.client.post('/admin/core/book/import/', data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('result', response.context)
+        with open("response.html", "wb") as f:
+            f.write(response.content)
+        self.assertFalse(response.context['result'].has_errors())
+        self.assertIn('confirm_form', response.context)
+        confirm_form = response.context['confirm_form']
+
+        data = confirm_form.initial
+        self.assertEqual(data['original_file_name'], 'books.csv')
+        response = self.client.post('/admin/core/book/process_import/', data,
+                                    follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response,
+            _('Import finished, with {} new and {} updated {}.').format(
+                0, 1, Book._meta.verbose_name_plural)
+        )
+        # Check, that we really use second resource - author_email didn't get imported
+        self.assertEqual(Book.objects.get(id=1).author_email, "")
+
     def test_delete_from_admin(self):
         # test delete from admin site (see #432)
 
@@ -174,6 +219,31 @@ class ImportExportAdminIntegrationTest(TestCase):
             response['Content-Disposition'],
             'attachment; filename="Book-{}.csv"'.format(date_str)
         )
+        self.assertEqual(
+            b"id,name,author,author_email,imported,published,"
+            b"published_time,price,added,categories\r\n",
+            response.content,
+        )
+
+    def test_export_second_resource(self):
+        response = self.client.get('/admin/core/book/export/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Export/Import only book names")
+
+        data = {
+            'file_format': '0',
+            'resource': 1,
+            }
+        date_str = datetime.now().strftime('%Y-%m-%d')
+        response = self.client.post('/admin/core/book/export/', data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.has_header("Content-Disposition"))
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertEqual(
+            response['Content-Disposition'],
+            'attachment; filename="Book-{}.csv"'.format(date_str)
+        )
+        self.assertEqual(b"id,name\r\n", response.content)
 
     def test_returns_xlsx_export(self):
         response = self.client.get('/admin/core/book/export/')
@@ -298,15 +368,15 @@ class ImportExportAdminIntegrationTest(TestCase):
                     raise Exception
 
         @monkeypatch_method(BookAdmin)
-        def get_resource_class(self):
-            return R
+        def get_resource_classes(self):
+            return [R]
 
         # Verify that when an exception occurs in import_row, when raise_errors is False,
         # the returned row result has a correct import_type value,
         # so generating log entries does not fail.
         @monkeypatch_method(BookAdmin)
         def process_dataset(self, dataset, confirm_form, request, *args, **kwargs):
-            resource = self.get_import_resource_class()(**self.get_import_resource_kwargs(request, *args, **kwargs))
+            resource = self.get_import_resource_classes()[0](**self.get_import_resource_kwargs(request, *args, **kwargs))
             return resource.import_data(dataset,
                                         dry_run=False,
                                         raise_errors=False,
@@ -459,6 +529,7 @@ class TestImportExportActionModelAdmin(ImportExportActionModelAdmin):
 class ImportActionDecodeErrorTest(TestCase):
     mock_model = mock.Mock(spec=Book)
     mock_model.__name__ = "mockModel"
+    mock_model._meta = mock.Mock(fields=[], many_to_many=[])
     mock_site = mock.MagicMock()
     mock_request = MagicMock(spec=HttpRequest)
     mock_request.POST = {'a': 1}
@@ -542,6 +613,8 @@ class TestExportEncoding(TestCase):
     mock_request.POST = {'file_format': 0}
 
     class TestMixin(ExportMixin):
+        model = Book
+
         def __init__(self, test_str=None):
             self.test_str = test_str
 

--- a/tests/core/tests/test_forms.py
+++ b/tests/core/tests/test_forms.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from import_export import forms, resources
+
+
+class MyResource(resources.ModelResource):
+    class Meta:
+        name = "My super resource"
+
+
+class FormTest(TestCase):
+
+    def test_formbase_init_blank_resources(self):
+        resource_list = []
+        form = forms.ImportExportFormBase(resource_list)
+        self.assertTrue('resource' not in form.fields)
+
+    def test_formbase_init_one_resources(self):
+        resource_list = [resources.ModelResource]
+        form = forms.ImportExportFormBase(resource_list)
+        self.assertTrue('resource' not in form.fields)
+
+    def test_formbase_init_two_resources(self):
+        resource_list = [resources.ModelResource, MyResource]
+        form = forms.ImportExportFormBase(resource_list)
+        self.assertEqual(
+            form.fields['resource'].choices,
+            [(0, 'ModelResource'), (1, "My super resource")],
+        )

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest
 from django.test.testcases import TestCase
 from django.urls import reverse
 
-from import_export import formats, forms, mixins
+from import_export import formats, forms, mixins, resources
 
 
 class ExportViewMixinTest(TestCase):
@@ -113,6 +113,10 @@ class BaseImportMixinTest(TestCase):
         self.assertEqual('CanImportFormat', formats[0].__name__)
 
 
+class FooResource(resources.Resource):
+    pass
+
+
 class MixinModelAdminTest(TestCase):
     """
     Tests for regression where methods in ModelAdmin with BaseImportMixin / BaseExportMixin
@@ -124,7 +128,7 @@ class MixinModelAdminTest(TestCase):
     class BaseImportModelAdminTest(mixins.BaseImportMixin):
         call_count = 0
 
-        def get_resource_class(self):
+        def get_resource_classes(self):
             self.call_count += 1
 
         def get_resource_kwargs(self, request, *args, **kwargs):
@@ -133,7 +137,7 @@ class MixinModelAdminTest(TestCase):
     class BaseExportModelAdminTest(mixins.BaseExportMixin):
         call_count = 0
 
-        def get_resource_class(self):
+        def get_resource_classes(self):
             self.call_count += 1
 
         def get_resource_kwargs(self, request, *args, **kwargs):
@@ -141,7 +145,7 @@ class MixinModelAdminTest(TestCase):
 
     def test_get_import_resource_class_calls_self_get_resource_class(self):
         admin = self.BaseImportModelAdminTest()
-        admin.get_import_resource_class()
+        admin.get_import_resource_classes()
         self.assertEqual(1, admin.call_count)
 
     def test_get_import_resource_kwargs_calls_self_get_resource_kwargs(self):
@@ -151,13 +155,110 @@ class MixinModelAdminTest(TestCase):
 
     def test_get_export_resource_class_calls_self_get_resource_class(self):
         admin = self.BaseExportModelAdminTest()
-        admin.get_export_resource_class()
+        admin.get_export_resource_classes()
         self.assertEqual(1, admin.call_count)
 
     def test_get_export_resource_kwargs_calls_self_get_resource_kwargs(self):
         admin = self.BaseExportModelAdminTest()
         admin.get_export_resource_kwargs(self.request)
         self.assertEqual(1, admin.call_count)
+
+    class BaseModelResourceClassTest(mixins.BaseImportMixin, mixins.BaseExportMixin):
+        resource_class = resources.Resource
+        export_call_count = 0
+        import_call_count = 0
+
+        def get_export_resource_class(self):
+            self.export_call_count += 1
+
+        def get_import_resource_class(self):
+            self.import_call_count += 1
+
+    def test_deprecated_resource_class_raises_warning(self):
+        """ Test that the mixin throws error if user didn't migrate to resource_classes """
+        admin = self.BaseModelResourceClassTest()
+        with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"^The 'get_export_resource_class\(\)' method has been deprecated. "
+                r"Please implement the new 'get_export_resource_classes\(\)' method$"):
+            admin.get_export_resource_classes()
+
+        with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"^The 'get_import_resource_class\(\)' method has been deprecated. "
+                r"Please implement the new 'get_import_resource_classes\(\)' method$"):
+            admin.get_import_resource_classes()
+
+        with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"^The 'resource_class' field has been deprecated. "
+                r"Please implement the new 'resource_classes' field$"):
+            self.assertEqual(admin.get_resource_classes(), [resources.Resource])
+
+        self.assertEqual(1, admin.export_call_count)
+        self.assertEqual(1, admin.import_call_count)
+
+    class BaseModelGetExportResourceClassTest(mixins.BaseExportMixin):
+        def get_resource_class(self):
+            pass
+
+    def test_deprecated_get_resource_class_raises_warning(self):
+        """ Test that the mixin throws error if user didn't migrate to resource_classes """
+        admin = self.BaseModelGetExportResourceClassTest()
+        with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"^The 'get_resource_class\(\)' method has been deprecated. "
+                r"Please implement the new 'get_resource_classes\(\)' method$"):
+            admin.get_resource_classes()
+
+    class BaseModelAdminFaultyResourceClassesTest(mixins.BaseExportMixin):
+        resource_classes = resources.Resource
+
+    def test_faulty_resource_class_raises_exception(self):
+        """ Test fallback mechanism to old get_export_resource_class() method """
+        admin = self.BaseModelAdminFaultyResourceClassesTest()
+        with self.assertRaisesRegex(
+                Exception,
+                r"^The resource_classes field type must be subscriptable"):
+            admin.get_export_resource_classes()
+
+    class BaseModelAdminBothResourceTest(mixins.BaseExportMixin):
+        call_count = 0
+
+        resource_class = resources.Resource
+        resource_classes = [resources.Resource]
+
+    def test_both_resource_class_raises_exception(self):
+        """ Test fallback mechanism to old get_export_resource_class() method """
+        admin = self.BaseModelAdminBothResourceTest()
+        with self.assertRaisesRegex(
+                Exception,
+                "Only one of 'resource_class' and 'resource_classes' can be set"):
+            admin.get_export_resource_classes()
+
+    class BaseModelExportChooseTest(mixins.BaseExportMixin):
+        resource_classes = [resources.Resource, FooResource]
+
+    @mock.patch("import_export.admin.ExportForm")
+    def test_choose_export_resource_class(self, form):
+        """ Test choose_export_resource_class() method """
+        admin = self.BaseModelExportChooseTest()
+        self.assertEqual(admin.choose_export_resource_class(form), resources.Resource)
+
+        form.cleaned_data = {'resource': 1}
+        self.assertEqual(admin.choose_export_resource_class(form), FooResource)
+
+    class BaseModelImportChooseTest(mixins.BaseImportMixin):
+        resource_classes = [resources.Resource, FooResource]
+
+    @mock.patch("import_export.admin.ImportForm")
+    def test_choose_import_resource_class(self, form):
+        """ Test choose_import_resource_class() method """
+        admin = self.BaseModelImportChooseTest()
+        self.assertEqual(admin.choose_import_resource_class(form), resources.Resource)
+
+        form.cleaned_data = {'resource': 1}
+        self.assertEqual(admin.choose_import_resource_class(form), FooResource)
 
 
 class BaseExportMixinTest(TestCase):

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -264,6 +264,20 @@ class ModelResourceTest(TestCase):
         self.assertIsInstance(widget, widgets.ForeignKeyWidget)
         self.assertEqual(widget.model, Author)
 
+    def test_get_display_name(self):
+        display_name = self.resource.get_display_name()
+        self.assertEqual(display_name, 'BookResource')
+
+        class BookResource(resources.ModelResource):
+            class Meta:
+                name = 'Foo Name'
+                model = Book
+                import_id_fields = ['name']
+
+        resource = BookResource()
+        display_name = resource.get_display_name()
+        self.assertEqual(display_name, 'Foo Name')
+
     def test_fields_m2m(self):
         fields = self.resource.fields
         self.assertIn('categories', fields)


### PR DESCRIPTION
**Problem**

Issue #765

**Solution**

If the resource classes in ModelAdmin are provided as list i.e.:
```python
class InvoiceAdmin(ModelAdmin):
    resource_class = [InvoiceResource, AccountingInvoiceResource]
```
Then there will be additional field in the ExportForm asking user to choose the resource:
![Snímek z 2020-12-12 09-05-15](https://user-images.githubusercontent.com/156755/101978939-35f5f700-3c59-11eb-8adc-5dc1cac0f5b2.png)

The displayed name of the resource can be set by `ModelResource.name` or `ModelResource.get_display_name()`.

**Acceptance Criteria**

I didn't write the documentation or tests yet, but I am willing to, but I would like some opinions on my approach first.