### PR TITLE
Drop support for EOL dependencies

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -18,8 +18,8 @@ jobs:
       max-parallel: 4
       matrix:
         db: [ sqlite, postgres, mysql ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10" ]
-        django-version: [ 2.2, 3.0, 3.1, 3.2, 4.0, main ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        django-version: [ 3.2, 4.0, main ]
         include:
           - db: postgres
             db_port: 5432
@@ -27,19 +27,9 @@ jobs:
             db_port: 3306
         exclude:
           - django-version: main
-            python-version: 3.6
-          - django-version: main
             python-version: 3.7
           - django-version: 4.0
-            python-version: 3.6
-          - django-version: 4.0
             python-version: 3.7
-          - django-version: 2.2
-            python-version: "3.10"
-          - django-version: 3.0
-            python-version: "3.10"
-          - django-version: 3.1
-            python-version: "3.10"
           - django-version: 3.2
             python-version: "3.10"
     services:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-2.7.2 (unreleased)
+2.8.0 (unreleased)
 ------------------
 
 - Updated import.css to support dark mode (#1318)
 - Fix crash when import_data() called with empty Dataset and `collect_failed_rows=True` (#1381)
-- Improve korean translation (#1402)
+- Improve Korean translation (#1402)
+- Drop support for python3.6, django 2.2, 3.0, 3.1 (#1408)
 
 2.7.1 (2021-12-23)
 ------------------

--- a/import_export/__init__.py
+++ b/import_export/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '2.7.2.dev0'
+__version__ = '2.8.0.dev0'

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -371,8 +371,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             'list_editable': self.list_editable,
             'model_admin': self,
         }
-        if django.VERSION >= (2, 1):
-            changelist_kwargs['sortable_by'] = self.sortable_by
+        changelist_kwargs['sortable_by'] = self.sortable_by
         if django.VERSION >= (4, 0):
             changelist_kwargs['search_help_text'] = self.search_help_text
         cl = ChangeList(**changelist_kwargs)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django>=2.2
+Django>=3.2
 tablib[html,ods,xls,xlsx,yaml]>=3.0.0
 diff-match-patch

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ VERSION = __import__("import_export").__version__
 
 CLASSIFIERS = [
     'Framework :: Django',
-    'Framework :: Django :: 2.2',
-    'Framework :: Django :: 3.1',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
     'Intended Audience :: Developers',
@@ -26,7 +24,7 @@ CLASSIFIERS = [
 
 install_requires = [
     'diff-match-patch',
-    'Django>=2.2',
+    'Django>=3.2',
     'tablib[html,ods,xls,xlsx,yaml]>=3.0.0',
 ]
 
@@ -53,7 +51,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=install_requires,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=CLASSIFIERS,
     zip_safe=False,
 )

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -3,13 +3,17 @@ from collections import OrderedDict
 from copy import deepcopy
 from datetime import date
 from decimal import Decimal, InvalidOperation
-from unittest import mock, skip, skipIf, skipUnless
+from unittest import mock, skipIf, skipUnless
 
 import django
 import tablib
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import (
+    FieldDoesNotExist,
+    ImproperlyConfigured,
+    ValidationError,
+)
 from django.core.paginator import Paginator
 from django.db import IntegrityError
 from django.db.models import Count
@@ -34,11 +38,6 @@ from ..models import (
     WithDynamicDefault,
     WithFloatField,
 )
-
-if django.VERSION[0] >= 3:
-    from django.core.exceptions import FieldDoesNotExist
-else:
-    from django.db.models.fields import FieldDoesNotExist
 
 
 class MyResource(resources.Resource):
@@ -408,21 +407,6 @@ class ModelResourceTest(TestCase):
                          '<span>Some </span><ins style="background:#e6ffe6;">'
                          'other </ins><span>book</span>')
         self.assertFalse(html[headers.index('author_email')])
-
-    @skip("See: https://github.com/django-import-export/django-import-export/issues/311")
-    def test_get_diff_with_callable_related_manager(self):
-        resource = AuthorResource()
-        author = Author(name="Some author")
-        author.save()
-        author2 = Author(name="Some author")
-        self.book.author = author
-        self.book.save()
-        diff = Diff(self.resource, author, False)
-        diff.compare_with(self.resource, author2)
-        html = diff.as_html()
-        headers = resource.get_export_headers()
-        self.assertEqual(html[headers.index('books')],
-                         '<span>core.Book.None</span>')
 
     def test_import_data(self):
         result = self.resource.import_data(self.dataset, raise_errors=True)
@@ -1244,19 +1228,15 @@ class PostgresTests(TransactionTestCase):
         except IntegrityError:
             self.fail('IntegrityError was raised.')
 
+
 if 'postgresql' in settings.DATABASES['default']['ENGINE']:
     from django.contrib.postgres.fields import ArrayField
     from django.db import models
-    try:
-        from django.db.models import JSONField
-    except ImportError:
-        from django.contrib.postgres.fields import JSONField
-
 
     class BookWithChapters(models.Model):
         name = models.CharField('Book name', max_length=100)
         chapters = ArrayField(models.CharField(max_length=100), default=list)
-        data = JSONField(null=True)
+        data = models.JSONField(null=True)
 
 
     class BookWithChaptersResource(resources.ModelResource):
@@ -1741,7 +1721,6 @@ class BulkCreateTest(BulkTest):
         self.assertIsNotNone(resource.get_or_init_instance(ModelInstanceLoader(resource), self.dataset[0]))
 
 
-@skipIf(django.VERSION[0] == 2 and django.VERSION[1] < 2, "bulk_update not supported in this version of django")
 class BulkUpdateTest(BulkTest):
     class _BookResource(resources.ModelResource):
         class Meta:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -50,8 +50,7 @@ TEMPLATES = [
     },
 ]
 
-if django.VERSION >= (3, 2):
-    DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 if os.environ.get('IMPORT_EXPORT_TEST_TYPE') == 'mysql-innodb':
     IMPORT_EXPORT_USE_TRANSACTIONS = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
 envlist =
        isort
-       {py36,py37,py38,py39,py310}-django22-tablib{dev,stable}
-       {py36,py37,py38,py39,py310}-django31-tablib{dev,stable}
-       {py36,py37,py38,py39,py310}-django32-tablib{dev,stable}
+       {py37,py38,py39,py310}-django32-tablib{dev,stable}
        {py38,py39,py310}-django40-tablib{dev,stable}
        {py38,py39,py310}-djangomain-tablib{dev,stable}
 


### PR DESCRIPTION
**Problem**

Drops support for the following which are past EOL.  This was reviewed in #1366 for inclusion in 3.0 release.  This release pushes it into the main repo for inclusion in 2.8.0.

- python 3.6
- django 2.2, 3.0, 3.1
- Remove skipped test 
  - I checked the history of this test and could not confirm that it was serving any useful purpose, so decided to remove.
- Removed import of `JSONField` from `django.contrib.postgres.fields` because this is included in Django since 3.1
