### PR TITLE
Feat add get export form to export mixin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,3 +122,4 @@ The following is a list of much appreciated contributors:
 * josx (José Luis Di Biase)
 * Jan Rydzewski
 * 2ykwang (Yeongkwang Yang)
+* KamilRizatdinov (Kamil Rizatdinov)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Updated import.css to support dark mode (#1318)
 - Fix crash when import_data() called with empty Dataset and `collect_failed_rows=True` (#1381)
 - Improve korean translation (#1402)
+- Add get_export_form() to ExportMixin (#1409)
 
 2.7.1 (2021-12-23)
 ------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -400,12 +400,19 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
     def get_context_data(self, **kwargs):
         return {}
 
+    def get_export_form(self):
+        """
+        Get the form type used to read the export format.
+        """
+        return ExportForm
+
     def export_action(self, request, *args, **kwargs):
         if not self.has_export_permission(request):
             raise PermissionDenied
 
         formats = self.get_export_formats()
-        form = ExportForm(formats, request.POST or None)
+        form_type = self.get_export_form()
+        form = form_type(formats, request.POST or None)
         if form.is_valid():
             file_format = formats[
                 int(form.cleaned_data['file_format'])

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest
 from django.test.testcases import TestCase
 from django.urls import reverse
 
-from import_export import formats, forms, mixins
+from import_export import admin, formats, forms, mixins
 
 
 class ExportViewMixinTest(TestCase):
@@ -203,3 +203,24 @@ class BaseExportMixinTest(TestCase):
         formats = m.get_export_formats()
         self.assertEqual(1, len(formats))
         self.assertEqual('CanExportFormat', formats[0].__name__)
+
+
+class ExportMixinTest(TestCase):
+    class TestExportMixin(admin.ExportMixin):
+        def __init__(self, export_form) -> None:
+            super().__init__()
+            self.export_form = export_form
+
+        def get_export_form(self):
+            return self.export_form
+
+    class TestExportForm(forms.ExportForm):
+        pass
+    
+    def test_get_export_form(self):
+        m = admin.ExportMixin()
+        self.assertEqual(forms.ExportForm, m.get_export_form())
+
+    def test_get_export_form_with_custom_form(self):
+        m = self.TestExportMixin(self.TestExportForm)
+        self.assertEqual(self.TestExportForm, m.get_export_form())


### PR DESCRIPTION
**Problem**

What problem have you solved?

You can see how hard it is to use the custom export form. You have to override the whole [export_action()](https://github.com/django-import-export/django-import-export/blob/26977ed44ff8f2c9769b14bc69f0b41f3524da6d/import_export/admin.py#L403) method.
https://stackoverflow.com/a/67653671/17465982 referes to this problem as well

**Solution**

How did you solve the problem?

Introduced the get_export_form() method on ExportMixin as an analogue to [get_import_form()](https://github.com/django-import-export/django-import-export/blob/26977ed44ff8f2c9769b14bc69f0b41f3524da6d/import_export/admin.py#L177) from ImportMixin

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 

Yes, I've written the test cases to ensure that both the base functionality and functionality work
I used the docstrings for the get_export_form() method, think that's a sufficient documentation