### PR TITLE
Fix tablib format documentation page url broken

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ additional formats like ``cli`` or ``Pandas DataFrame``, you should install the
 appropriate tablib dependencies (e.g. ``pip install tablib[pandas]``). Read
 more on the `tablib format documentation page`_.
 
-.. _tablib format documentation page: https://tablib.readthedocs.io/en/stable/formats/
+.. _tablib format documentation page: https://tablib.readthedocs.io/en/stable/formats.html
 
 Alternatively, you can install the git repository directly to obtain the
 development version::


### PR DESCRIPTION
The following link is broken
https://github.com/django-import-export/django-import-export/blob/cccf7884566b77da9c89da597a078c8a9a67a778/docs/installation.rst#L15


The URL should be https://tablib.readthedocs.io/en/stable/formats.html