### PR TITLE
Fix failure when CacheStorage enabled and file contains LF char

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,7 @@ Enhancements
 - Added option to store raw row values in each row's `RowResult` (#1393)
 - Add natural key support to `ForeignKeyWidget` (#1371)
 - Optimised default instantiation of `CharWidget` (#1414)
+- Fixed handling of LF character when using `CacheStorage` (#)
 
 Development
 ###########

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,7 +43,7 @@ Enhancements
 - Added option to store raw row values in each row's `RowResult` (#1393)
 - Add natural key support to `ForeignKeyWidget` (#1371)
 - Optimised default instantiation of `CharWidget` (#1414)
-- Fixed handling of LF character when using `CacheStorage` (#)
+- Fixed handling of LF character when using `CacheStorage` (#1417)
 
 Development
 ###########

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 Django>=3.2
-tablib[html,ods,xls,xlsx,yaml]>=3.0.0
+tablib[html,ods,xls,xlsx,yaml]>=3.2.1
 diff-match-patch

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ CLASSIFIERS = [
 install_requires = [
     'diff-match-patch',
     'Django>=3.2',
-    'tablib[html,ods,xls,xlsx,yaml]>=3.0.0',
+    'tablib[html,ods,xls,xlsx,yaml]>=3.2.1',
 ]
 
 

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -1,7 +1,7 @@
 import os.path
 import warnings
 from datetime import datetime
-from unittest import mock, skip
+from unittest import mock
 from unittest.mock import MagicMock
 
 import chardet
@@ -692,7 +692,6 @@ class ConfirmImportEncodingTest(TestCase):
     def test_import_action_handles_CacheStorage_read(self):
         self.assert_string_in_response('books.csv', '0')
 
-    @skip("waiting for fix in tablib - see #1397")
     @override_settings(IMPORT_EXPORT_TMP_STORAGE_CLASS='import_export.tmp_storages.CacheStorage')
     def test_import_action_handles_CacheStorage_read_mac(self):
         self.assert_string_in_response('books-mac.csv', '0')
@@ -778,7 +777,6 @@ class CompleteImportEncodingTest(TestCase):
     def test_import_action_handles_CacheStorage_read(self):
         self.assert_string_in_response('books.csv', '0')
 
-    @skip("waiting for fix in tablib - see #1397")
     @override_settings(IMPORT_EXPORT_TMP_STORAGE_CLASS='import_export.tmp_storages.CacheStorage')
     def test_import_action_handles_CacheStorage_read_mac(self):
         self.assert_string_in_response('books-mac.csv', '0')


### PR DESCRIPTION
**Problem**

#1397 Imports fail when CacheStorage is enabled and the file contains LF char.

**Solution**

This was an issue in tablib which was fixed in release 3.2.1.
This means that django-import-now requires tablib 3.2.1 as a minimum dependency.

**Acceptance Criteria**

- Integration tests are included which verifies the fix.
- Manually tested steps to reproduce from issue