### PR TITLE
Added python3.10 to tox environment list

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 4
       matrix:
         db: [ sqlite, postgres, mysql ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10" ]
         django-version: [ 2.2, 3.0, 3.1, 3.2, main ]
         include:
           - db: postgres
@@ -30,6 +30,14 @@ jobs:
             python-version: 3.6
           - django-version: main
             python-version: 3.7
+          - django-version: 2.2
+            python-version: "3.10"
+          - django-version: 3.0
+            python-version: "3.10"
+          - django-version: 3.1
+            python-version: "3.10"
+          - django-version: 3.2
+            python-version: "3.10"
     services:
       mysql:
         image: mysql:8.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Big integer support for Integer widget (#788)
 - Run compilemessages command to keep .mo files in sync (#1299)
 - Added `skip_html_diff` meta attribute (#1329)
+- Added python3.10 to tox and CI environment list (#1336)
 - Add ability to rollback the import on validation error (#1339)
 - Fix missing migration on example app (#1346)
 - Fix crash when deleting via admin site (#1347)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3 :: Only',
     'Topic :: Software Development',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
        isort
-       {py36,py37,py38,py39}-django22-tablib{dev,stable}
-       {py36,py37,py38,py39}-django31-tablib{dev,stable}
-       {py36,py37,py38,py39}-django32-tablib{dev,stable}
-       {py38,py39}-djangomain-tablib{dev,stable}
+       {py36,py37,py38,py39,py310}-django22-tablib{dev,stable}
+       {py36,py37,py38,py39,py310}-django31-tablib{dev,stable}
+       {py36,py37,py38,py39,py310}-django32-tablib{dev,stable}
+       {py38,py39,py310}-djangomain-tablib{dev,stable}
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning {toxinidir}/tests/manage.py test core


### PR DESCRIPTION
**Problem**

Now that [python 3.10](https://docs.python.org/3.10/whatsnew/3.10.html) is available, I have added it to the list of supported python releases.

Whilst testing this, I noticed tox failures for >= 3.9 only, because support for pytz was dropped in that release.  However, since pytz is still a dependency for Django, I added it to the import list in `test.txt`, since it is required for `test_widgets.py`.

**Solution**

- Updated files to reference python 3.10.

**Acceptance Criteria**

Ran full tox run through locally.