### PR TITLE
Fix AttributeError bug caused by using id in skip_row instead of pk

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -630,7 +630,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                 if len(instance_values) != len(original_values):
                     return False
 
-                if sorted(v.id for v in instance_values) != sorted(v.id for v in original_values):
+                if sorted(v.pk for v in instance_values) != sorted(v.pk for v in original_values):
                     return False
             else:
                 if field.get_value(instance) != field.get_value(original):


### PR DESCRIPTION
**Problem**

Crash caused by the problem described in this issue https://github.com/django-import-export/django-import-export/issues/1435 . A recent commit uses the `id` field of instances instead of `pk` which causes crashes.

**Solution**

Use `pk` field which universally works to designate the primary key of an instance, instead of `id`

**Acceptance Criteria**

I have added a comment to make sure no one introduces a regression on this.
Writing tests for this would require significant additions to the test infrastructure (adding a model with a different pk than id and associated `Resource`). I don't have the time resources to do this.