### PR TITLE
Documentation: correct error in example application which leads to crash

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 - Add ability to rollback the import on validation error (#1339)
 - Fix missing migration on example app (#1346)
 - Fix crash when deleting via admin site (#1347)
+- Documentation: correct error in example application which leads to crash (#1353)
 
 2.6.1 (2021-09-30)
 ------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,6 +2,14 @@
 Getting started
 ===============
 
+Test data
+=========
+
+There are test data files which can be used for importing in the `test/core/exports` directory.
+
+The test models
+===============
+
 For example purposes, we'll use a simplified book app. Here is our
 ``models.py``::
 
@@ -188,7 +196,9 @@ data structure on export, ``dehydrate_<fieldname>`` method should be defined::
             model = Book
 
         def dehydrate_full_title(self, book):
-            return '%s by %s' % (book.name, book.author.name)
+            book_name = getattr(book, "name", "unknown")
+            author_name = getattr(book.author, "name", "unknown")
+            return '%s by %s' % (book_name, author_name)
 
 In this case, the export looks like this:
 


### PR DESCRIPTION
**Problem**

Issue #778.  If one follows the documentation it can lead to a crash when trying to import a book with no author name.
This change fixes that error.

**Solution**

Updated the documentation so that the example gracefully handles book imports when there is no author name.

**Acceptance Criteria**

- No tests required
- Built documentation locally and verified the change is correct.