### PR TITLE
CachedInstanceLoader defaults to empty when import_id is missing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,3 +115,4 @@ The following is a list of much appreciated contributors:
 * kjpc-tech (Kyle)
 * Matthew Hegarty
 * jinmay (jinmyeong Cho)
+* DonQueso89 (Kees van Ekeren)

--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -67,3 +67,4 @@ class CachedInstanceLoader(ModelInstanceLoader):
     def get_instance(self, row):
         if self.all_instances:
             return self.all_instances.get(self.pk_field.clean(row))
+        return None

--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -65,4 +65,5 @@ class CachedInstanceLoader(ModelInstanceLoader):
             }
 
     def get_instance(self, row):
-        return self.all_instances.get(self.pk_field.clean(row))
+        if self.all_instances:
+            return self.all_instances.get(self.pk_field.clean(row))

--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -50,15 +50,19 @@ class CachedInstanceLoader(ModelInstanceLoader):
         pk_field_name = self.resource.get_import_id_fields()[0]
         self.pk_field = self.resource.fields[pk_field_name]
 
-        ids = [self.pk_field.clean(row) for row in self.dataset.dict]
-        qs = self.get_queryset().filter(**{
-            "%s__in" % self.pk_field.attribute: ids
-            })
+        # If the pk field is missing, all instances in dataset are new
+        # and cache is empty.
+        self.all_instances = {}
+        if self.dataset.dict and self.pk_field.column_name in self.dataset.dict[0]:
+            ids = [self.pk_field.clean(row) for row in self.dataset.dict]
+            qs = self.get_queryset().filter(**{
+                "%s__in" % self.pk_field.attribute: ids
+                })
 
-        self.all_instances = {
-            self.pk_field.get_value(instance): instance
-            for instance in qs
-        }
+            self.all_instances = {
+                self.pk_field.get_value(instance): instance
+                for instance in qs
+            }
 
     def get_instance(self, row):
         return self.all_instances.get(self.pk_field.clean(row))

--- a/tests/core/tests/test_instance_loaders.py
+++ b/tests/core/tests/test_instance_loaders.py
@@ -26,3 +26,28 @@ class CachedInstanceLoaderTest(TestCase):
     def test_get_instance(self):
         obj = self.instance_loader.get_instance(self.dataset.dict[0])
         self.assertEqual(obj, self.book)
+
+
+
+class CachedInstanceLoaderWithAbsentImportIdFieldTest(TestCase):
+    """Ensure that the cache is empty when the PK field is absent
+    in the inbound dataset.
+    """
+
+    def setUp(self):
+        self.resource = resources.modelresource_factory(Book)()
+        self.dataset = tablib.Dataset(headers=['name', 'author_email'])
+        self.book = Book.objects.create(name="Some book")
+        self.book2 = Book.objects.create(name="Some other book")
+        row = ['Some book', 'test@example.com']
+        self.dataset.append(row)
+        self.instance_loader = instance_loaders.CachedInstanceLoader(
+            self.resource, self.dataset)
+
+    def test_all_instances(self):
+        self.assertEqual(self.instance_loader.all_instances, {})
+        self.assertEqual(len(self.instance_loader.all_instances), 0)
+
+    def test_get_instance(self):
+        obj = self.instance_loader.get_instance(self.dataset.dict[0])
+        self.assertEqual(obj, None)


### PR DESCRIPTION
**Problem**

CachedInstanceLoader tries to clean the import_id field, even when it is not present in the inbound dataset, resulting in a KeyError thrown in fields.py. When using ModelInstanceLoader, an absent import_id column is allowed and results in the entries all being new, which is (to my mind) the most desirable behavior. 

**Solution**

Refactor CachedInstanceLoader to initialize with an empty cache when it gets a dataset without the import_id column. get_instance is then never called by the Resource since it checks whether the import_id_fields are present in the inbound dataset before calling get_instance.

**Acceptance Criteria**

Added a unit test which demonstrates the KeyError in the previous code and shows the correct initialization of CachedInstanceLoader in the new code. 

Documentation is not necessary since this makes no change to a public API. Code using CachedInstanceLoader which has implemented a workaround for this problem should still work since most workarounds will probably have implemented some hook to guarantee the presence of the import_id field. In the unlikely event that someone is explicitly checking for a KeyError and basing their behavior on that, they will have to update their code.