### PR TITLE
Fix crash on `import_data(Dataset(), collect_failed_rows=True)`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix crash when import_data() called with empty Dataset and `collect_failed_rows=True` (#1381)
 
 
 2.7.1 (2021-12-23)

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -106,6 +106,7 @@ class Result:
         self.base_errors.append(error)
 
     def add_dataset_headers(self, headers):
+        headers = list() if not headers else headers
         self.failed_dataset.headers = headers + ["Error"]
 
     def append_failed_row(self, row, error):

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -469,6 +469,11 @@ class ModelResourceTest(TestCase):
         self.assertIs(result.rows[0].import_type, results.RowResult.IMPORT_TYPE_INVALID)
         self.assertIn('birthday', result.invalid_rows[0].field_specific_errors)
 
+    def test_import_data_empty_dataset_with_collect_failed_rows(self):
+        resource = AuthorResource()
+        result = resource.import_data(tablib.Dataset(), collect_failed_rows=True)
+        self.assertEqual(['Error'], result.failed_dataset.headers)
+
     def test_collect_failed_rows(self):
         resource = ProfileResource()
         headers = ['id', 'user']

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -15,8 +15,18 @@ class ResultTest(TestCase):
         self.dataset = Dataset(*rows, headers=headers)
 
     def test_add_dataset_headers(self):
+        target = ['some_header', 'Error']
+        self.result.add_dataset_headers(['some_header'])
+        self.assertEqual(target, self.result.failed_dataset.headers)
+
+    def test_add_dataset_headers_empty_list(self):
         target = ['Error']
         self.result.add_dataset_headers([])
+        self.assertEqual(target, self.result.failed_dataset.headers)
+
+    def test_add_dataset_headers_None(self):
+        target = ['Error']
+        self.result.add_dataset_headers(None)
         self.assertEqual(target, self.result.failed_dataset.headers)
 
     def test_result_append_failed_row_with_ValidationError(self):


### PR DESCRIPTION
**Problem**

`import_data()` crashes when passed an empty dataset and `collect_failed_rows` is True.

See #1380 

**Solution**

Add check for `headers is None` and create empty list if so.

**Acceptance Criteria**

- Added unit tests.