### PR TITLE
fix get_import_resource_class refactor

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -1,6 +1,12 @@
 name: django-import-export CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   test:

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -26,7 +26,7 @@ class BaseImportMixin(BaseImportExportMixin):
         """
         Returns ResourceClass to use for import.
         """
-        return super().get_resource_class()
+        return self.get_resource_class()
 
     def get_import_formats(self):
         """
@@ -35,7 +35,7 @@ class BaseImportMixin(BaseImportExportMixin):
         return [f for f in self.formats if f().can_import()]
 
     def get_import_resource_kwargs(self, request, *args, **kwargs):
-        return super().get_resource_kwargs(request, *args, **kwargs)
+        return self.get_resource_kwargs(request, *args, **kwargs)
 
 
 class BaseExportMixin(BaseImportExportMixin):
@@ -51,10 +51,10 @@ class BaseExportMixin(BaseImportExportMixin):
         """
         Returns ResourceClass to use for export.
         """
-        return super().get_resource_class()
+        return self.get_resource_class()
 
     def get_export_resource_kwargs(self, request, *args, **kwargs):
-        return super().get_resource_kwargs(request, *args, **kwargs)
+        return self.get_resource_kwargs(request, *args, **kwargs)
 
     def get_data_for_export(self, request, queryset, *args, **kwargs):
         resource_class = self.get_export_resource_class()


### PR DESCRIPTION
**Problem**

[This commit](https://github.com/django-import-export/django-import-export/commit/e1873a931367299d95863ab3dfabf1bb4dedf1af) produced a regression in one of my applications. The method `get_resource_class` is no longer called on the `ModelAdmin`.

**Solution**

Use original code, `self` was changed for `super()` in the refactor.

**Acceptance Criteria**

Local testing only. Will add tests if the change makes sense.