### PR TITLE
feat: adaptive column width

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -191,6 +191,10 @@ class XLSX(TablibFormat):
             dataset.append(row_values)
         return dataset
 
+    def export_data(self, dataset, column_width = "adaptive", **kwargs):
+        """column_width is adaptive by default"""
+        return dataset.export(self.get_title(), column_width, **kwargs)
+
 
 #: These are the default formats for import and export. Whether they can be
 #: used or not is depending on their implementation in the tablib library.


### PR DESCRIPTION
**Problem**

This PR changes column width to be adaptive and based on the values in column. The width will be the length of the longest entry in a column.

https://github.com/django-import-export/django-import-export/issues/500 is a somehow-related issue

**Solution**

The PR adopts a new feature for adaptive column width in tablib. It should be merged after https://github.com/jazzband/tablib/pull/516 will be merged and new version will be released.


**Acceptance Criteria**

I didn't write the tests as I didn't found any for XLSX exporting. Let me know if this is required

I didn't document the changes, as I didn't found the documentation on format classes. Let me know if this is required 