### PR TITLE
Support Django 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ env:
     - DJANGO="Django==3.1.*" IMPORT_EXPORT_TEST_TYPE=postgres
     - DJANGO="Django==3.1.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
     - DJANGO="Django==3.1.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+    - DJANGO="Django==3.2.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - DJANGO="Django==3.2.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - DJANGO="Django==3.2.*" IMPORT_EXPORT_TEST_TYPE=sqlite
     - DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
     - DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
     - DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,8 @@ Changelog
 2.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support Django 3.2.
+- Correctly select widget for ``SmallAutoField`` and ``BigAutoField``.
 
 
 2.5.0 (2020-12-30)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -997,7 +997,9 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         'BigIntegerField': widgets.IntegerWidget,
         'PositiveSmallIntegerField': widgets.IntegerWidget,
         'SmallIntegerField': widgets.IntegerWidget,
+        'SmallAutoField': widgets.IntegerWidget,
         'AutoField': widgets.IntegerWidget,
+        'BigAutoField': widgets.IntegerWidget,
         'NullBooleanField': widgets.BooleanWidget,
         'BooleanField': widgets.BooleanWidget,
     }

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 isort
-psycopg2
+psycopg2-binary
 mysqlclient
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 2.2',
     'Framework :: Django :: 3.0',
     'Framework :: Django :: 3.1',
+    'Framework :: Django :: 3.2',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import django
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -47,6 +49,9 @@ TEMPLATES = [
         },
     },
 ]
+
+if django.VERSION >= (3, 2):
+    DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 if os.environ.get('IMPORT_EXPORT_TEST_TYPE') == 'mysql-innodb':
     IMPORT_EXPORT_USE_TRANSACTIONS = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
-       {py36,py37}-django20-tablib{dev,stable},
-       {py36,py37}-django21-tablib{dev,stable},
-       {py36,py37}-django22-tablib{dev,stable},
-       {py36,py37,py38}-django30-tablib{dev,stable},
-       {py36,py37,py38}-django31-tablib{dev,stable},
-       {py36,py37,py38}-djangomain-tablib{dev,stable},
+       {py36,py37}-django20-tablib{dev,stable}
+       {py36,py37}-django21-tablib{dev,stable}
+       {py36,py37}-django22-tablib{dev,stable}
+       {py36,py37,py38}-django30-tablib{dev,stable}
+       {py36,py37,py38}-django31-tablib{dev,stable}
+       {py36,py37,py38}-django32-tablib{dev,stable}
+       {py36,py37,py38}-djangomain-tablib{dev,stable}
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning {toxinidir}/tests/manage.py test core
@@ -17,6 +18,7 @@ deps =
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<4.0
     djangomain: https://github.com/django/django/archive/main.tar.gz
     -rrequirements/test.txt
 


### PR DESCRIPTION
* Add to tox and travis grids
* Set `DEFAULT_AUTO_FIELD` setting to avoid checks warnings.
* Update `ModelResource` to support `BigAutoField` and `SmallAutoField` correctly.
* Update setup.py to declare PyPI classifier.
