### PR TITLE
basiccustomformat

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1087,7 +1087,10 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         """
         Returns a queryset of all objects for this model. Override this if you
         want to limit the returned queryset.
-        """
+        """    if self._meta.fields is not None:
+                return self._meta.model.objects.only(*self._meta.fields)
+
+
         return self._meta.model.objects.all()
 
     def init_instance(self, row=None):

--- a/import_export/templates/admin/import_export/export.html
+++ b/import_export/templates/admin/import_export/export.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% load admin_urls %}
 {% load import_export_tags %}
+{% block extrahead %}{{ block.super }}
+<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+{{ form.media }}
+{% endblock %}
 
 {% block breadcrumbs_last %}
 {% trans "Export" %}


### PR DESCRIPTION
Signed-off-by: harsh6768-svg 1905391@kiit.ac.in

Problem
When custom import/export forms contain complex widgets with linked media it is not added to output.

Solution
Added standard form.media to templates.

Acceptance Criteria
This fix does not require tests and documentation changes.

