### PR TITLE
Remove code duplication from mixins.py and admin.py

### DIFF
--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -8,7 +8,7 @@ from .resources import modelresource_factory
 from .signals import post_export
 
 
-class ImportExportMixin:
+class BaseImportExportMixin:
     formats = base_formats.DEFAULT_FORMATS
     resource_class = None
 
@@ -20,11 +20,8 @@ class ImportExportMixin:
     def get_resource_kwargs(self, request, *args, **kwargs):
         return {}
 
-    def get_formats(self):
-        return [f for f in self.formats if f().can_import()]
 
-
-class BaseImportMixin(ImportExportMixin):
+class BaseImportMixin(BaseImportExportMixin):
     def get_import_resource_class(self):
         """
         Returns ResourceClass to use for import.
@@ -35,20 +32,20 @@ class BaseImportMixin(ImportExportMixin):
         """
         Returns available import formats.
         """
-        return super().get_formats()
+        return [f for f in self.formats if f().can_import()]
 
     def get_import_resource_kwargs(self, request, *args, **kwargs):
         return super().get_resource_kwargs(request, *args, **kwargs)
 
 
-class BaseExportMixin(ImportExportMixin):
+class BaseExportMixin(BaseImportExportMixin):
     model = None
 
     def get_export_formats(self):
         """
         Returns available export formats.
         """
-        return super().get_formats()
+        return [f for f in self.formats if f().can_export()]
 
     def get_export_resource_class(self):
         """

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -8,50 +8,80 @@ from .resources import modelresource_factory
 from .signals import post_export
 
 
-class ExportViewMixin:
+class ImportExportMixin:
     formats = base_formats.DEFAULT_FORMATS
-    form_class = ExportForm
     resource_class = None
-
-    def get_export_formats(self):
-        """
-        Returns available export formats.
-        """
-        return [f for f in self.formats if f().can_export()]
 
     def get_resource_class(self):
         if not self.resource_class:
             return modelresource_factory(self.model)
         return self.resource_class
 
+    def get_resource_kwargs(self, request, *args, **kwargs):
+        return {}
+
+    def get_formats(self):
+        return [f for f in self.formats if f().can_import()]
+
+
+class BaseImportMixin(ImportExportMixin):
+    def get_import_resource_class(self):
+        """
+        Returns ResourceClass to use for import.
+        """
+        return super().get_resource_class()
+
+    def get_import_formats(self):
+        """
+        Returns available import formats.
+        """
+        return super().get_formats()
+
+    def get_import_resource_kwargs(self, request, *args, **kwargs):
+        return super().get_resource_kwargs(request, *args, **kwargs)
+
+
+class BaseExportMixin(ImportExportMixin):
+    model = None
+
+    def get_export_formats(self):
+        """
+        Returns available export formats.
+        """
+        return super().get_formats()
+
     def get_export_resource_class(self):
         """
         Returns ResourceClass to use for export.
         """
-        return self.get_resource_class()
-
-    def get_resource_kwargs(self, request, *args, **kwargs):
-        return {}
+        return super().get_resource_class()
 
     def get_export_resource_kwargs(self, request, *args, **kwargs):
-        return self.get_resource_kwargs(request, *args, **kwargs)
+        return super().get_resource_kwargs(request, *args, **kwargs)
 
-    def get_export_data(self, file_format, queryset, *args, **kwargs):
-        """
-        Returns file_format representation for given queryset.
-        """
+    def get_data_for_export(self, request, queryset, *args, **kwargs):
         resource_class = self.get_export_resource_class()
-        data = resource_class(**self.get_export_resource_kwargs(self.request))\
+        return resource_class(**self.get_export_resource_kwargs(request, *args, **kwargs))\
             .export(queryset, *args, **kwargs)
-        export_data = file_format.export_data(data)
-        return export_data
 
-    def get_export_filename(self, file_format):
+    def get_filename(self, file_format):
         date_str = now().strftime('%Y-%m-%d')
         filename = "%s-%s.%s" % (self.model.__name__,
                                  date_str,
                                  file_format.get_extension())
         return filename
