### PR TITLE
refactored forms 'media' declaration for easier testing

### DIFF
--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -28,12 +28,15 @@ class ImportForm(forms.Form):
 
         self.fields['input_format'].choices = choices
 
-    class Media:
+    @property
+    def media(self):
         extra = "" if settings.DEBUG else ".min"
-        js = (
-            f'admin/js/vendor/jquery/jquery{extra}.js',
-            'admin/js/jquery.init.js',
-            'import_export/guess_format.js',
+        return forms.Media(
+            js=(
+                f'admin/js/vendor/jquery/jquery{extra}.js',
+                'admin/js/jquery.init.js',
+                'import_export/guess_format.js',
+            )
         )
 
 

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -37,6 +37,7 @@ from import_export.tmp_storages import TempFolderStorage
 class ImportExportAdminIntegrationTest(TestCase):
 
     def setUp(self):
+        super().setUp()
         user = User.objects.create_user('admin', 'admin@example.com',
                                         'password')
         user.is_staff = True
@@ -52,7 +53,6 @@ class ImportExportAdminIntegrationTest(TestCase):
         self.assertContains(response, _('Import'))
         self.assertContains(response, _('Export'))
 
-
     @override_settings(TEMPLATE_STRING_IF_INVALID='INVALID_VARIABLE')
     def test_import(self):
         # GET the import form
@@ -60,9 +60,6 @@ class ImportExportAdminIntegrationTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'admin/import_export/import.html')
         self.assertContains(response, 'form action=""')
-        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.min.js">', count=1, html=True)
-        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
-        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
 
         # POST the import form
         input_format = '0'
@@ -89,9 +86,31 @@ class ImportExportAdminIntegrationTest(TestCase):
                                     follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response,
-            _('Import finished, with {} new and {} updated {}.').format(
-                1, 0, Book._meta.verbose_name_plural)
-        )
+                            _('Import finished, with {} new and {} updated {}.').format(
+                                1, 0, Book._meta.verbose_name_plural)
+                            )
+
+    @override_settings(DEBUG=True)
+    def test_correct_scripts_declared_when_debug_is_true(self):
+        # GET the import form
+        response = self.client.get('/admin/core/book/import/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/import_export/import.html')
+        self.assertContains(response, 'form action=""')
+        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
+
+    @override_settings(DEBUG=False)
+    def test_correct_scripts_declared_when_debug_is_false(self):
+        # GET the import form
+        response = self.client.get('/admin/core/book/import/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/import_export/import.html')
+        self.assertContains(response, 'form action=""')
+        self.assertContains(response, '<script src="/static/admin/js/vendor/jquery/jquery.min.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/admin/js/jquery.init.js">', count=1, html=True)
+        self.assertContains(response, '<script src="/static/import_export/guess_format.js">', count=1, html=True)
 
     def test_delete_from_admin(self):
         # test delete from admin site (see #432)

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -86,9 +86,9 @@ class ImportExportAdminIntegrationTest(TestCase):
                                     follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response,
-                            _('Import finished, with {} new and {} updated {}.').format(
-                                1, 0, Book._meta.verbose_name_plural)
-                            )
+            _('Import finished, with {} new and {} updated {}.').format(
+                1, 0, Book._meta.verbose_name_plural)
+        )
 
     @override_settings(DEBUG=True)
     def test_correct_scripts_declared_when_debug_is_true(self):


### PR DESCRIPTION
**Problem**

Minor refactoring of `Media` declaration from #1460 for easier testing.

**Solution**

Moved `Media` class declaration to [dynamic](https://docs.djangoproject.com/en/4.1/topics/forms/media/#media-as-a-dynamic-property) declaration.

**Acceptance Criteria**

- Added integration tests
- Tested manually with example app with both DEBUG on / off