### PR TITLE
Autodetect the format through the extension

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -124,3 +124,4 @@ The following is a list of much appreciated contributors:
 * 2ykwang (Yeongkwang Yang)
 * KamilRizatdinov (Kamil Rizatdinov)
 * Mark Walker
+* HaPyTeX (Willem Van Onsem)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Fix deprecation in example application: Added support for transitional form renderer (#1451)
+- Automatically guess the format of the file when importing (#1460)
 
 
 2.8.0 (2022-03-31)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -295,7 +295,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         context['title'] = _("Import")
         context['form'] = form
         context['opts'] = self.model._meta
-        context['media'] = self.media
+        context['media'] = self.media + form.media
         context['fields'] = [f.column_name for f in resource.get_user_visible_fields()]
 
         request.current_app = self.admin_site.name

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -295,6 +295,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         context['title'] = _("Import")
         context['form'] = form
         context['opts'] = self.model._meta
+        context['media'] = self.media
         context['fields'] = [f.column_name for f in resource.get_user_visible_fields()]
 
         request.current_app = self.admin_site.name

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -1,6 +1,7 @@
 import os.path
 
 from django import forms
+from django.conf import settings
 from django.contrib.admin.helpers import ActionForm
 from django.utils.translation import gettext_lazy as _
 
@@ -28,11 +29,19 @@ class ImportForm(forms.Form):
         self.fields['input_format'].choices = choices
 
     class Media:
-        js = (
-            'vendor/jquery/jquery.min.js',
-            'jquery.init.js',
-            'import_export/guess_format.js',
-        )
+        if settings.DEBUG:
+            js = (
+                'admin/js/vendor/jquery/jquery.js',
+                'admin/js/jquery.init.js',
+                'import_export/guess_format.js',
+            )
+        else:
+            js = (
+                'admin/js/vendor/jquery/jquery.min.js',
+                'admin/js/jquery.init.js',
+                'import_export/guess_format.js',
+            )
+
 
 
 class ConfirmImportForm(forms.Form):

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -29,7 +29,7 @@ class ImportForm(forms.Form):
 
     class Media:
         js = (
-            'vendor/jquery/jquery.js',
+            'vendor/jquery/jquery.min.js',
             'jquery.init.js',
             'import_export/guess_format.js',
         )

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -28,7 +28,11 @@ class ImportForm(forms.Form):
         self.fields['input_format'].choices = choices
 
     class Media:
-        js = ('import_export/guess_format.js', )
+        js = (
+            'vendor/jquery/jquery.js',
+            'jquery.init.js',
+            'import_export/guess_format.js',
+        )
 
 
 class ConfirmImportForm(forms.Form):

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -8,21 +8,27 @@ from django.utils.translation import gettext_lazy as _
 class ImportForm(forms.Form):
     import_file = forms.FileField(
         label=_('File to import')
-        )
+    )
     input_format = forms.ChoiceField(
         label=_('Format'),
         choices=(),
-        )
+    )
 
     def __init__(self, import_formats, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        choices = []
-        for i, f in enumerate(import_formats):
-            choices.append((str(i), f().get_title(),))
+        choices = [
+            (str(i), f().get_title())
+            for i, f in enumerate(import_formats)
+        ]
         if len(import_formats) > 1:
             choices.insert(0, ('', '---'))
+            self.fields['import_file'].widget.attrs['class'] = 'guess_format'
+            self.fields['input_format'].widget.attrs['class'] = 'guess_format'
 
         self.fields['input_format'].choices = choices
+
+    class Media:
+        js = ('import_export/guess_format.js', )
 
 
 class ConfirmImportForm(forms.Form):

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -29,19 +29,12 @@ class ImportForm(forms.Form):
         self.fields['input_format'].choices = choices
 
     class Media:
-        if settings.DEBUG:
-            js = (
-                'admin/js/vendor/jquery/jquery.js',
-                'admin/js/jquery.init.js',
-                'import_export/guess_format.js',
-            )
-        else:
-            js = (
-                'admin/js/vendor/jquery/jquery.min.js',
-                'admin/js/jquery.init.js',
-                'import_export/guess_format.js',
-            )
-
+        extra = "" if settings.DEBUG else ".min"
+        js = (
+            f'admin/js/vendor/jquery/jquery{extra}.js',
+            'admin/js/jquery.init.js',
+            'import_export/guess_format.js',
+        )
 
 
 class ConfirmImportForm(forms.Form):

--- a/import_export/static/import_export/guess_format.js
+++ b/import_export/static/import_export/guess_format.js
@@ -4,7 +4,7 @@
       var files = this.files;
       var dropdowns = $(this.form).find('select.guess_format');
       if(files.length > 0) {
-        var extension = files[0].name.split('.').pop().trim().trim().toLowerCase();
+        var extension = files[0].name.split('.').pop().trim().toLowerCase();
         for(var i = 0; i < dropdowns.length; i++) {
           var dropdown = dropdowns[i];
           dropdown.selectedIndex = 0;

--- a/import_export/static/import_export/guess_format.js
+++ b/import_export/static/import_export/guess_format.js
@@ -1,0 +1,21 @@
+(function($) {
+  $().ready(function () {
+    $('input.guess_format[type="file"]').change(function () {
+      var files = this.files;
+      var dropdowns = $(this.form).find('select.guess_format');
+      if(files.length > 0) {
+        var extension = files[0].name.split('.').pop().trim().trim().toLowerCase();
+        for(var i = 0; i < dropdowns.length; i++) {
+          var dropdown = dropdowns[i];
+          dropdown.selectedIndex = 0;
+          for(var j = 0; j < dropdown.options.length; j++) {
+            if(extension === dropdown.options[j].text.trim().toLowerCase()) {
+              dropdown.selectedIndex = j;
+              break;
+            }
+          }
+        }
+      }
+    });
+  });
+})(django.jQuery);

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -5,6 +5,7 @@
 {% load static %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "import_export/import.css" %}" />{% endblock %}
+{% block extrahead %}{{ block.super }}{{ media.js }}{% endblock %}
 
 {% block breadcrumbs_last %}
 {% trans "Import" %}
@@ -26,6 +27,7 @@
   {% else %}
     <form action="" method="post" enctype="multipart/form-data">
       {% csrf_token %}
+      {{ form.media }}
 
       <p>
         {% trans "This importer will import the following fields: " %}

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -5,7 +5,7 @@
 {% load static %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "import_export/import.css" %}" />{% endblock %}
-{% block extrahead %}{{ block.super }}{{ media.js }}{% endblock %}
+{% block extrahead %}{{ block.super }}{{ media.js }}{{ form.media }}{% endblock %}
 
 {% block breadcrumbs_last %}
 {% trans "Import" %}
@@ -27,7 +27,6 @@
   {% else %}
     <form action="" method="post" enctype="multipart/form-data">
       {% csrf_token %}
-      {{ form.media }}
 
       <p>
         {% trans "This importer will import the following fields: " %}

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -5,7 +5,7 @@
 {% load static %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "import_export/import.css" %}" />{% endblock %}
-{% block extrahead %}{{ block.super }}{{ media.js }}{{ form.media }}{% endblock %}
+{% block extrahead %}{{ block.super }}{{ media.js }}{% endblock %}
 
 {% block breadcrumbs_last %}
 {% trans "Import" %}

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -51,6 +51,10 @@ class ImportExportAdminIntegrationTest(TestCase):
                 'admin/import_export/change_list_import_export.html')
         self.assertContains(response, _('Import'))
         self.assertContains(response, _('Export'))
+        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.min.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
+
 
     @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
     def test_import(self):
@@ -157,10 +161,7 @@ class ImportExportAdminIntegrationTest(TestCase):
             _('Import finished, with {} new and {} updated {}.').format(
                 1, 0, Book._meta.verbose_name_plural)
         )
-        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.min.js">', count=1, html=True)
-        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
-        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
-
+        
     def test_export(self):
         response = self.client.get('/admin/core/book/export/')
         self.assertEqual(response.status_code, 200)

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -157,6 +157,9 @@ class ImportExportAdminIntegrationTest(TestCase):
             _('Import finished, with {} new and {} updated {}.').format(
                 1, 0, Book._meta.verbose_name_plural)
         )
