### PR TITLE
Remove unnecessary files generated when running tox locally

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -19,6 +19,7 @@ jobs:
       IMPORT_EXPORT_POSTGRESQL_PASSWORD: somepass
       IMPORT_EXPORT_MYSQL_USER: root
       IMPORT_EXPORT_MYSQL_PASSWORD: root
+      COVERAGE: 1
     strategy:
       matrix:
         python-version:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Fix broken link to tablib formats page (#1418)
 - Fix broken image ref in `README.rst`
 - Include custom form media in templates (#1038)
+- Remove unnecessary files generated when running tox locally (#1426)
 
 3.0.0-beta.1 (2022-04-11)
 -------------------------

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,22 @@
+"""
+Helper script to generate coverage data only if running in CI.
+This script is called from tox (see tox.ini).
+Coverage files are generated only if a `COVERAGE` environment variable is present.
+This is necessary to prevent unwanted coverage files when running locally (issue #1424)
+"""
+import os
+
+
+def main():
+    coverage_args = "-m coverage run" if os.environ.get("COVERAGE") else ""
+
+    os.system(
+        "python -W error::DeprecationWarning -W error::PendingDeprecationWarning "
+        f"{coverage_args} "
+        "./tests/manage.py test core --settings=settings"
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -119,8 +119,6 @@ class ImportExportAdminIntegrationTest(TestCase):
             response = self.client.post('/admin/core/book/import/', data)
         self.assertEqual(response.status_code, 200)
         self.assertIn('result', response.context)
-        with open("response.html", "wb") as f:
-            f.write(response.content)
         self.assertFalse(response.context['result'].has_errors())
         self.assertIn('confirm_form', response.context)
         confirm_form = response.context['confirm_form']

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/tests
-commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run {toxinidir}/tests/manage.py test core
+commands = python ./runtests.py
 deps =
     tablibdev: -egit+https://github.com/jazzband/tablib.git#egg=tablib
     django32: Django>=3.2,<4.0
@@ -25,6 +25,7 @@ deps =
 
 # if postgres / mysql environment variables exist, we can go ahead and run db specific tests
 passenv =
+    COVERAGE
     IMPORT_EXPORT_POSTGRESQL_USER
     IMPORT_EXPORT_POSTGRESQL_PASSWORD
     IMPORT_EXPORT_MYSQL_USER


### PR DESCRIPTION
**Problem**

Fixes issue #1424 
Coverage files and 'response.html' get generated when running locally

**Solution**

- Removed the unused write to `response.html`
- Added an Env var which gets set in CI only, and which indicates that coverage data should be generated.
- Added a new script `runtests.py` which adds the `COVERAGE` env var if present

**Acceptance Criteria**

- Tested locally
- Tested in CI