### PR TITLE
added support for 'to_encoding' attribute

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ isort
 psycopg2-binary
 mysqlclient
 coveralls
+chardet

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+       isort
        {py36,py37,py38,py39}-django22-tablib{dev,stable}
        {py36,py37,py38,py39}-django31-tablib{dev,stable}
        {py36,py37,py38,py39}-django32-tablib{dev,stable}
@@ -19,4 +20,4 @@ deps =
 [testenv:isort]
 skip_install = True
 deps = isort
-commands = isort --check-only import_export/ tests/
+commands = isort --check-only import_export tests


### PR DESCRIPTION
**Problem**

The admin.py class has a `to_encoding` attribute, but it is not used (see #1305).  There was a PR (#245) for this but it was reverted in commit d331cb56.

**Solution**

A new kwarg is added to `get_export_data()` so that the encoding attribute can be passed.  By default `to_encoding` is None, meaning that there is no op and export data defaults to 'utf-8'.  If `to_encoding` is set, then export data is called with `encode()`.

**Acceptance Criteria**

- New unit and integration tests have been added.
- Tested manual exports from Admin console.
