### PR TITLE
Fixes: (xls/xlsx) Time fields rejected on import even though they are valid

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -117,3 +117,4 @@ The following is a list of much appreciated contributors:
 * jinmay (jinmyeong Cho)
 * DonQueso89 (Kees van Ekeren)
 * yazdanRa (Yazdan Ranjbar)
+* Gabriel Warkentin

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -1,5 +1,5 @@
 import json
-from datetime import date, datetime
+from datetime import date, datetime, time
 from decimal import Decimal
 
 import django
@@ -257,6 +257,8 @@ class TimeWidget(Widget):
     def clean(self, value, row=None, *args, **kwargs):
         if not value:
             return None
+        if isinstance(value, time):
+            return value
         for format in self.formats:
             try:
                 return datetime.strptime(value, format).time()

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -172,6 +172,8 @@ class TimeWidgetTest(TestCase):
         with self.assertRaisesRegex(ValueError, "Enter a valid time."):
             self.widget.clean("20:15:00")
 
+    def test_clean_returns_time_when_time_passed(self):
+        self.assertEqual(self.time, self.widget.clean(self.time))
 
 class DurationWidgetTest(TestCase):
 


### PR DESCRIPTION
Fixes #1313 

Was receiving "Enter a valid time" errors for time fields because tablib is already parsing these fields into python datetime objects, then it tries to convert them again in the clean method. This was already done with same method for the DateWidget and DateTimeWidget classes.

I did not test the change on the DurationWidget. I assume it will have the same issue, but I've never used timedelta fields before.
