### PR TITLE
Don't test Django main branch using python36,37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 env:
   global:
     - IMPORT_EXPORT_POSTGRESQL_USER=postgres
@@ -14,12 +15,6 @@ env:
     - IMPORT_EXPORT_MYSQL_USER=root
     - IMPORT_EXPORT_MYSQL_PASSWORD=
   matrix:
-    - DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=postgres
-    - DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
-    - DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=sqlite
-    - DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=postgres
-    - DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
-    - DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=sqlite
     - DJANGO="Django==2.2.*" IMPORT_EXPORT_TEST_TYPE=postgres
     - DJANGO="Django==2.2.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
     - DJANGO="Django==2.2.*" IMPORT_EXPORT_TEST_TYPE=sqlite
@@ -32,9 +27,95 @@ env:
     - DJANGO="Django==3.2.*" IMPORT_EXPORT_TEST_TYPE=postgres
     - DJANGO="Django==3.2.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
     - DJANGO="Django==3.2.*" IMPORT_EXPORT_TEST_TYPE=sqlite
-    - DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
-    - DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
-    - DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+matrix:
+  include:
+    - python: "3.9"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.9"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.9"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.8"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.8"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.8"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    # unsupported Django versions, included in allow_failures
+    - python: "3.7"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.7"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.7"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.6"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.6"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.6"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.7"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.7"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.7"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.6"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.6"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.6"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+  allow_failures:
+    - python: "3.9"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.9"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.9"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.8"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.8"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.8"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.7"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.7"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.7"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.6"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.6"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.6"
+      env: DJANGO="Django==2.1.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.7"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.7"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.7"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
+    - python: "3.6"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=postgres
+    - python: "3.6"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=mysql-innodb
+    - python: "3.6"
+      env: DJANGO="Django==2.0.*" IMPORT_EXPORT_TEST_TYPE=sqlite
+
 install:
   - pip install -q $DJANGO
   - pip install -r requirements/base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 envlist =
        {py36,py37}-django20-tablib{dev,stable}
        {py36,py37}-django21-tablib{dev,stable}
-       {py36,py37}-django22-tablib{dev,stable}
-       {py36,py37,py38}-django30-tablib{dev,stable}
-       {py36,py37,py38}-django31-tablib{dev,stable}
-       {py36,py37,py38}-django32-tablib{dev,stable}
-       {py36,py37,py38}-djangomain-tablib{dev,stable}
+       {py36,py37,py38,py39}-django22-tablib{dev,stable}
+       {py36,py37,py38,py39}-django30-tablib{dev,stable}
+       {py36,py37,py38,py39}-django31-tablib{dev,stable}
+       {py36,py37,py38,py39}-django32-tablib{dev,stable}
+       {py38,py39}-djangomain-tablib{dev,stable}
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning {toxinidir}/tests/manage.py test core


### PR DESCRIPTION
**Problem**

Travis is trying to run tests using python36,37 against Django main, which only supports python38,39

**Solution**

Exclude from matrix

**Acceptance Criteria**

Tests should pass now