### PR TITLE
Use Github secret in CI script instead of hard-coded password

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       USERNAME: testuser
-      PASSWD: somepass
+      PASSWD: ${{ secrets.TEST_PASSWD }}
     strategy:
       max-parallel: 4
       matrix:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 - Add ability to rollback the import on validation error (#1339)
 - Fix missing migration on example app (#1346)
 - Fix crash when deleting via admin site (#1347)
+- Use Github secret in CI script instead of hard-coded password (#1348)
 - Documentation: correct error in example application which leads to crash (#1353)
 
 2.6.1 (2021-09-30)


### PR DESCRIPTION
**Problem**

A minor improvement to the CI script.

The CI script was using a hard-coded password which is not ideal.  Best practice is to use a secret defined in Github.

**Solution**

The CI script now uses a Github secret instead of a hard-coded password.

**Acceptance Criteria**

Verified that the CI process ran ok, meaning the change is valid.