### PR TITLE
Escape HTML output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - Fix deprecation in example application: Added support for transitional form renderer (#1451)
-
+- Escape HTML output when rendering decoding errors (#1469)
 
 2.8.0 (2022-03-31)
 ------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -14,6 +14,7 @@ from django.utils.encoding import force_str
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
+from django.template.defaultfilters import escape
 
 from .forms import ConfirmImportForm, ExportForm, ImportForm, export_action_form_factory
 from .mixins import BaseExportMixin, BaseImportMixin
@@ -259,9 +260,10 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     data = force_str(data, self.from_encoding)
                 dataset = input_format.create_dataset(data)
             except UnicodeDecodeError as e:
-                return HttpResponse(_(u"<h1>Imported file has a wrong encoding: %s</h1>" % e))
+                return HttpResponse(_(u"<h1>Imported file has a wrong encoding: %s</h1>" % escape(e)))
             except Exception as e:
-                return HttpResponse(_(u"<h1>%s encountered while trying to read file: %s</h1>" % (type(e).__name__, import_file.name)))
+                return HttpResponse(_(u"<h1>%s encountered while trying to read file: %s</h1>" % (
+                    escape(type(e).__name__), escape(import_file.name))))
 
             # prepare kwargs for import data, if needed
             res_kwargs = self.get_import_resource_kwargs(request, form=form, *args, **kwargs)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_permission_codename
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseRedirect
+from django.template.defaultfilters import escape
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
@@ -14,7 +15,6 @@ from django.utils.encoding import force_str
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
-from django.template.defaultfilters import escape
 
 from .forms import ConfirmImportForm, ExportForm, ImportForm, export_action_form_factory
 from .mixins import BaseExportMixin, BaseImportMixin

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -471,9 +471,11 @@ class ImportActionDecodeErrorTest(TestCase):
         m = TestImportExportActionModelAdmin(self.mock_model, self.mock_site,
                                                   UnicodeDecodeError('codec', b_arr, 1, 2, 'fail!'))
         res = m.import_action(self.mock_request)
-        self.assertEqual(
-            "<h1>Imported file has a wrong encoding: \'codec\' codec can\'t decode byte 0x00 in position 1: fail!</h1>",
-            res.content.decode())
+        target = (
+            "<h1>Imported file has a wrong encoding: &#x27;codec&#x27; codec "
+            "can&#x27;t decode byte 0x00 in position 1: fail!</h1>"
+        )
+        self.assertEqual(target, res.content.decode())
 
     @mock.patch("import_export.admin.ImportForm")
     def test_import_action_handles_error(self, mock_form):


### PR DESCRIPTION
As per Django's documentation

> Clearly, user-submitted data shouldn’t be trusted blindly and inserted
> directly into your web pages, because a malicious user could use this kind of
> hole to do potentially bad things. This type of security exploit is called a
> Cross Site Scripting (XSS) attack.

> To avoid this problem, you have two options:
>
> * One, you can make sure to run each untrusted variable through the escape
>   filter (documented below), which converts potentially harmful HTML characters
>   to unharmful ones.