+
+
+class ExportViewMixin(BaseExportMixin):
+    form_class = ExportForm
+
+    def get_export_data(self, file_format, queryset, *args, **kwargs):
+        """
+        Returns file_format representation for given queryset.
+        """
+        data = self.get_data_for_export(self.request, queryset, *args, **kwargs)
+        export_data = file_format.export_data(data)
+        return export_data
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -86,3 +116,6 @@ class ExportViewFormMixin(ExportViewMixin, FormView):
 
         post_export.send(sender=None, model=self.model)
         return response
+
+    def get_export_filename(self, file_format):
+        return super().get_filename(file_format)

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -1,17 +1,33 @@
 import os.path
 from datetime import datetime
+from unittest import mock
+from unittest.mock import MagicMock
 
-from core.admin import AuthorAdmin, BookAdmin, BookResource, CustomBookAdmin
+from core.admin import (
+    AuthorAdmin,
+    BookAdmin,
+    BookResource,
+    CustomBookAdmin,
+    ImportMixin,
+)
 from core.models import Author, Book, Category, EBook, Parent
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import HttpRequest
 from django.test.testcases import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
 
+from import_export.admin import (
+    ExportActionModelAdmin,
+    ExportMixin,
+    ImportExportActionModelAdmin,
+)
 from import_export.formats.base_formats import DEFAULT_FORMATS
+from import_export.tmp_storages import TempFolderStorage
 
 
 class ImportExportAdminIntegrationTest(TestCase):
@@ -328,6 +344,110 @@ class ImportExportAdminIntegrationTest(TestCase):
                 1, 0, EBook._meta.verbose_name_plural)
         )
 
+    def test_get_skip_admin_log_attribute(self):
+        m = ImportMixin()
+        m.skip_admin_log = True
+        self.assertTrue(m.get_skip_admin_log())
+
+    def test_get_tmp_storage_class_attribute(self):
+        """Mock dynamically loading a class defined by an attribute"""
+        target = "SomeClass"
+        m = ImportMixin()
+        m.tmp_storage_class = "tmpClass"
+        with mock.patch("import_export.admin.import_string") as mock_import_string:
+            mock_import_string.return_value = target
+            self.assertEqual(target, m.get_tmp_storage_class())
+
+    def test_get_import_data_kwargs_with_form_kwarg(self):
+        """
+        Test that if a the method is called with a 'form' kwarg,
+        then it is removed and the updated dict is returned
+        """
+        request = MagicMock(spec=HttpRequest)
+        m = ImportMixin()
+        kw = {
+            "a": 1,
+            "form": "some_form"
+        }
+        target = {
+            "a": 1
+        }
+        self.assertEqual(target, m.get_import_data_kwargs(request, **kw))
+
+    def test_get_import_data_kwargs_with_no_form_kwarg_returns_empty_dict(self):
+        """
+        Test that if a the method is called with no 'form' kwarg,
+        then an empty dict is returned
+        """
+        request = MagicMock(spec=HttpRequest)
+        m = ImportMixin()
+        kw = {
+            "a": 1,
+        }
+        target = {}
+        self.assertEqual(target, m.get_import_data_kwargs(request, **kw))
+
+    def test_get_context_data_returns_empty_dict(self):
+        m = ExportMixin()
+        self.assertEqual(dict(), m.get_context_data())
+
+    def test_media_attribute(self):
+        """
+        Test that the 'media' attribute of the ModelAdmin class is overridden to include
+        the project-specific js file.
+        """
+        mock_model = mock.MagicMock()
+        mock_site = mock.MagicMock()
+
+        class TestExportActionModelAdmin(ExportActionModelAdmin):
+            def __init__(self):
+                super().__init__(mock_model, mock_site)
+
+        m = TestExportActionModelAdmin()
+        target_media = m.media
+        self.assertEqual('import_export/action_formats.js', target_media._js[-1])
+
+
+class ImportActionDecodeErrorTest(TestCase):
+    mock_model = mock.Mock(spec=Book)
+    mock_model.__name__ = "mockModel"
+    mock_site = mock.MagicMock()
+    mock_request = MagicMock(spec=HttpRequest)
+    mock_request.POST = {'a': 1}
+    mock_request.FILES = {}
+
+    class TestImportExportActionModelAdmin(ImportExportActionModelAdmin):
+        def __init__(self, mock_model, mock_site, error_instance):
+            self.error_instance = error_instance
+            super().__init__(mock_model, mock_site)
+
+        def write_to_tmp_storage(self, import_file, input_format):
+            mock_storage = MagicMock(spec=TempFolderStorage)
+
+            mock_storage.read.side_effect = self.error_instance
+            return mock_storage
+
+    @mock.patch("import_export.admin.ImportForm")
+    def test_import_action_handles_UnicodeDecodeError(self, mock_form):
+        mock_form.is_valid.return_value = True
+        b_arr = b'\x00\x00'
+        m = self.TestImportExportActionModelAdmin(self.mock_model, self.mock_site,
+                                                  UnicodeDecodeError('codec', b_arr, 1, 2, 'fail!'))
+        res = m.import_action(self.mock_request)
+        self.assertEqual(
+            "<h1>Imported file has a wrong encoding: \'codec\' codec can\'t decode byte 0x00 in position 1: fail!</h1>",
+            res.content.decode())
+
+    @mock.patch("import_export.admin.ImportForm")
+    def test_import_action_handles_error(self, mock_form):
+        mock_form.is_valid.return_value = True
+        m = self.TestImportExportActionModelAdmin(self.mock_model, self.mock_site,
+                                                  ValueError("fail"))
+        res = m.import_action(self.mock_request)
+        self.assertRegex(
+            res.content.decode(),
+            r"<h1>ValueError encountered while trying to read file: .*</h1>")
+
 
 class ExportActionAdminIntegrationTest(TestCase):
 
