### PR TITLE
Import file without show screen to confirm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist/
 *.sw[po]
 
 tests/database.db
+.vscode/settings.json
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ dist/
 *.sw[po]
 
 tests/database.db
-.vscode/settings.json
+.vscode/
 venv/

--- a/AUTHORS
+++ b/AUTHORS
@@ -117,3 +117,4 @@ The following is a list of much appreciated contributors:
 * jinmay (jinmyeong Cho)
 * DonQueso89 (Kees van Ekeren)
 * yazdanRa (Yazdan Ranjbar)
+* flaviosilva-iteris

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -104,6 +104,11 @@ decreasing it, or speed up exports by increasing it.
 Can be overridden on a ``Resource`` class by setting the ``chunk_size`` class
 attribute.
 
+``PROCESS_WITHOUT_SHOW_CONFIRM_FORM``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If that environment variable is true, the form to confirm 
+data inside the file to import won´t be shown and the file will be imported.
 
 Example app
 ===========

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -65,6 +65,12 @@ of losing an audit trail.
 Can be overridden on a ``ModelAdmin`` class inheriting from ``ImportMixin`` by
 setting the ``skip_admin_log`` class attribute.
 
+``IMPORT_EXPORT_SKIP_ADMIN_CONFIRM_FORM``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If that environment variable is true, the form to confirm 
+data inside the file to import won´t be shown and the file will be imported.
+
 ``IMPORT_EXPORT_TMP_STORAGE_CLASS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -103,12 +109,6 @@ decreasing it, or speed up exports by increasing it.
 
 Can be overridden on a ``Resource`` class by setting the ``chunk_size`` class
 attribute.
-
-``PROCESS_WITHOUT_SHOW_CONFIRM_FORM``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If that environment variable is true, the form to confirm 
-data inside the file to import won´t be shown and the file will be imported.
 
 Example app
 ===========

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -283,7 +283,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                 confirm_form = self.get_confirm_import_form()
                 # If that flag is true, the file has sent will be processed without show the confirmation form
                 # In multi-container architecture, it's impossible to ensure where the file will be saved to be imported after data confirmation.
-                if getattr(settings, 'PROCESS_WITHOUT_SHOW_CONFIRM_FORM', False):
+                if getattr(settings, 'IMPORT_EXPORT_SKIP_ADMIN_CONFIRM_FORM', False):
                     result = self.process_dataset(
                         dataset, confirm_form, request, *args, original_file_name=import_file.name
                     )

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -281,8 +281,6 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
             if not result.has_errors() and not result.has_validation_errors():
                 confirm_form = self.get_confirm_import_form()
-                # If that flag is true, the file has sent will be processed without show the confirmation form
-                # In multi-container architecture, it's impossible to ensure where the file will be saved to be imported after data confirmation.
                 if getattr(settings, 'IMPORT_EXPORT_SKIP_ADMIN_CONFIRM_FORM', False):
                     result = self.process_dataset(
                         dataset, confirm_form, request, *args, original_file_name=import_file.name

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -348,7 +348,7 @@ class ImportExportAdminIntegrationTest(TestCase):
                 1, 0, EBook._meta.verbose_name_plural)
         )
 
-    @override_settings(PROCESS_WITHOUT_SHOW_CONFIRM_FORM=True)
+    @override_settings(IMPORT_EXPORT_SKIP_ADMIN_CONFIRM_FORM=True)
     def test_import_without_show_confirm_form(self):
         """
         Test if process work without show the confirm form to import file

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -190,7 +190,7 @@ class ImportExportAdminIntegrationTest(TestCase):
             'exports',
             'books.csv')
         data = {
-            'input_format': "0",
+            'input_format': "0", 
             'import_file_name': import_file_name,
             'original_file_name': 'books.csv'
         }
@@ -346,6 +346,28 @@ class ImportExportAdminIntegrationTest(TestCase):
             response,
             _('Import finished, with {} new and {} updated {}.').format(
                 1, 0, EBook._meta.verbose_name_plural)
+        )
+
+    @override_settings(PROCESS_WITHOUT_SHOW_CONFIRM_FORM=True)
+    def test_import_without_show_confirm_form(self):
+        """
+        Test if process work without show the confirm form to import file
+        """
+        Author.objects.create(id=11, name='Test Author')
+
+        input_format = '0'
+        filename = os.path.join(os.path.dirname(__file__), os.path.pardir, 'exports', 'books.csv')
+        with open(filename, "rb") as fobj:
+            data = {'author': 11, 
+                    'input_format': input_format, 
+                    'import_file': fobj}
+            response = self.client.post('/admin/core/ebook/import/', data, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            _('Import finished, with {} new and {} updated {}.').format(
+                1, 0, EBook._meta.verbose_name_plural),
         )
 
     def test_get_skip_admin_log_attribute(self):
@@ -576,3 +598,4 @@ class TestExportEncoding(TestCase):
             self.export_mixin.export_admin_action(self.mock_request, list())
             encoding_kwarg = mock_get_export_data.call_args_list[0][1]["encoding"]
             self.assertEqual("utf-8", encoding_kwarg)
+

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -190,7 +190,7 @@ class ImportExportAdminIntegrationTest(TestCase):
             'exports',
             'books.csv')
         data = {
-            'input_format': "0", 
+            'input_format': "0",
             'import_file_name': import_file_name,
             'original_file_name': 'books.csv'
         }


### PR DESCRIPTION
Problem

Currently, when we want to import a file, in the first screen django-import-export send that file to save it in the server's temp directory and return a form where there is the file's data to user confirm if they want to import it. After the user's confirmation, the library uses the file saved on the temp directory and import its data.

When an app has two or more containers provisioned, that approach doesn't work because it's impossible to ensure the same container where the file has been created will be the same container that will receive the request to import that file.

Solution

Implemented a new feature that if the environment variable "PROCESS_WITHOUT_SHOW_CONFIRM_FORM" is true, the file will be imported directly without showing the screen to confirm data inside of that. This way, it's possible to ensure the same file sent will be imported into the database.

Acceptance Criteria

If the environment variable "PROCESS_WITHOUT_SHOW_CONFIRM_FORM" is false, the library must work as it works nowadays. If true, the confirmation form mustn't show and the file has to be imported.

Have you written tests?  Yes, I have (tests/core/tests/test_admin_integration.py, test_import_without_show_confirm_form)
Have you included screenshots of your changes if applicable? No, It's not applicable.
Did you document your changes?  Yes,