### PR TITLE
Drop support for django EOL versions

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -18,8 +18,8 @@ jobs:
       max-parallel: 4
       matrix:
         db: [ sqlite, postgres, mysql ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10" ]
-        django-version: [ 2.2, 3.0, 3.1, 3.2, 4.0, main ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        django-version: [ 3.2, 4.0, main ]
         include:
           - db: postgres
             db_port: 5432
@@ -27,19 +27,9 @@ jobs:
             db_port: 3306
         exclude:
           - django-version: main
-            python-version: 3.6
-          - django-version: main
             python-version: 3.7
           - django-version: 4.0
-            python-version: 3.6
-          - django-version: 4.0
             python-version: 3.7
-          - django-version: 2.2
-            python-version: "3.10"
-          - django-version: 3.0
-            python-version: "3.10"
-          - django-version: 3.1
-            python-version: "3.10"
           - django-version: 3.2
             python-version: "3.10"
     services:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,17 +18,22 @@ accommodate these changes.
 
 - Use 'create' flag instead of instance.pk (#1362)
    - ``import_export.resources.save_instance()`` now takes an additional mandatory argument: `is_create`.
-     If you have over-ridden `save_instance()` in your own code, you will need to add this new argument.#
+     If you have over-ridden `save_instance()` in your own code, you will need to add this new argument.
 
 - Add support for multiple resources in ModelAdmin. (#1223)
   - The `*Mixin.resource_class` accepting single resource has been deprecated (will work for few next versions) and
     the new `*Mixin.resource_classes` accepting subscriptable type (list, tuple, ...) has been added.
   - Same applies to all of the `get_resource_class`, `get_import_resource_class` and `get_export_resource_class` methods.
-     
+
 Enhancements
 ############
 
 - Updated import.css to support dark mode (#1370)
+
+Development
+###########
+
+- Drop support for python3.6, django 2.2, 3.0, 3.1 (#1366)
 
 2.7.1 (2021-12-23)
 ------------------

--- a/import_export/__init__.py
+++ b/import_export/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '2.7.2.dev0'
+__version__ = '3.0.0.dev0'

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -378,8 +378,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             'list_editable': self.list_editable,
             'model_admin': self,
         }
-        if django.VERSION >= (2, 1):
-            changelist_kwargs['sortable_by'] = self.sortable_by
+        changelist_kwargs['sortable_by'] = self.sortable_by
         if django.VERSION >= (4, 0):
             changelist_kwargs['search_help_text'] = self.search_help_text
         cl = ChangeList(**changelist_kwargs)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -4,11 +4,14 @@ import traceback
 from collections import OrderedDict
 from copy import deepcopy
 
-import django
 import tablib
 from diff_match_patch import diff_match_patch
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import (
+    FieldDoesNotExist,
+    ImproperlyConfigured,
+    ValidationError,
+)
 from django.core.management.color import no_style
 from django.core.paginator import Paginator
 from django.db import connections, router
@@ -29,12 +32,6 @@ from .instance_loaders import ModelInstanceLoader
 from .results import Error, Result, RowResult
 from .utils import atomic_if_using_transaction
 
-if django.VERSION[0] >= 3:
-    from django.core.exceptions import FieldDoesNotExist
-else:
-    from django.db.models.fields import FieldDoesNotExist
-
-
 logger = logging.getLogger(__name__)
 # Set default logging handler to avoid "No handler found" warnings.
 logger.addHandler(logging.NullHandler())
@@ -43,9 +40,6 @@ logger.addHandler(logging.NullHandler())
 def get_related_model(field):
     if hasattr(field, 'related_model'):
         return field.related_model
-    # Django 1.6, 1.7
-    if field.rel:
-        return field.rel.to
 
 
 class ResourceOptions:
@@ -1057,6 +1051,7 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         'BigAutoField': widgets.IntegerWidget,
         'NullBooleanField': widgets.BooleanWidget,
         'BooleanField': widgets.BooleanWidget,
+        'JSONField': widgets.JSONWidget,
     }
 
     @classmethod
@@ -1099,22 +1094,13 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         else:
             try:
                 from django.contrib.postgres.fields import ArrayField
-                try:
-                    from django.db.models import JSONField
-                except ImportError:
-                    from django.contrib.postgres.fields import JSONField
             except ImportError:
                 # ImportError: No module named psycopg2.extras
                 class ArrayField:
                     pass
 
-                class JSONField:
-                    pass
-
             if isinstance(f, ArrayField):
                 return widgets.SimpleArrayWidget
-            elif isinstance(f, JSONField):
-                return widgets.JSONWidget
 
         return result
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django>=2.2
+Django>=3.2
 tablib[html,ods,xls,xlsx,yaml]>=3.0.0
 diff-match-patch

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ VERSION = __import__("import_export").__version__
 
 CLASSIFIERS = [
     'Framework :: Django',
-    'Framework :: Django :: 2.2',
-    'Framework :: Django :: 3.1',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
     'Intended Audience :: Developers',
@@ -15,7 +13,6 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -26,7 +23,7 @@ CLASSIFIERS = [
 
 install_requires = [
     'diff-match-patch',
-    'Django>=2.2',
+    'Django>=3.2',
     'tablib[html,ods,xls,xlsx,yaml]>=3.0.0',
 ]
 
@@ -53,7 +50,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=install_requires,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=CLASSIFIERS,
     zip_safe=False,
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -50,8 +50,7 @@ TEMPLATES = [
     },
 ]
 
-if django.VERSION >= (3, 2):
-    DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 if os.environ.get('IMPORT_EXPORT_TEST_TYPE') == 'mysql-innodb':
     IMPORT_EXPORT_USE_TRANSACTIONS = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
 envlist =
        isort
-       {py36,py37,py38,py39,py310}-django22-tablib{dev,stable}
-       {py36,py37,py38,py39,py310}-django31-tablib{dev,stable}
-       {py36,py37,py38,py39,py310}-django32-tablib{dev,stable}
+       {py37,py38,py39,py310}-django32-tablib{dev,stable}
        {py38,py39,py310}-django40-tablib{dev,stable}
        {py38,py39,py310}-djangomain-tablib{dev,stable}
 
@@ -12,8 +10,6 @@ commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarni
 deps =
     tablibdev: -egit+https://github.com/jazzband/tablib.git#egg=tablib
     tablibstable: tablib
-    django22: Django>=2.2,<3.0
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     djangomain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
**Problem**

**This is for inclusion into Release 3**

Drops support for the following which are at EOL.

- python 3.6
- django 2.2, 3.0, 3.1
- Remove skipped test 
  - I checked the history of this test and could not confirm that it was serving any useful purpose, so decided to remove.
- Removed import of `JSONField` from `django.contrib.postgres.fields` because this is included in Django since 3.1

Planned for inclusion in 3.0 release