### PR TITLE
Removed `django_extensions` from example app settings.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,7 @@ Changelog
 2.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Removed `django_extensions` from example app settings (#1356)
 
 2.7.0 (2021-12-07)
 ------------------

--- a/tests/bulk/README.md
+++ b/tests/bulk/README.md
@@ -45,6 +45,10 @@ docker-compose -f bulk/docker-compose.yml up -d
 ./manage.py createsuperuser --username admin  --email=email@example.com
 ```
 
+### Update settings
+
+In order to use the `runscript` command, add `django_extensions` to `settings.py` (`INSTALLED_APPS`).
+
 ### Running script
 
 ```bash

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,7 +10,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.sites',
-    'django_extensions',
 
     'import_export',
 


### PR DESCRIPTION
**Problem**

Whilst testing #1329, I added `django_extensions` to `settings.py` so that the `runscript` command could be used during bulk testing.  However, this causes a crash (see issue #1355) if the `test.txt` dependencies are not used.

**Solution**

1. Removed `django_extensions` from settings.
2. Updated bulk testing readme.md to clarify that this needs to be installed if testing.

**Acceptance Criteria**

- Tested locally in a new virtualenv.
- No new tests necessary.  
- Ran the existing test suite.