### PR TITLE
Suport multiple databases

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -11,12 +11,11 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.management.color import no_style
 from django.core.paginator import Paginator
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import connections, router
 from django.db.models.fields.related import ForeignObjectRel
 from django.db.models.query import QuerySet
 from django.db.transaction import (
     TransactionManagementError,
-    atomic,
     savepoint,
     savepoint_commit,
     savepoint_rollback,
@@ -159,6 +158,13 @@ class ResourceOptions:
     contain new instances.
     """
 
+    using_db = None
+    """
+    DB Connection name to use for db transactions. If not provided,
+    ``router.db_for_write(model)`` will be evaluated and if it's missing,
+    DEFAULT_DB_ALIAS constant ("default") is used.
+    """
+
 
 class DeclarativeMetaclass(type):
 
@@ -271,6 +277,12 @@ class Resource(metaclass=DeclarativeMetaclass):
         Returns the class used to display the diff for an imported instance.
         """
         return Diff
+
+    def get_db_connection_name(self):
+        if self._meta.using_db is None:
+            return router.db_for_write(self._meta.model)
+        else:
+            return self._meta.using_db
 
     def get_use_transactions(self):
         if self._meta.use_transactions is None:
@@ -726,7 +738,8 @@ class Resource(metaclass=DeclarativeMetaclass):
         if use_transactions is None:
             use_transactions = self.get_use_transactions()
 
-        connection = connections[DEFAULT_DB_ALIAS]
+        db_connection = self.get_db_connection_name()
+        connection = connections[db_connection]
         supports_transactions = getattr(connection.features, "supports_transactions", False)
 
         if use_transactions and not supports_transactions:
@@ -737,21 +750,22 @@ class Resource(metaclass=DeclarativeMetaclass):
         if self._meta.batch_size is not None and (not isinstance(self._meta.batch_size, int) or self._meta.batch_size < 0):
             raise ValueError("Batch size must be a positive integer")
 
-        with atomic_if_using_transaction(using_transactions):
+        with atomic_if_using_transaction(using_transactions, using=db_connection):
             return self.import_data_inner(dataset, dry_run, raise_errors, using_transactions, collect_failed_rows, **kwargs)
 
     def import_data_inner(self, dataset, dry_run, raise_errors, using_transactions, collect_failed_rows, **kwargs):
         result = self.get_result_class()()
         result.diff_headers = self.get_diff_headers()
         result.total_rows = len(dataset)
+        db_connection = self.get_db_connection_name()
 
         if using_transactions:
             # when transactions are used we want to create/update/delete object
             # as transaction will be rolled back if dry_run is set
-            sp1 = savepoint()
+            sp1 = savepoint(using=db_connection)
 
         try:
-            with atomic_if_using_transaction(using_transactions):
+            with atomic_if_using_transaction(using_transactions, using=db_connection):
                 self.before_import(dataset, using_transactions, dry_run, **kwargs)
         except Exception as e:
             logger.debug(e, exc_info=e)
@@ -769,7 +783,7 @@ class Resource(metaclass=DeclarativeMetaclass):
             result.add_dataset_headers(dataset.headers)
 
         for i, row in enumerate(dataset.dict, 1):
-            with atomic_if_using_transaction(using_transactions):
+            with atomic_if_using_transaction(using_transactions, using=db_connection):
                 row_result = self.import_row(
                     row,
                     instance_loader,
@@ -798,13 +812,13 @@ class Resource(metaclass=DeclarativeMetaclass):
 
         if self._meta.use_bulk:
             # bulk persist any instances which are still pending
-            with atomic_if_using_transaction(using_transactions):
+            with atomic_if_using_transaction(using_transactions, using=db_connection):
                 self.bulk_create(using_transactions, dry_run, raise_errors)
                 self.bulk_update(using_transactions, dry_run, raise_errors)
                 self.bulk_delete(using_transactions, dry_run, raise_errors)
 
         try:
-            with atomic_if_using_transaction(using_transactions):
+            with atomic_if_using_transaction(using_transactions, using=db_connection):
                 self.after_import(dataset, result, using_transactions, dry_run, **kwargs)
         except Exception as e:
             logger.debug(e, exc_info=e)
@@ -815,9 +829,9 @@ class Resource(metaclass=DeclarativeMetaclass):
 
         if using_transactions:
             if dry_run or result.has_errors():
-                savepoint_rollback(sp1)
+                savepoint_rollback(sp1, using=db_connection)
             else:
-                savepoint_commit(sp1)
+                savepoint_commit(sp1, using=db_connection)
 
         return result
 
@@ -1102,7 +1116,8 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         """
         # Adapted from django's loaddata
         if not dry_run and any(r.import_type == RowResult.IMPORT_TYPE_NEW for r in result.rows):
-            connection = connections[DEFAULT_DB_ALIAS]
+            db_connection = self.get_db_connection_name()
+            connection = connections[db_connection]
             sequence_sql = connection.ops.sequence_reset_sql(no_style(), [self._meta.model])
             if sequence_sql:
                 cursor = connection.cursor()

--- a/import_export/utils.py
+++ b/import_export/utils.py
@@ -7,14 +7,14 @@ class atomic_if_using_transaction:
     Replaces code::
 
         if using_transactions:
-            with transaction.atomic():
+            with transaction.atomic(using=using):
                 return something()
         return something()
     """
-    def __init__(self, using_transactions):
+    def __init__(self, using_transactions, using):
         self.using_transactions = using_transactions
         if using_transactions:
-            self.context_manager = transaction.atomic()
+            self.context_manager = transaction.atomic(using=using)
 
     def __enter__(self):
         if self.using_transactions:

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -94,7 +94,7 @@ class ResourceTestCase(TestCase):
         self.assertIsInstance(self.my_resource._meta,
                               resources.ResourceOptions)
 
-    def test_get_export_orderget_export_order(self):
+    def test_get_export_order(self):
         self.assertEqual(self.my_resource.get_export_headers(),
                          ['email', 'name', 'extra'])
 


### PR DESCRIPTION
**Problem**

Fixes #1137 

**Solution**

Based on #1226
Uses Django's DB router as a fallback to decide which DB connection to use.

**Acceptance Criteria**

Added tests