### PR TITLE
ObjectDoesNotExist should raise a ValueError

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -414,7 +414,7 @@ class ForeignKeyWidget(Widget):
                 else:
                     return self.get_queryset(value, row, **kwargs).get(**{self.field: val})
             except ObjectDoesNotExist:
-                raise ValueError("Object does not exist")
+                raise ValueError("Object does not exist.")
         else:
             return None
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -406,12 +406,15 @@ class ForeignKeyWidget(Widget):
     def clean(self, value, row=None, **kwargs):
         val = super().clean(value)
         if val:
-            if self.use_natural_foreign_keys:
-                # natural keys will always be a tuple, which ends up as a json list.
-                value = json.loads(value) 
-                return self.model.objects.get_by_natural_key(*value)
-            else:
-                return self.get_queryset(value, row, **kwargs).get(**{self.field: val})
+            try:
+                if self.use_natural_foreign_keys:
+                    # natural keys will always be a tuple, which ends up as a json list.
+                    value = json.loads(value)
+                    return self.model.objects.get_by_natural_key(*value)
+                else:
+                    return self.get_queryset(value, row, **kwargs).get(**{self.field: val})
+            except ObjectDoesNotExist:
+                raise ValueError("Object does not exist")
         else:
             return None
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -402,6 +402,11 @@ class ForeignKeyWidgetTest(TestCase):
             self.natural_key_book_widget.render(self.book), json.dumps(self.book.natural_key())
         )
 
+    def test_clean_raises_ValueError(self):
+        with self.assertRaisesRegex(ValueError, "Object does not exist."):
+            self.widget.clean("123456789123456789")
+
+
 class ManyToManyWidget(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This ensures that it shows up as connected to a particular field with
a nice red error-box rather than as a stacktrace

Cherry-picked (with manual changes) from #1468