### PR TITLE
Add an ability to rollback the import on validation error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,3 +118,4 @@ The following is a list of much appreciated contributors:
 * DonQueso89 (Kees van Ekeren)
 * yazdanRa (Yazdan Ranjbar)
 * Gabriel Warkentin
+* striveforbest (Alex Zagoro)


### PR DESCRIPTION
**Problem**
Inability to roll back a transaction in case of `ValidationError`. Currently, the lib only supports rolling back on exceptions other than `ValidationError`

**Solution**
Provide a mechanism to roll back on `ValidationError` without breaking the current design.

This PR Implements support for the `rollback_on_validation_error` argument being passed to the `import_data` method that controls the flow. Defaults to False.

**Acceptance Criteria**
- Testcase added
- Docstring updated

See [conversation](https://github.com/django-import-export/django-import-export/issues/1338) with @matthewhegarty.