### PR TITLE
Raise a ValueError for DecimalField parsing

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -1,6 +1,6 @@
 import json
 from datetime import date, datetime, time
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 import django
 from django.conf import settings
@@ -96,7 +96,10 @@ class DecimalWidget(NumberWidget):
     def clean(self, value, row=None, **kwargs):
         if self.is_empty(value):
             return None
-        return Decimal(force_str(value))
+        try:
+            return Decimal(force_str(value))
+        except InvalidOperation:
+            raise ValueError("Enter a valid Decimal")
 
 
 class CharWidget(Widget):

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -99,7 +99,7 @@ class DecimalWidget(NumberWidget):
         try:
             return Decimal(force_str(value))
         except InvalidOperation:
-            raise ValueError("Enter a valid Decimal")
+            raise ValueError("Enter a valid Decimal.")
 
 
 class CharWidget(Widget):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -287,6 +287,10 @@ class DecimalWidgetTest(TestCase):
         self.assertEqual(self.widget.clean(" "), None)
         self.assertEqual(self.widget.clean("\r\n\t"), None)
 
+    def test_clean_raises_ValueError(self):
+        with self.assertRaisesRegex(ValueError, "Enter a valid Decimal."):
+            self.widget.clean('asdf')
+
 
 class IntegerWidgetTest(TestCase):
 


### PR DESCRIPTION
The error-handling code elsewhere (i.e. in resource.py) presupposes that problems
during clean() result in ValueError being raised. For more general exceptions, no
pretty box is shown but instead the exception is shown as a traceback with no means
of understanding what field in particular triggered it. If the DecimalWidget plays
nicely and raises a ValueError for invalid Decimals this problem is fixed

This is the cherry-picked version of #1467 on the release-3-x branch