### PR TITLE
Fix widgets incorrect method definitions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,7 @@ This release makes some minor changes to the public API.  If you have overridden
 
   - If you have overridden `clean()` then you will need to update your method definition to reflect this change.
 
-  - `widgets.ForeignKeyWidget` / `widgets.ManyToManyWidget`: The unused `*args` param has been removed from `__init__()`.  If you have overridden `ForeignKeyWidget` you may need to update your implementation to reflect this change.
+  - `widgets.ForeignKeyWidget` / `widgets.ManyToManyWidget`: The unused `*args` param has been removed from `__init__()`.  If you have overridden `ForeignKeyWidget` or `ManyToManyWidget` you may need to update your implementation to reflect this change.
 
 Deprecations
 ############

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,16 +7,25 @@ Changelog
 Breaking changes
 ################
 
-This release makes some minor changes to the public API.  If you have overridden any methods from the `resources` module, you may need to update your implementation to accommodate these changes.
+This release makes some minor changes to the public API.  If you have overridden any methods from the `resources` or `widgets` modules, you may need to update your implementation to accommodate these changes.
 
 - Check value of ManyToManyField in skip_row() (#1271)
+
     - This fixes an issue where ManyToMany fields are not checked correctly in `skip_row()`.  This means that `skip_row()` now takes `row` as a mandatory arg.  If you have overridden `skip_row()` in your own implementation, you will need to add `row` as an arg.
 
 - Bug fix: validation errors were being ignored when `skip_unchanged` is set (#1378)
-  - If you have overridden `skip_row()` you can choose whether or not to skip rows if validation errors are present.  The default behavior is to not to skip rows if there are validation errors during import.
+
+    - If you have overridden `skip_row()` you can choose whether or not to skip rows if validation errors are present.  The default behavior is to not to skip rows if there are validation errors during import.
 
 - Use 'create' flag instead of instance.pk (#1362)
+
     - `import_export.resources.save_instance()` now takes an additional mandatory argument: `is_create`.  If you have overridden `save_instance()` in your own code, you will need to add this new argument.
+
+- `widgets`: Unused `*args` params have been removed from method definitions. (#1412)
+
+  - If you have overridden `clean()` then you will need to update your method definition to reflect this change.
+
+  - `widgets.ForeignKeyWidget` / `widgets.ManyToManyWidget`: The unused `*args` param has been removed from `__init__()`.  If you have overridden `ForeignKeyWidget` you may need to update your implementation to reflect this change.
 
 Deprecations
 ############
@@ -25,9 +34,9 @@ This release adds some deprecations which will be removed in the 3.1 release.
 
 - Add support for multiple resources in ModelAdmin. (#1223)
 
-   - The `*Mixin.resource_class` accepting single resource has been deprecated and the new `*Mixin.resource_classes` accepting subscriptable type (list, tuple, ...) has been added.
+  - The `*Mixin.resource_class` accepting single resource has been deprecated and the new `*Mixin.resource_classes` accepting subscriptable type (list, tuple, ...) has been added.
 
-   - Same applies to all of the `get_resource_class`, `get_import_resource_class` and `get_export_resource_class` methods.
+  - Same applies to all of the `get_resource_class`, `get_import_resource_class` and `get_export_resource_class` methods.
 
 - Deprecated `exceptions.py` (#1372)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,7 @@ This release makes some minor changes to the public API.  If you have overridden
 
     - `import_export.resources.save_instance()` now takes an additional mandatory argument: `is_create`.  If you have overridden `save_instance()` in your own code, you will need to add this new argument.
 
-- `widgets`: Unused `*args` params have been removed from method definitions. (#1412)
+- `widgets`: Unused `*args` params have been removed from method definitions. (#1413)
 
   - If you have overridden `clean()` then you will need to update your method definition to reflect this change.
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -28,7 +28,7 @@ class Widget:
     :meth:`~import_export.widgets.Widget.clean` and
     :meth:`~import_export.widgets.Widget.render`.
     """
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         """
         Returns an appropriate Python object for an imported value.
 
@@ -71,7 +71,7 @@ class FloatWidget(NumberWidget):
     Widget for converting floats fields.
     """
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if self.is_empty(value):
             return None
         return float(value)
@@ -82,7 +82,7 @@ class IntegerWidget(NumberWidget):
     Widget for converting integer fields.
     """
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if self.is_empty(value):
             return None
         return int(Decimal(value))
@@ -93,7 +93,7 @@ class DecimalWidget(NumberWidget):
     Widget for converting decimal fields.
     """
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if self.is_empty(value):
             return None
         return Decimal(force_str(value))
@@ -152,7 +152,7 @@ class BooleanWidget(Widget):
             return ""
         return self.TRUE_VALUES[0] if value else self.FALSE_VALUES[0]
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if value in self.NULL_VALUES:
             return None
         return True if value in self.TRUE_VALUES else False
@@ -175,7 +175,7 @@ class DateWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if not value:
             return None
         if isinstance(value, date):
@@ -211,7 +211,7 @@ class DateTimeWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if not value:
             return None
         if isinstance(value, datetime):
@@ -254,7 +254,7 @@ class TimeWidget(Widget):
             formats = (format,)
         self.formats = formats
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if not value:
             return None
         if isinstance(value, time):
@@ -277,7 +277,7 @@ class DurationWidget(Widget):
     Widget for converting time duration fields.
     """
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if not value:
             return None
 
@@ -305,7 +305,7 @@ class SimpleArrayWidget(Widget):
         self.separator = separator
         super().__init__()
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         return value.split(self.separator) if value else []
 
     def render(self, value, obj=None):
@@ -321,7 +321,7 @@ class JSONWidget(Widget):
     tries to use single quotes and then convert it to proper JSON.
     """
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         val = super().clean(value)
         if val:
             try:
@@ -376,11 +376,11 @@ class ForeignKeyWidget(Widget):
     :param use_natural_foreign_keys: Use natural key functions to identify 
         related object, default to False
     """
-    def __init__(self, model, field='pk', use_natural_foreign_keys=False, *args, **kwargs):
+    def __init__(self, model, field='pk', use_natural_foreign_keys=False, **kwargs):
         self.model = model
         self.field = field
         self.use_natural_foreign_keys = use_natural_foreign_keys
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def get_queryset(self, value, row, *args, **kwargs):
         """
@@ -405,7 +405,7 @@ class ForeignKeyWidget(Widget):
         """
         return self.model.objects.all()
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         val = super().clean(value)
         if val:
             if self.use_natural_foreign_keys:
@@ -413,7 +413,7 @@ class ForeignKeyWidget(Widget):
                 value = json.loads(value) 
                 return self.model.objects.get_by_natural_key(*value)
             else:
-                return self.get_queryset(value, row, *args, **kwargs).get(**{self.field: val})
+                return self.get_queryset(value, row, **kwargs).get(**{self.field: val})
         else:
             return None
 
@@ -449,7 +449,7 @@ class ManyToManyWidget(Widget):
     :param field: A field on the related model. Default is ``pk``.
     """
 
-    def __init__(self, model, separator=None, field=None, *args, **kwargs):
+    def __init__(self, model, separator=None, field=None, **kwargs):
         if separator is None:
             separator = ','
         if field is None:
@@ -457,9 +457,9 @@ class ManyToManyWidget(Widget):
         self.model = model
         self.separator = separator
         self.field = field
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(self, value, row=None, **kwargs):
         if not value:
             return self.model.objects.none()
         if isinstance(value, (float, int)):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -320,8 +320,8 @@ class ForeignKeyWidgetTest(TestCase):
         author2.birthday = "2016-01-01"
         author2.save()
         birthday_widget = BirthdayWidget(Author, 'name')
-        row = {'name': "Foo", 'birthday': author2.birthday}
-        self.assertEqual(birthday_widget.clean("Foo", row), author2)
+        row_dict = {'name': "Foo", 'birthday': author2.birthday}
+        self.assertEqual(birthday_widget.clean("Foo", row=row_dict), author2)
 
     def test_invalid_get_queryset(self):
         class BirthdayWidget(widgets.ForeignKeyWidget):
@@ -331,9 +331,9 @@ class ForeignKeyWidgetTest(TestCase):
                 )
 
         birthday_widget = BirthdayWidget(Author, 'name')
-        row = {'name': "Foo", 'age': 38}
+        row_dict = {'name': "Foo", 'age': 38}
         with self.assertRaises(TypeError):
-            birthday_widget.clean("Foo", row, row_number=1)
+            birthday_widget.clean("Foo", row=row_dict, row_number=1)
 
     def test_render_handles_value_error(self):
         class TestObj(object):


### PR DESCRIPTION
**Problem**

Method definitions are defined incorrectly in `widgets.py`.  See #1412.

**Solution**

Change the interface for `clean()` to remove the unused `args` param.

```python 
# old
def clean(self, value, row=None, *args, **kwargs):

# new
def clean(self, value, row=None, **kwargs):
```

Also, changed the constructors for `ForeignKeyWidget` / `ManyToManyWidget`.

**Acceptance Criteria**

- Ran test suite.
- Described breaking changes in changelog.