### PR TITLE
added guard for null 'options' to fix crash (#1163)

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -181,7 +181,7 @@ class DeclarativeMetaclass(type):
                 # Collect the Meta options
                 options = getattr(base, 'Meta', None)
                 for option in [option for option in dir(options)
-                               if not option.startswith('_')]:
+                               if not option.startswith('_') and hasattr(options, option)]:
                     setattr(meta, option, getattr(options, option))
 
         # Add direct fields
@@ -198,7 +198,7 @@ class DeclarativeMetaclass(type):
         # Add direct options
         options = getattr(new_class, 'Meta', None)
         for option in [option for option in dir(options)
-                       if not option.startswith('_')]:
+                       if not option.startswith('_') and hasattr(options, option)]:
             setattr(meta, option, getattr(options, option))
         new_class._meta = meta
 

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -94,6 +94,15 @@ class ResourceTestCase(TestCase):
         self.assertIsInstance(self.my_resource._meta,
                               resources.ResourceOptions)
 
+    @mock.patch("builtins.dir")
+    def test_new_handles_null_options(self, mock_dir):
+        # #1163 - simulates a call to dir() returning additional attributes
+        mock_dir.return_value = ['attrs']
+        class A(MyResource):
+            pass
+
+        A()
+
     def test_get_export_order(self):
         self.assertEqual(self.my_resource.get_export_headers(),
                          ['email', 'name', 'extra'])


### PR DESCRIPTION
**Problem**

If the [forbiddenfruit](https://github.com/clarete/forbiddenfruit) library is installed, then crashes are seen at object instantiation.

The cause is that when forbiddenfruit is installed, calling [`dir()` on a null object](https://github.com/django-import-export/django-import-export/blob/89e52409787b36ea1f03e8eab2bfa68dc58e8a63/import_export/resources.py#L183) returns additional properties.  The logic attempts to get these properties from a null `options` reference, which causes the crash:

```
'NoneType' object has no attribute 'attrs' 
```

#1163 

**Solution**

This fix adds a check that `options` is not None.

**Acceptance Criteria**

- Ran tests with `forbiddenfruit` installed
- A test which simulates the problem is included.
- Have tested Admin console manually.