### PR TITLE
(example app) fix crash on migrate when test dependencies not installed (issue 1125)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -110,9 +110,9 @@ Example app
 
 There's an example application that showcases what django-import-export can do.
 It's assumed that you have set up a Python ``venv`` with all required dependencies
-or are otherwise able to run Django locally.
+(from ``test.txt`` requirements file) and are able to run Django locally.
 
-You can run it via::
+You can run the example application as follows::
 
     cd tests
     ./manage.py makemigrations

--- a/tests/core/migrations/0004_bookwithchapters.py
+++ b/tests/core/migrations/0004_bookwithchapters.py
@@ -1,7 +1,10 @@
 from django.db import migrations, models
 
 can_use_postgres_fields = False
-chapters_field = models.Field()  # Dummy field
+
+# Dummy fields
+chapters_field = models.Field()
+data_field = models.Field()
 
 try:
     from django.contrib.postgres.fields import ArrayField, JSONField
@@ -10,7 +13,7 @@ try:
     data_field = JSONField(null=True)
     can_use_postgres_fields = True
 except ImportError:
-    # We can't use ArrayField if psycopg2 is not installed
+    # We can't use ArrayField if psycopg2 is not installed - issue #1125
     pass
 
 


### PR DESCRIPTION
**Problem**

If the example app is installed from scratch and the test.txt requirements file has not been installed, then there is a crash when `./manage.py migrate` is run.  (see #1125).  Although users should install the test dependencies, it's not clear that they should do this.  There might be cases where they don't want or need to install test dependencies.

**Solution**

- Adding an extra dummy field prevents the crash (thanks to josx)
- Updated the documentation to clarify that `test.txt` needs to be installed.

**Acceptance Criteria**

- No tests - code changes the test app migration
- I reproduced the issue (detailed in #1125) and proved that it is resolved with this patch.