### PR TITLE
updated import.css to support dark mode (#1318)

### DIFF
--- a/import_export/static/import_export/import.css
+++ b/import_export/static/import_export/import.css
@@ -79,3 +79,37 @@ table.import-preview tr.update {
   font-weight: bold;
   font-size: 0.85em;
 }
+
+@media (prefers-color-scheme: dark) {
+  table.import-preview tr.skip {
+    background-color: #2d2d2d;
+  }
+
+  table.import-preview tr.new {
+    background-color: #42274d;
+  }
+
+  table.import-preview tr.delete {
+    background-color: #064140;
+  }
+
+  table.import-preview tr.update {
+    background-color: #020230;
+  }
+
+  .validation-error-container {
+    background-color: #003e3e;
+  }
+
+  /*
+  these declarations are necessary to forcibly override the
+  formatting applied by the diff-match-patch python library
+   */
+  table.import-preview td ins {
+    background-color: #190019 !important;
+  }
+
+  table.import-preview td del {
+    background-color: #001919 !important;
+  }
+}


### PR DESCRIPTION
**Problem**

If the browser is switched to 'dark mode', then the confirm import page does not render correctly (reported in #1318).

**Solution**

Updated import.css to override colors using the 'prefers-color-scheme: dark' media query.

Colors were chosen by finding the [inverse](https://pinetools.com/invert-color) of the existing color.

**Acceptance Criteria**

- manually tested import using browser light and dark mode
- checked the existing admin site to confirm that it renders correctly in dark mode.

![darkmode1](https://user-images.githubusercontent.com/6249838/131226936-e7c9ac73-470c-4202-b3e6-9652a6575ed4.png)
