### PR TITLE
add mixin to support drf views

### DIFF
--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -68,7 +68,7 @@ class BaseExportMixin(BaseImportExportMixin):
 
     def get_export_filename(self, file_format):
         date_str = now().strftime('%Y-%m-%d')
-        filename = "%s-%s.%s" % (self.model.__name__,
+        filename = "%s-%s.%s" % (self.resource_class.Meta.model.__name__,
                                  date_str,
                                  file_format.get_extension())
         return filename

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -120,7 +120,7 @@ class ExportViewFormMixin(ExportViewMixin, FormView):
         return response
 
 
-class ExportModelDRFMixin(BaseExportMixin):
+class ExportModelDRFMixin(ExportViewMixin):
     """
     Export a queryset.
     """


### PR DESCRIPTION
**Problem**
I just wanted to integrate this great library with django-rest-framework, so I could use export capability of library beside ListModelMixin in drf
**Solution**

I developed a mixin with one drf.action so if you inherit it in your view, you can export your queryset in your APIs 
**Acceptance Criteria**
this is work with swagger, so its look like this image.
![image](https://user-images.githubusercontent.com/24705793/165039666-1d336b10-b829-452f-ba50-54e2be3a5efe.png)
