### PR TITLE
import_action: Added check for dataset.headers (#1192)

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -232,6 +232,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         if not self.has_import_permission(request):
             raise PermissionDenied
 
+        resource = None
         context = self.get_import_context_data()
 
         import_formats = self.get_import_formats()
@@ -259,33 +260,40 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     data = force_str(data, self.from_encoding)
                 dataset = input_format.create_dataset(data)
             except UnicodeDecodeError as e:
-                return HttpResponse(_(u"<h1>Imported file has a wrong encoding: %s</h1>" % e))
+                form.add_error('import_file', _(f"imported file has a wrong encoding: {str(e)}"))
             except Exception as e:
-                return HttpResponse(_(u"<h1>%s encountered while trying to read file: %s</h1>" % (type(e).__name__, import_file.name)))
+                form.add_error('import_file',
+                               _(f"'{type(e).__name__}' encountered while trying to read file. "
+                                 "Ensure you have chosen the correct format for the file. "
+                                 f"{str(e)}"))
 
-            # prepare kwargs for import data, if needed
-            res_kwargs = self.get_import_resource_kwargs(request, form=form, *args, **kwargs)
-            resource = self.get_import_resource_class()(**res_kwargs)
+            if not form.errors and not dataset.headers:
+                form.add_error('import_file', _("the import file does not contain a valid header on row 1"))
 
-            # prepare additional kwargs for import_data, if needed
-            imp_kwargs = self.get_import_data_kwargs(request, form=form, *args, **kwargs)
-            result = resource.import_data(dataset, dry_run=True,
-                                          raise_errors=False,
-                                          file_name=import_file.name,
-                                          user=request.user,
-                                          **imp_kwargs)
+            if not form.errors:
+                # prepare kwargs for import data, if needed
+                res_kwargs = self.get_import_resource_kwargs(request, form=form, *args, **kwargs)
+                resource = self.get_import_resource_class()(**res_kwargs)
 
-            context['result'] = result
+                # prepare additional kwargs for import_data, if needed
+                imp_kwargs = self.get_import_data_kwargs(request, form=form, *args, **kwargs)
+                result = resource.import_data(dataset, dry_run=True,
+                                              raise_errors=False,
+                                              file_name=import_file.name,
+                                              user=request.user,
+                                              **imp_kwargs)
 
-            if not result.has_errors() and not result.has_validation_errors():
-                initial = {
-                    'import_file_name': tmp_storage.name,
-                    'original_file_name': import_file.name,
-                    'input_format': form.cleaned_data['input_format'],
-                }
-                confirm_form = self.get_confirm_import_form()
-                initial = self.get_form_kwargs(form=form, **initial)
-                context['confirm_form'] = confirm_form(initial=initial)
+                context['result'] = result
+
+                if not result.has_errors() and not result.has_validation_errors():
+                    initial = {
+                        'import_file_name': tmp_storage.name,
+                        'original_file_name': import_file.name,
+                        'input_format': form.cleaned_data['input_format'],
+                    }
+                    confirm_form = self.get_confirm_import_form()
+                    initial = self.get_form_kwargs(form=form, **initial)
+                    context['confirm_form'] = confirm_form(initial=initial)
         else:
             res_kwargs = self.get_import_resource_kwargs(request, form=form, *args, **kwargs)
             resource = self.get_import_resource_class()(**res_kwargs)
@@ -295,7 +303,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         context['title'] = _("Import")
         context['form'] = form
         context['opts'] = self.model._meta
-        context['fields'] = [f.column_name for f in resource.get_user_visible_fields()]
+        context['fields'] = [f.column_name for f in resource.get_user_visible_fields()] if resource else []
 
         request.current_app = self.admin_site.name
         return TemplateResponse(request, [self.import_template_name],

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -28,8 +28,10 @@
       {% csrf_token %}
 
       <p>
-        {% trans "This importer will import the following fields: " %}
-        <code>{{ fields|join:", " }}</code>
+        {% if fields %}
+          {% trans "This importer will import the following fields: " %}
+          <code>{{ fields|join:", " }}</code>
+        {% endif %}
       </p>
 
       <fieldset class="module aligned">

--- a/tests/core/exports/books-with-empty-header-row.csv
+++ b/tests/core/exports/books-with-empty-header-row.csv
@@ -1,0 +1,3 @@
+
+id,name,author_email
+1,Some book,test@example.com

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -490,36 +490,6 @@ class TestImportExportActionModelAdmin(ImportExportActionModelAdmin):
         return mock_storage
 
 
-class ImportActionDecodeErrorTest(TestCase):
-    mock_model = mock.Mock(spec=Book)
-    mock_model.__name__ = "mockModel"
-    mock_site = mock.MagicMock()
-    mock_request = MagicMock(spec=HttpRequest)
-    mock_request.POST = {'a': 1}
-    mock_request.FILES = {}
-
-    @mock.patch("import_export.admin.ImportForm")
-    def test_import_action_handles_UnicodeDecodeError(self, mock_form):
-        mock_form.is_valid.return_value = True
-        b_arr = b'\x00\x00'
-        m = TestImportExportActionModelAdmin(self.mock_model, self.mock_site,
-                                                  UnicodeDecodeError('codec', b_arr, 1, 2, 'fail!'))
-        res = m.import_action(self.mock_request)
-        self.assertEqual(
-            "<h1>Imported file has a wrong encoding: \'codec\' codec can\'t decode byte 0x00 in position 1: fail!</h1>",
-            res.content.decode())
-
-    @mock.patch("import_export.admin.ImportForm")
-    def test_import_action_handles_error(self, mock_form):
-        mock_form.is_valid.return_value = True
-        m = TestImportExportActionModelAdmin(self.mock_model, self.mock_site,
-                                                  ValueError("fail"))
-        res = m.import_action(self.mock_request)
-        self.assertRegex(
-            res.content.decode(),
-            r"<h1>ValueError encountered while trying to read file: .*</h1>")
-
-
 class ExportActionAdminIntegrationTest(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
**Problem**

If one tries to import a file with an empty first row via the Admin site, then there is a confusing exception reported.

**Solution**

How did you solve the problem?

- Add a check for `dataset.headers` in admin `import_action()`, and add a form error if there is no header row.
- Added a check in `import.html` for the presence of the 'fields' property - this will not be populated if there is an error.
- Errors raised during import are now presented as form errors instead of returned in the HTTP response.
  - This could affect the way that clients handle these errors, so have marked the PR as 'breaking change'. 
 - Test class `ImportActionDecodeErrorTest` is removed (superseded by new form error tests)

**Acceptance Criteria**

- Added unit tests
- Ran test suite