+        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.min.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
 
     def test_export(self):
         response = self.client.get('/admin/core/book/export/')

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -51,9 +51,6 @@ class ImportExportAdminIntegrationTest(TestCase):
                 'admin/import_export/change_list_import_export.html')
         self.assertContains(response, _('Import'))
         self.assertContains(response, _('Export'))
-        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.min.js">', count=1, html=True)
-        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
-        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
 
 
     @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
@@ -63,6 +60,9 @@ class ImportExportAdminIntegrationTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'admin/import_export/import.html')
         self.assertContains(response, 'form action=""')
+        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.min.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
 
         # POST the import form
         input_format = '0'


### PR DESCRIPTION
**Problem**

In the Django-admin, a small piece of JavaScript looks to the file extension of the file uploaded, and select the format, given the format for that extension occurs in the dropdown.

**Solution**

A JavaScript file `guess_format.js` hooks an event handler on the file input element. In case the file changes, it obtains the file extension and starts looking for that extension in the dropdown. In case it finds that extension, it picks that format.

**Acceptance Criteria**

Have you written tests? No, this is frontend.
Have you included screenshots of your changes if applicable? below two images. After selecting the `file.csv`, the format automatically changes to `csv`.
![import-export-0](https://user-images.githubusercontent.com/3482343/179391994-6e214b2b-0a7d-4e9f-b351-bc73607e3a46.jpg)
![import-export-1](https://user-images.githubusercontent.com/3482343/179391995-55b9a194-fa42-4cc2-a8f3-5bdadf5889f7.jpg)

Did you document your changes? 