### PR TITLE
Simplify get_export_filename

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -435,7 +435,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         return super().changelist_view(request, extra_context)
 
     def get_export_filename(self, request, queryset, file_format):
-        return super().get_filename(file_format)
+        return super().get_export_filename(file_format)
 
 
 class ImportExportMixin(ImportMixin, ExportMixin):

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -61,7 +61,7 @@ class BaseExportMixin(BaseImportExportMixin):
         return resource_class(**self.get_export_resource_kwargs(request, *args, **kwargs))\
             .export(queryset, *args, **kwargs)
 
-    def get_filename(self, file_format):
+    def get_export_filename(self, file_format):
         date_str = now().strftime('%Y-%m-%d')
         filename = "%s-%s.%s" % (self.model.__name__,
                                  date_str,
@@ -113,6 +113,3 @@ class ExportViewFormMixin(ExportViewMixin, FormView):
 
         post_export.send(sender=None, model=self.model)
         return response
-
-    def get_export_filename(self, file_format):
-        return super().get_filename(file_format)


### PR DESCRIPTION
Further simplify `get_export_filename`.

@matthewhegarty this is what I meant here: https://github.com/django-import-export/django-import-export/pull/1277/files#diff-4faa8df298a05dc4474064942a1f01c316b6501091d1a4baa3095b3b1435cfa5R64

Tests are passing.