### PR TITLE
drop support for python3.6

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 4
       matrix:
         db: [ sqlite, postgres, mysql ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
         django-version: [ 2.2, 3.0, 3.1, 3.2, 4.0, main ]
         include:
           - db: postgres
@@ -27,11 +27,7 @@ jobs:
             db_port: 3306
         exclude:
           - django-version: main
-            python-version: 3.6
-          - django-version: main
             python-version: 3.7
-          - django-version: 4.0
-            python-version: 3.6
           - django-version: 4.0
             python-version: 3.7
           - django-version: 2.2

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.2 (unreleased)
 ------------------
 
-- Drop support for python3.6
+- Drop support for python3.6 (#1364)
 
 
 2.7.1 (2021-12-23)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for python3.6
 
 
 2.7.1 (2021-12-23)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -53,7 +52,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=install_requires,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=CLASSIFIERS,
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
        isort
-       {py36,py37,py38,py39,py310}-django22-tablib{dev,stable}
-       {py36,py37,py38,py39,py310}-django31-tablib{dev,stable}
-       {py36,py37,py38,py39,py310}-django32-tablib{dev,stable}
+       {py37,py38,py39,py310}-django22-tablib{dev,stable}
+       {py37,py38,py39,py310}-django31-tablib{dev,stable}
+       {py37,py38,py39,py310}-django32-tablib{dev,stable}
        {py38,py39,py310}-django40-tablib{dev,stable}
        {py38,py39,py310}-djangomain-tablib{dev,stable}
 


### PR DESCRIPTION
**Problem**

Support for python3.6 ends on 23 Dec 2021.

**Solution**

This PR removes references to python3.6 from the repo.

**Acceptance Criteria**

- Full tox run