@@ -366,3 +486,16 @@ class ExportActionAdminIntegrationTest(TestCase):
         }
         response = self.client.post('/admin/core/category/', data)
         self.assertEqual(response.status_code, 302)
+
+    def test_get_export_data_raises_PermissionDenied_when_no_export_permission_assigned(self):
+        request = MagicMock(spec=HttpRequest)
+
+        class TestMixin(ExportMixin):
+            model = Book
+
+            def has_export_permission(self, request):
+                return False
+        m = TestMixin()
+        with self.assertRaises(PermissionDenied):
+            m.get_export_data('0', Book.objects.none(), request=request)
+

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -86,8 +86,33 @@ class ExportViewMixinTest(TestCase):
         self.assertEqual(1, m.mock_get_filterset_class_call_count)
 
 
-class BaseExportMixinTest(TestCase):
+class BaseImportMixinTest(TestCase):
+    def test_get_import_formats(self):
+        class Format(object):
+            def __init__(self, id, can_import):
+                self.id = id
+                self.val = can_import
 
+            def can_import(self):
+                return self.val
+
+        class CanImportFormat(Format):
+            def __init__(self):
+                super().__init__(1, True)
+
+        class CannotImportFormat(Format):
+            def __init__(self):
+                super().__init__(2, False)
+
+        m = mixins.BaseImportMixin()
+        m.formats = [CanImportFormat, CannotImportFormat]
+
+        formats = m.get_import_formats()
+        self.assertEqual(1, len(formats))
+        self.assertEqual('CanImportFormat', formats[0].__name__)
+
+
+class BaseExportMixinTest(TestCase):
     class TestBaseExportMixin(mixins.BaseExportMixin):
         def get_export_resource_kwargs(self, request, *args, **kwargs):
             self.args = args
@@ -107,3 +132,27 @@ class BaseExportMixinTest(TestCase):
         m.get_data_for_export(request, Book.objects.none(), *target_args, **target_kwargs)
         self.assertEqual(m.args, target_args)
         self.assertEqual(m.kwargs, target_kwargs)
