### PR TITLE
Better support for Django main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
+addons:
+  postgresql: "10"
 env:
   global:
     - IMPORT_EXPORT_POSTGRESQL_USER=postgres

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1043,7 +1043,11 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
                 result = getattr(cls, result)(f)
         else:
             try:
-                from django.contrib.postgres.fields import ArrayField, JSONField
+                from django.contrib.postgres.fields import ArrayField
+                try:
+                    from django.db.models import JSONField
+                except ImportError:
+                    from django.contrib.postgres.fields import JSONField
             except ImportError:
                 # ImportError: No module named psycopg2.extras
                 class ArrayField:

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -1110,8 +1110,12 @@ class PostgresTests(TransactionTestCase):
 
 
 if 'postgresql' in settings.DATABASES['default']['ENGINE']:
-    from django.contrib.postgres.fields import ArrayField, JSONField
+    from django.contrib.postgres.fields import ArrayField
     from django.db import models
+    try:
+        from django.db.models import JSONField
+    except ImportError:
+        from django.contrib.postgres.fields import JSONField
 
 
     class BookWithChapters(models.Model):


### PR DESCRIPTION
The Postgresql JSONField is deprecated since Django 3.1 and will be removed in Django 4.0:

https://docs.djangoproject.com/en/dev/releases/3.1/#postgresql-jsonfield

**Problem**

Import export not working with Django main

**Solution**

Change imports to new JSONField, remaining compatible with old Django versions.

**Acceptance Criteria**

All tests passing now.