### PR TITLE
Fix example in BooleanWidget docs

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -118,13 +118,13 @@ class BooleanWidget(Widget):
         class BooleanExample(resources.ModelResource):
             warn = fields.Field(widget=widgets.BooleanWidget())
 
-            def before_row_import(self, row, **kwargs):
+            def before_import_row(self, row, row_number=None, **kwargs):
                 if "warn" in row.keys():
                     # munge "warn" to "True"
                     if row["warn"] in ["warn", "WARN"]:
                         row["warn"] = True
 
-                return super().before_import_row(row, **kwargs)
+                return super().before_import_row(row, row_number, **kwargs)
     """
     TRUE_VALUES = ["1", 1, True, "true", "TRUE", "True"]
     FALSE_VALUES = ["0", 0, False, "false", "FALSE", "False"]


### PR DESCRIPTION
- Fix wrong function name `before_row_import` to 
`before_import_row` in BooleanWidget's example

https://django-import-export.readthedocs.io/en/latest/api_widgets.html#import_export.widgets.BooleanWidget

![image](https://user-images.githubusercontent.com/11746585/115774469-9279d780-a3ec-11eb-950f-b621f6894c7f.png)