### PR TITLE
Default format selections on export action

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -121,3 +121,4 @@ The following is a list of much appreciated contributors:
 * striveforbest (Alex Zagoro)
 * josx (José Luis Di Biase)
 * Jan Rydzewski
+* shimakaze-git

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,7 @@ Enhancements
 ############
 
 - Updated import.css to support dark mode (#1370)
+- Default format selections set correctly for export action (#1389)
 
 Development
 ###########

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -481,9 +481,11 @@ class ExportActionMixin(ExportMixin):
         choices = []
         formats = self.get_export_formats()
         if formats:
-            choices.append(('', '---'))
             for i, f in enumerate(formats):
                 choices.append((str(i), f().get_title()))
+
+        if len(formats) > 1:
+            choices.insert(0, ('', '---'))
 
         self.action_form = export_action_form_factory(choices)
         super().__init__(*args, **kwargs)

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -30,6 +30,7 @@ from import_export.admin import (
     ExportMixin,
     ImportExportActionModelAdmin,
 )
+from import_export.formats import base_formats
 from import_export.formats.base_formats import DEFAULT_FORMATS
 from import_export.tmp_storages import TempFolderStorage
 
@@ -606,6 +607,64 @@ class ExportActionAdminIntegrationTest(TestCase):
         m = TestMixin()
         with self.assertRaises(PermissionDenied):
             m.get_export_data('0', Book.objects.none(), request=request)
+
+    def test_export_admin_action_one_formats(self):
+        mock_model = mock.MagicMock()
+        mock_site = mock.MagicMock()
+
+        class TestCategoryAdmin(ExportActionModelAdmin):
+            def __init__(self):
+                super().__init__(mock_model, mock_site)
+
+            formats = [base_formats.CSV]
+
+        m = TestCategoryAdmin()
+        action_form = m.action_form
+ 
+        items = list(action_form.base_fields.items())
+        file_format = items[len(items)-1][1]
+        choices = file_format.choices
+
+        self.assertNotEqual(choices[0][0], '---')
+        self.assertEqual(choices[0][1], "csv")
+
+    def test_export_admin_action_formats(self):
+
+        mock_model = mock.MagicMock()
+        mock_site = mock.MagicMock()
+
+        class TestCategoryAdmin(ExportActionModelAdmin):
+            def __init__(self):
+                super().__init__(mock_model, mock_site)
+
+        class TestFormatsCategoryAdmin(ExportActionModelAdmin):
+            def __init__(self):
+                super().__init__(mock_model, mock_site)
+
+            formats = [base_formats.CSV, base_formats.JSON]
+
+        m = TestCategoryAdmin()
+        action_form = m.action_form
+ 
+        items = list(action_form.base_fields.items())
+        file_format = items[len(items)-1][1]
+        choices = file_format.choices
+
+        self.assertEqual(choices[0][1], "---")
+        self.assertEqual(len(choices), 9)
+
+        m = TestFormatsCategoryAdmin()
+        action_form = m.action_form
+ 
+        items = list(action_form.base_fields.items())
+        file_format = items[len(items)-1][1]
+        choices = file_format.choices
+
+        self.assertEqual(choices[0][1], "---")
+        self.assertEqual(len(m.formats) + 1, len(choices))
+
+        self.assertIn('csv', [c[1] for c in choices])
+        self.assertIn('json', [c[1] for c in choices])
 
 
 class TestExportEncoding(TestCase):


### PR DESCRIPTION
**Problem**

https://github.com/django-import-export/django-import-export/issues/1373

This is the PR for this issue.

When there is only one `formats` like the code below,the format on the Export action does not display  `---`.
By default, you can select the contents specified in formats.

```python
from import_export.admin import ExportActionModelAdmin
from import_export.formats import base_formats

class CategoryAdmin(ExportActionModelAdmin):

    formats = [base_formats.CSV]
```

**Solution**

In the `ExportActionMixin` constructor of `import_export/admin.py`, if the size of `formats` exceeds 1, add `---` to choices.

**Acceptance Criteria**

- After modifying `CategoryAdmin` in `tests/core/admin.py` as follows, I confirmed that the format of the Export action in the admin screen is csv.

- I added a [unit tests](https://github.com/django-import-export/django-import-export/pull/1389/files#diff-c7912cbcb2ed17b538f802a7329907437a1025d63f18fda8deeafd19c4f785c3).

![django-import-export-admin](https://user-images.githubusercontent.com/26370659/152962872-594a092a-f032-4595-8df2-5cc6300fd010.png)
