### PR TITLE
Simple Fix for #591

### DIFF
--- a/import_export/static/import_export/action_formats.js
+++ b/import_export/static/import_export/action_formats.js
@@ -1,22 +1,32 @@
-(function($) {
-  $(document).ready(function() {
-    var $actionsSelect, $formatsElement;
-    if ($('body').hasClass('grp-change-list')) {
-        // using grappelli
-        $actionsSelect = $('#grp-changelist-form select[name="action"]');
-        $formatsElement = $('#grp-changelist-form select[name="file_format"]');
-    } else {
-        // using default admin
-        $actionsSelect = $('#changelist-form select[name="action"]');
-        $formatsElement = $('#changelist-form select[name="file_format"]').parent();
-    }
-    $actionsSelect.change(function() {
-      if ($(this).val() === 'export_admin_action') {
-        $formatsElement.show();
-      } else {
-        $formatsElement.hide();
-      }
+(function ($) {
+    $(document).ready(function () {
+        var $actionsSelect, $formatsElement;
+        $actionsSelect = $('.actions select[name="action"]');
+        $formatsElement = $('.actions select[name="file_format"]');
+        if ($('body').hasClass('grp-change-list')) {
+            // using grappelli
+            $ShowElementToShow = $formatsElement;
+        } else {
+            // using default admin
+            $formatsElementToShow = $formatsElement.parent();
+        }
+        for (let i = 0; i < $actionsSelect.length; i++) {
+            $actionsSelect.eq(i).change(function () {
+                if ($(this).val() === 'export_admin_action') {
+                    $formatsElementToShow.eq(i).show();
+                } else {
+                    $formatsElementToShow.eq(i).hide();
+                }
+            });
+            $actionsSelect.eq(i).change();
+
+            $formatsElement.eq(i).change(function () {
+                for (let j = 0; j < $formatsElement.length; j++) {
+                    if ($formatsElement.eq(j).val() != $(this).val()) {
+                        $formatsElement.eq(j).val($(this).val());
+                    }
+                }
+            });
+        }
     });
-    $actionsSelect.change();
-  });
 })(django.jQuery);


### PR DESCRIPTION
Simple Fix for #591 (Exporting via admin action fails if actions_on_top and actions_on_bottom available #591)
Allow use of actions_on_top and actions_on_bottom at the same time.

**Problem**

What problem have you solved?
- Exporting via admin action fails if both of actions_on_top and actions_on_bottom available #591
- when you select the export_admin_action at any action area (top or bottom) the file_format input appears in all the action area not only the one of interest
- at submision of export action it will fail the last (bottom) file_format input not filled and neglegt the one at the top action area

**Solution**

How did you solve the problem?
- using selectors eq() to differentiate between the top and bottom areas 
- update all the file_format inputs on change of any one of them to be all aligned
