### PR TITLE
Remove EOL Python 3.5 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - postgresql
   - mysql
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
@@ -33,26 +32,6 @@ env:
     - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
     - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
     - DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
-matrix:
-  exclude:
-    - python: "3.5"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
-    - python: "3.5"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
-    - python: "3.5"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
-    - python: "3.5"
-      env: DJANGO="Django==3.1.*" IMPORT_EXPORT_TEST_TYPE=postgres
-    - python: "3.5"
-      env: DJANGO="Django==3.1.*" IMPORT_EXPORT_TEST_TYPE=sqlite
-    - python: "3.5"
-      env: DJANGO="Django==3.1.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
-    - python: "3.5"
-      env: DJANGO="Django==3.0.*" IMPORT_EXPORT_TEST_TYPE=postgres
-    - python: "3.5"
-      env: DJANGO="Django==3.0.*" IMPORT_EXPORT_TEST_TYPE=sqlite
-    - python: "3.5"
-      env: DJANGO="Django==3.0.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
 install:
   - pip install -q $DJANGO
   - pip install -r requirements/base.txt

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3 :: Only',
     'Topic :: Software Development',
 ]
@@ -52,7 +52,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=install_requires,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=CLASSIFIERS,
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-       {py35,py36,py37}-django20-tablib{dev,stable},
-       {py35,py36,py37}-django21-tablib{dev,stable},
-       {py35,py36,py37}-django22-tablib{dev,stable},
+       {py36,py37}-django20-tablib{dev,stable},
+       {py36,py37}-django21-tablib{dev,stable},
+       {py36,py37}-django22-tablib{dev,stable},
        {py36,py37,py38}-django30-tablib{dev,stable},
        {py36,py37,py38}-django31-tablib{dev,stable},
        {py36,py37,py38}-djangomaster-tablib{dev,stable},


### PR DESCRIPTION
**Problem**

EOL python 3.5
https://devguide.python.org/devcycle/#end-of-life-branches

**Solution**

Remove it from Travis