### PR TITLE
Fix for crash when deleting via admin site

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Run compilemessages command to keep .mo files in sync (#1299)
 - Add ability to rollback the import on validation error (#1339)
 - Fix missing migration on example app (#1346)
+- Fix crash when deleting via admin site (#1347)
 
 2.6.1 (2021-09-30)
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -9,6 +10,7 @@ sys.path.append(os.path.abspath('../tests'))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
 import django
+
 django.setup()
 
 # -- General configuration -----------------------------------------------------
@@ -42,6 +44,7 @@ copyright = '2012–2020, Bojan Mihelac'
 #
 try:
     from import_export import __version__
+
     # The short X.Y version.
     version = '.'.join(__version__.split('.')[:2])
     # The full version, including alpha/beta/rc tags.

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -664,6 +664,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                         diff.compare_with(self, None, dry_run)
                 else:
                     row_result.import_type = RowResult.IMPORT_TYPE_DELETE
+                    row_result.add_instance_info(instance)
                     self.delete_instance(instance, using_transactions, dry_run)
                     if not skip_diff:
                         diff.compare_with(self, None, dry_run)
@@ -682,9 +683,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                     self.validate_instance(instance, import_validation_errors)
                     self.save_instance(instance, using_transactions, dry_run)
                     self.save_m2m(instance, row, using_transactions, dry_run)
-                    # Add object info to RowResult for LogEntry
-                    row_result.object_id = instance.pk
-                    row_result.object_repr = force_str(instance)
+                    row_result.add_instance_info(instance)
                 if not skip_diff:
                     diff.compare_with(self, instance, dry_run)
 

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django.core.exceptions import NON_FIELD_ERRORS
+from django.utils.encoding import force_str
 from tablib import Dataset
 
 
@@ -32,6 +33,14 @@ class RowResult:
         self.diff = None
         self.import_type = None
         self.raw_values = {}
+        self.object_id = None
+        self.object_repr = None
+
+    def add_instance_info(self, instance):
+        if instance is not None:
+            # Add object info to RowResult (e.g. for LogEntry)
+            self.object_id = getattr(instance, "pk", None)
+            self.object_repr = force_str(instance)
 
 
 class InvalidRow:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,4 @@ psycopg2-binary
 mysqlclient
 coveralls
 chardet
+pytz

--- a/tests/core/exports/books-for-delete.csv
+++ b/tests/core/exports/books-for-delete.csv
@@ -1,0 +1,2 @@
+id,name,author_email
+1,,test@example.com

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -1,3 +1,4 @@
+from core.models import Book
 from django.core.exceptions import ValidationError
 from django.test.testcases import TestCase
 from tablib import Dataset
@@ -30,3 +31,25 @@ class ResultTest(TestCase):
         row_result.errors = [error]
         self.result.append_failed_row(self.dataset.dict[0], row_result.errors[0])
         self.assertEqual(target, self.result.failed_dataset.dict)
+
+    def test_add_instance_info_null_instance(self):
+        row_result = RowResult()
+        row_result.add_instance_info(None)
+        self.assertEqual(None, row_result.object_id)
+        self.assertEqual(None, row_result.object_repr)
+
+    def test_add_instance_info_no_instance_pk(self):
+        row_result = RowResult()
+        row_result.add_instance_info(Book())
+        self.assertEqual(None, row_result.object_id)
+        self.assertEqual("", row_result.object_repr)
+
+    def test_add_instance_info(self):
+        class BookWithObjectRepr(Book):
+            def __str__(self):
+                return self.name
+
+        row_result = RowResult()
+        row_result.add_instance_info(BookWithObjectRepr(pk=1, name="some book"))
+        self.assertEqual(1, row_result.object_id)
+        self.assertEqual("some book", row_result.object_repr)


### PR DESCRIPTION
**Problem**

I have verified that there is a crash if one tries to delete records using the admin site (see #432).

**Solution**

The fix is simple - to add instance attributes to the `RowResult`.  

This introduced some code duplication, so I added a minor refactor of `RowResult` to set attributes via a new method.

- I also fixed sort order for `conf.py` attributes (raised by `make lint`).
- I added the `pytz` dependency which is needed for testing with python 3.9 (see #1336).
- Added test file `books-for-delete.csv`

**Acceptance Criteria**

- Integration test to prove the issue exists and is fixed (`test_admin_integration.py`)
- Added unit tests for the new `RowResult` method