### PR TITLE
CharWidget optimisations

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Breaking changes
 
 This release makes some minor changes to the public API.  If you have overridden any methods from the `resources` module, you may need to update your implementation to accommodate these changes.
 
-- Check value of ManyToManyField in skip_row() (#1271)
+- Check value of `ManyToManyField` in skip_row() (#1271)
     - This fixes an issue where ManyToMany fields are not checked correctly in `skip_row()`.  This means that `skip_row()` now takes `row` as a mandatory arg.  If you have overridden `skip_row()` in your own implementation, you will need to add `row` as an arg.
 
 - Bug fix: validation errors were being ignored when `skip_unchanged` is set (#1378)
@@ -36,7 +36,8 @@ Enhancements
 
 - Default format selections set correctly for export action (#1389)
 - Added option to store raw row values in each row's `RowResult` (#1393)
-- Add natural key support to ForeignKeyWidget (#1371)
+- Add natural key support to `ForeignKeyWidget` (#1371)
+- Optimised default instantiation of `CharWidget` (#1414)
 
 Development
 ###########

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1048,6 +1048,7 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         'ManyToManyField': 'get_m2m_widget',
         'OneToOneField': 'get_fk_widget',
         'ForeignKey': 'get_fk_widget',
+        'CharField': widgets.CharWidget,
         'DecimalField': widgets.DecimalWidget,
         'DateTimeField': widgets.DateTimeWidget,
         'DateField': widgets.DateWidget,

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -103,9 +103,7 @@ class CharWidget(Widget):
     """
     Widget for converting text fields.
     """
-
-    def render(self, value, obj=None):
-        return force_str(value)
+    pass
 
 
 class BooleanWidget(Widget):

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -1303,6 +1303,15 @@ class ModelResourceFactoryTest(TestCase):
         self.assertEqual(BookResource._meta.model, Book)
 
 
+class WidgetFromDjangoFieldTest(TestCase):
+
+    def test_widget_from_django_field_for_CharField_returns_CharWidget(self):
+        f = CharField()
+        resource = BookResource()
+        w = resource.widget_from_django_field(f)
+        self.assertEqual(widgets.CharWidget, w)
+
+
 @skipUnless(
     'postgresql' in settings.DATABASES['default']['ENGINE'],
     'Run only against Postgres')
@@ -1326,6 +1335,7 @@ class PostgresTests(TransactionTestCase):
         resource = BookResource()
         res = resource.widget_from_django_field(f)
         self.assertEqual(widgets.SimpleArrayWidget, res)
+
 
 if 'postgresql' in settings.DATABASES['default']['ENGINE']:
     from django.contrib.postgres.fields import ArrayField

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -13,6 +13,28 @@ from django.utils import timezone
 from import_export import widgets
 
 
+class WidgetTest(TestCase):
+    def setUp(self):
+        self.widget = widgets.Widget()
+
+    def test_clean(self):
+        self.assertEqual("a", self.widget.clean("a"))
+
+    def test_render(self):
+        self.assertEqual("1", self.widget.render(1))
+
+
+class CharWidgetTest(TestCase):
+    def setUp(self):
+        self.widget = widgets.CharWidget()
+
+    def test_clean(self):
+        self.assertEqual("a", self.widget.clean("a"))
+
+    def test_render(self):
+        self.assertEqual("1", self.widget.render(1))
+
+
 class BooleanWidgetTest(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
**Problem**

`CharWidget` did not appear in `resources.WIDGET_MAP` - this is not an issue because the functionality of `CharWidget` is equivalent to `Widget`.  However this does mean that there is a redundant method in `CharWidget` which I have removed.

**Solution**

- Updated `WIDGETS_MAP` to return `CharWidget` for `CharField` for consistency.
- Removed redundant method `render()` from `CharWidget` (it is equivalent to the `Widget` method)

**Acceptance Criteria**

- Added tests