### PR TITLE
Allow custom change_list_template in admin views using mixins

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -127,3 +127,4 @@ The following is a list of much appreciated contributors:
 * Mark Walker
 * shimakaze-git
 * frgmt
+* nikhaldi (Nik Haldimann)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -61,6 +61,9 @@ This release makes some minor changes to the public API.  If you have overridden
 - ImportForm: improve compatibility with previous signature (#1434)
     - Previous `ImportForm` implementation was based on Django's `forms.Form`, if you have any custom ImportForm you now need to inherit from `import_export.forms.ImportExportFormBase`.
 
+- Allow custom `change_list_template` in admin views using mixins (#1483)
+    - If you are using admin mixins from this library in conjunction with code that overrides `change_list_template` (typically admin mixins from other libraries such as django-admin-sortable2 or reversion), object tools in the admin change list views may render differently now.
+
 Deprecations
 ############
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 - bugfix: `skip_row()` fix crash when model has m2m field and none is provided in upload (#1439)
 - Fix deprecation in example application: Added support for transitional form renderer (#1451)
+- Allow custom `change_list_template` in admin views using mixins (#1483)
 - Fixed Makefile coverage: added `coverage combine`
 
 3.0.0-beta.4 (2022-05-17)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -32,9 +32,33 @@ from .utils import original
 
 
 class ImportExportMixinBase:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Store already set change_list_template to allow users to independently
+        # customize the change list object tools. This treats the cases where
+        # `self.change_list_template` is `None` (the default in `ModelAdmin`) or
+        # where `self.import_export_change_list_template` is `None` as falling
+        # back on the default templates.
+        if getattr(self, 'change_list_template', None):
+            self.base_change_list_template = self.change_list_template
+        else:
+            self.base_change_list_template = 'admin/change_list.html'
+
+        self.change_list_template = getattr(
+            self, 'import_export_change_list_template', None
+        )
+        if self.change_list_template is None:
+            self.change_list_template = self.base_change_list_template
+
     def get_model_info(self):
         app_label = self.model._meta.app_label
         return (app_label, self.model._meta.model_name)
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['base_change_list_template'] = self.base_change_list_template
+        return super().changelist_view(request, extra_context)
 
 
 class ImportMixin(BaseImportMixin, ImportExportMixinBase):
@@ -46,7 +70,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     """
 
     #: template for change_list view
-    change_list_template = 'admin/import_export/change_list_import.html'
+    import_export_change_list_template = 'admin/import_export/change_list_import.html'
     #: template for import view
     import_template_name = 'admin/import_export/import.html'
     #: available import formats
@@ -545,7 +569,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
     https://docs.djangoproject.com/en/dev/ref/contrib/admin/
     """
     #: template for change_list view
-    change_list_template = 'admin/import_export/change_list_export.html'
+    import_export_change_list_template = 'admin/import_export/change_list_export.html'
     #: template for export view
     export_template_name = 'admin/import_export/export.html'
     #: export data encoding
@@ -707,7 +731,7 @@ class ImportExportMixin(ImportMixin, ExportMixin):
     Import and export mixin.
     """
     #: template for change_list view
-    change_list_template = 'admin/import_export/change_list_import_export.html'
+    import_export_change_list_template = 'admin/import_export/change_list_import_export.html'
 
 
 class ImportExportModelAdmin(ImportExportMixin, admin.ModelAdmin):
@@ -722,7 +746,7 @@ class ExportActionMixin(ExportMixin):
     """
 
     # Don't use custom change list template.
-    change_list_template = None
+    import_export_change_list_template = None
 
     def __init__(self, *args, **kwargs):
         """

--- a/import_export/templates/admin/import_export/change_list.html
+++ b/import_export/templates/admin/import_export/change_list.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_list.html" %}
+{% extends base_change_list_template %}
 
 {# Original template renders object-tools only when has_add_permission is True. #}
 {# This hack allows sub templates to add to object-tools #}

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -32,6 +32,7 @@ class BookAdmin(ImportExportMixin, admin.ModelAdmin):
     list_display = ('name', 'author', 'added')
     list_filter = ['categories', 'author']
     resource_classes = [BookResource, BookNameResource]
+    change_list_template = "core/admin/change_list.html"
 
 
 class CategoryAdmin(ExportActionModelAdmin):

--- a/tests/core/templates/core/admin/change_list.html
+++ b/tests/core/templates/core/admin/change_list.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_list.html" %}
 {% comment %}
-A template used for testing custimzations to the change_list view (See #1483).
+A template used for testing customizations to the change_list view (See #1483).
 {% endcomment %}
 
 {% block object-tools-items %}

--- a/tests/core/templates/core/admin/change_list.html
+++ b/tests/core/templates/core/admin/change_list.html
@@ -4,6 +4,6 @@ A template used for testing custimzations to the change_list view (See #1483).
 {% endcomment %}
 
 {% block object-tools-items %}
-  <li class="hidden">Custom change list item</li>
+  <!-- <li>Custom change list item</li> -->
   {{ block.super }}
 {% endblock %}

--- a/tests/core/templates/core/admin/change_list.html
+++ b/tests/core/templates/core/admin/change_list.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_list.html" %}
 
 {% block object-tools-items %}
-  <li>Custom change list item</li>
+  <li><a href="#">Custom change list item</a></li>
   {{ block.super }}
 {% endblock %}

--- a/tests/core/templates/core/admin/change_list.html
+++ b/tests/core/templates/core/admin/change_list.html
@@ -1,6 +1,9 @@
 {% extends "admin/change_list.html" %}
+{% comment %}
+A template used for testing custimzations to the change_list view (See #1483).
+{% endcomment %}
 
 {% block object-tools-items %}
-  <li><a href="#">Custom change list item</a></li>
+  <li class="hidden">Custom change list item</li>
   {{ block.super }}
 {% endblock %}

--- a/tests/core/templates/core/admin/change_list.html
+++ b/tests/core/templates/core/admin/change_list.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools-items %}
+  <li>Custom change list item</li>
+  {{ block.super }}
+{% endblock %}

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -52,8 +52,11 @@ class ImportExportAdminIntegrationTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response,
                 'admin/import_export/change_list_import_export.html')
+        self.assertTemplateUsed(response, 'admin/change_list.html')
+        self.assertTemplateUsed(response, 'core/admin/change_list.html')
         self.assertContains(response, _('Import'))
         self.assertContains(response, _('Export'))
+        self.assertContains(response, 'Custom change list item')
 
     @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
     def test_import(self):


### PR DESCRIPTION
**Problem**

The mixins for the admin integration override the admin `change_list_template`. This means that any customization of that template done by the user is effectively ignored. This also means that `django-export-import` is not compatible with mixins from other libraries that customize the object tools in the change list view (e.g., `django-admin-sortable2` or `reversion`).

This issue was reported in #1450

**Solution**

This makes the `change_list_template` extend whatever customized template is already present in the class hierarchy. This solution is loosely based on the [solution to the same issue in django-admin-sortable2](https://github.com/jrief/django-admin-sortable2/pull/317).

**Acceptance Criteria**

Additional assertions in admin integration tests cover this use case.