### PR TITLE
Big integer support for Integer widget (#788)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0-dev (unreleased)
 ---------
 
+- Big integer support for Integer widget (#788)
 - Run compilemessages command to keep .mo files in sync (#1299)
 - Add ability to rollback the import on validation error (#1339)
 - Fix missing migration on example app (#1346)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -85,7 +85,7 @@ class IntegerWidget(NumberWidget):
     def clean(self, value, row=None, *args, **kwargs):
         if self.is_empty(value):
             return None
-        return int(float(value))
+        return int(Decimal(value))
 
 
 class DecimalWidget(NumberWidget):

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from unittest import mock, skip, skipIf, skipUnless
 
 import django
@@ -625,8 +625,8 @@ class ModelResourceTest(TestCase):
         self.assertTrue(result.has_errors())
         self.assertTrue(result.rows[0].errors)
         actual = result.rows[0].errors[0].error
-        self.assertIsInstance(actual, ValueError)
-        self.assertIn("could not convert string to float", str(actual))
+        self.assertIsInstance(actual, (ValueError, InvalidOperation))
+        self.assertIn(str(actual), {"could not convert string to float", "[<class 'decimal.ConversionSyntax'>]"})
 
     def test_import_data_delete(self):
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -255,9 +255,13 @@ class IntegerWidgetTest(TestCase):
     def setUp(self):
         self.value = 0
         self.widget = widgets.IntegerWidget()
+        self.bigintvalue = 163371428940853127
 
     def test_clean_integer_zero(self):
         self.assertEqual(self.widget.clean(0), self.value)
+
+    def test_clean_big_integer(self):
+        self.assertEqual(self.widget.clean(163371428940853127), self.bigintvalue)
 
     def test_clean_string_zero(self):
         self.assertEqual(self.widget.clean("0"), self.value)


### PR DESCRIPTION

What problem have you solved?

Using interger widget with big interger generate overflow. check #788 

How did you solve the problem?

Change the use of `float` with `decimal` (more precision) in interget widget

Have you written tests?
- Create a new testing it
- I have changed tests to match decimal use.
