### PR TITLE
Extends scope of transactions to rollback when using dry_run=True

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -127,3 +127,4 @@ The following is a list of much appreciated contributors:
 * Mark Walker
 * shimakaze-git
 * frgmt
+* kreatemore


### PR DESCRIPTION
**Problem**

I believe the changes below address and fix the following:
https://github.com/django-import-export/django-import-export/issues/1099
https://github.com/django-import-export/django-import-export/issues/1447
https://github.com/django-import-export/django-import-export/issues/1078

and our similar problem we're facing internally (at work) which is exactly the same as https://github.com/django-import-export/django-import-export/issues/1078#issuecomment-600225790

**Solution**

Instead of creating a `savepoint` before inserting rows and then rolling back to said `savepoint` (if applicable), I'm proposing to implicitly mark the outermost transaction to be rolled back if `dry_run=True and use_transactions=True`. This should mark related functions awaiting execution `on_commit` to be considered "rolled back". 

I'm not a 100% sure I fully understand why this happens, but during my investigation of this issue I've found that the manually created savepoint didn't exist in `connection.savepoint_ids`, but rolling back to it was successful, while another savepoint was added to `connection.savepoint_ids` (these were the auxiliary actions, like signal handlers, etc), but there was no related savepoint in the database. I suspect it might be somewhat due to threading, but I'm not experienced enough to be able to tell confidently if that's the case.

**Important!** While I think this is more aligned with what end-users would expect to happen when rolling back, and existing tests still pass, this might be considered as a breaking change. Should this be based to the v3-release branch instead?

**Acceptance Criteria**

Have you written tests? ✅  
Have you included screenshots of your changes if applicable? N/A
Did you document your changes? I sure hope so!

Thanks for the review in advance!