+
+    def test_get_export_formats(self):
+        class Format(object):
+            def __init__(self, id, can_export):
+                self.id = id
+                self.val = can_export
+
+            def can_export(self):
+                return self.val
+
+        class CanExportFormat(Format):
+            def __init__(self):
+                super().__init__(1, True)
+
+        class CannotExportFormat(Format):
+            def __init__(self):
+                super().__init__(2, False)
+
+        m = mixins.BaseExportMixin()
+        m.formats = [CanExportFormat, CannotExportFormat]
+
+        formats = m.get_export_formats()
+        self.assertEqual(1, len(formats))
+        self.assertEqual('CanExportFormat', formats[0].__name__)

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -135,8 +135,7 @@ class BaseExportMixinTest(TestCase):
 
     def test_get_export_formats(self):
         class Format(object):
-            def __init__(self, id, can_export):
-                self.id = id
+            def __init__(self, can_export):
                 self.val = can_export
 
             def can_export(self):
@@ -144,11 +143,11 @@ class BaseExportMixinTest(TestCase):
 
         class CanExportFormat(Format):
             def __init__(self):
-                super().__init__(1, True)
+                super().__init__(True)
 
         class CannotExportFormat(Format):
             def __init__(self):
-                super().__init__(2, False)
+                super().__init__(False)
 
         m = mixins.BaseExportMixin()
         m.formats = [CanExportFormat, CannotExportFormat]

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -1,14 +1,24 @@
-from core.models import Category
+from unittest import mock
+from unittest.mock import MagicMock
+
+from core.models import Book, Category
+from django.http import HttpRequest
 from django.test.testcases import TestCase
 from django.urls import reverse
 
+from import_export import formats, forms, mixins
+
 
 class ExportViewMixinTest(TestCase):
+    class TestExportForm(forms.ExportForm):
+        cleaned_data = dict()
 
     def setUp(self):
         self.url = reverse('export-category')
         self.cat1 = Category.objects.create(name='Cat 1')
         self.cat2 = Category.objects.create(name='Cat 2')
+        self.form = ExportViewMixinTest.TestExportForm(formats.base_formats.DEFAULT_FORMATS)
+        self.form.cleaned_data["file_format"] = "0"
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -23,3 +33,77 @@ class ExportViewMixinTest(TestCase):
         self.assertContains(response, self.cat1.name, status_code=200)
         self.assertTrue(response.has_header("Content-Disposition"))
         self.assertEqual(response['Content-Type'], 'text/csv')
