### PR TITLE
Fix deprecation: Added support for transitional form renderer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix deprecation: Added support for transitional form renderer (#1449)
 
 
 2.8.0 (2022-03-31)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.8.1 (unreleased)
 ------------------
 
-- Fix deprecation: Added support for transitional form renderer (#1449)
+- Fix deprecation in example application: Added support for transitional form renderer (#1449)
 
 
 2.8.0 (2022-03-31)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.8.1 (unreleased)
 ------------------
 
-- Fix deprecation in example application: Added support for transitional form renderer (#1449)
+- Fix deprecation in example application: Added support for transitional form renderer (#1451)
 
 
 2.8.0 (2022-03-31)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -108,3 +108,5 @@ LOGGING = {
 
 
 USE_TZ = False
+if django.VERSION >= (4, 1):
+    FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"


### PR DESCRIPTION
**Problem**

Fixes #1449.  This affects the example application only.

There is a form template in the test app (`category_list.html`).  This uses a `{{ form }}` tag.  For django 4.1 this means that there has to be a [declaration of the form renderer to use](https://docs.djangoproject.com/en/dev/releases/4.1/#forms-4-1). 

**Solution**

This change adds a conditional FormRenderer to test settings when the Django version is 4.1.

**Acceptance Criteria**

- Ran unit tests
- Manually checked the HTML rendering of http://localhost:8000/export/category/ before and after the addition of the setting.  The form still renders ok.

 
[form_after.html.txt](https://github.com/django-import-export/django-import-export/files/8888964/form_after.html.txt)
[form_before.html.txt](https://github.com/django-import-export/django-import-export/files/8888965/form_before.html.txt)
