### PR TITLE
ObjectDoesNotExist should raise a ValueError

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -403,7 +403,10 @@ class ForeignKeyWidget(Widget):
     def clean(self, value, row=None, *args, **kwargs):
         val = super().clean(value)
         if val:
-            return self.get_queryset(value, row, *args, **kwargs).get(**{self.field: val})
+            try:
+                return self.get_queryset(value, row, *args, **kwargs).get(**{self.field: val})
+            except ObjectDoesNotExist:
+                raise ValueError("Object does not exist")
         else:
             return None
 


### PR DESCRIPTION
This ensures that it shows up as connected to a particular field with
a nice red error-box rather than as a stacktrace

**Acceptance Criteria**

This is a completely shoot-from-the-hip style PR; no new tests were created, I did not run tests, etc. I did briefly check, for my personal use-case, this indeed makes it so that an object that cannot be founds shows up with a nice red exclamation-mark in the import, rather than a big traceback.

I understand that this is in some way only half the work but my thinking is that something is better than nothing, and that others are better positioned to do the other half of the work. If nothing else, it make the raised issue more easily understandable.