+
+    def test_get_response_raises_TypeError_when_content_type_kwarg_used(self):
+        """
+        Test that HttpResponse is instantiated using the correct kwarg.
+        """
+        content_type = "text/csv"
+
+        class TestMixin(mixins.ExportViewFormMixin):
+            def __init__(self):
+                self.model = MagicMock()
+                self.request = MagicMock(spec=HttpRequest)
+                self.model.__name__ = "mockModel"
+
+            def get_queryset(self):
+                return MagicMock()
+
+        m = TestMixin()
+        with mock.patch("import_export.mixins.HttpResponse") as mock_http_response:
+            # on first instantiation, raise TypeError, on second, return mock
+            mock_http_response.side_effect = [TypeError(), mock_http_response]
+            m.form_valid(self.form)
+            self.assertEqual(content_type, mock_http_response.call_args_list[0][1]["content_type"])
+            self.assertEqual(content_type, mock_http_response.call_args_list[1][1]["mimetype"])
+
+    def test_implements_get_filterset(self):
+        """
+        test that if the class-under-test defines a get_filterset()
+        method, then this is called as required.
+        """
+        class TestMixin(mixins.ExportViewFormMixin):
+            mock_get_filterset_call_count = 0
+            mock_get_filterset_class_call_count = 0
+
+            def __init__(self):
+                self.model = MagicMock()
+                self.request = MagicMock(spec=HttpRequest)
+                self.model.__name__ = "mockModel"
+
+            def get_filterset(self, filterset_class):
+                self.mock_get_filterset_call_count += 1
+                return MagicMock()
+
+            def get_filterset_class(self):
+                self.mock_get_filterset_class_call_count += 1
+                return MagicMock()
+
+        m = TestMixin()
+        res = m.form_valid(self.form)
+        self.assertEqual(200, res.status_code)
+        self.assertEqual(1, m.mock_get_filterset_call_count)
+        self.assertEqual(1, m.mock_get_filterset_class_call_count)
+
+
+class BaseExportMixinTest(TestCase):
+
+    class TestBaseExportMixin(mixins.BaseExportMixin):
+        def get_export_resource_kwargs(self, request, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            return super().get_resource_kwargs(request, *args, **kwargs)
+
+    def test_get_data_for_export_sets_args_and_kwargs(self):
+        """
+        issue 1268
+        Ensure that get_export_resource_kwargs() handles the args and kwargs arguments.
+        """
+        request = MagicMock(spec=HttpRequest)
+        m = self.TestBaseExportMixin()
+        m.model = Book
+        target_args = (1,)
+        target_kwargs = {"a": 1}
+        m.get_data_for_export(request, Book.objects.none(), *target_args, **target_kwargs)
+        self.assertEqual(m.args, target_args)
+        self.assertEqual(m.kwargs, target_kwargs)


### PR DESCRIPTION
**Problem**

- A [bug](#1268) where args and kwargs are not passed to `get_export_resource_kwargs()`
- Removed code duplication in `admin.py` and `mixins.py`

**Solution**

When looking into this issue, I noticed that we have a fair amount of code duplication in mixins.py and admin.py.
I removed the duplication as part of this fix.

I tried to keep code changes to a minimum, and also not to affect the public API defined in mixins.
I added some tests to improve the coverage in this area.

Would appreciate a code review from @manelclos and @ZuluPro

[Related comments](https://github.com/django-import-export/django-import-export/pull/692#issuecomment-359684319) by @manelclos 

> base mixin for import and base mixin for export, reused in the ViewMixin and the Admin Mixin, share code as much as possible when it makes sense.

### Issue 1268

Added `get_data_for_export()` to remove duplication and to pass the args and kwargs to `get_export_resource_kwargs()` which was the original issue reported in #1268.
Also added a unit test for this.

### Updated `mixins.py`

Removed the following duplicate methods from `ExportViewMixin` and added to
`ImportExportMixin`:

```
def get_resource_class(self):
def get_resource_kwargs(self, request, *args, **kwargs):
```

Removed the following duplicate methods from `ExportViewMixin` and added to
`BaseImportMixin`:

```
def get_import_resource_class(self):
def get_import_formats(self):
def get_import_resource_kwargs(self, request, *args, **kwargs):
```

Removed the following duplicate methods from `ExportViewMixin` and added to
`BaseExportMixin`:

```
def get_export_formats(self):
def get_export_resource_class(self):
def get_export_resource_kwargs(self, request, *args, **kwargs):
def get_export_filename(self, file_format):
```

### Updated `admin.py`

I didn't rename any classes here because they might be part of the public API.

- `ImportMixin` now subclasses `BaseImportMixin` (and `ImportExportMixinBase`)

- Updated `ImportMixin`: Removed the following duplicate methods (now inherited
  from `BaseImportMixin`):

```
def get_resource_kwargs(self, request, *args, **kwargs):
def get_import_resource_kwargs(self, request, *args, **kwargs):
def get_resource_class(self):
def get_import_resource_class(self):
def get_import_formats(self):
```

- `ExportMixin` now subclasses `BaseExportMixin` (and `ImportExportMixinBase`)

- Updated `ExportMixin`: Removed the following duplicate methods (now inherited
  from `BaseExportMixin`):

```
def get_resource_kwargs(self, request, *args, **kwargs):
def get_export_resource_kwargs(self, request, *args, **kwargs):
def get_resource_class(self):
def get_export_resource_class(self):
def get_export_formats(self):

# I kept this filename for API compatibility, even though 'request' and
# 'queryset' are not used
def get_export_filename(self, request, queryset, file_format):
```

**Acceptance Criteria**

#### Test coverage

- increased `admin.py` coverage to 100%
- increased `mixins.py` coverage to 100%

### Testing

- Ran test suite
- Manually exported & imported Book
- Manually exported Category (using 'action' menu)