### PR TITLE
bugfix: `DateTimeWidget.clean()` handles tz aware datetime

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- bugfix: `DateTimeWidget.clean()` handles tz aware datetime
+- bugfix: `DateTimeWidget.clean()` handles tz aware datetime (#1499)
 
 3.0.0 (2022-10-18)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,7 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- bugfix: `DateTimeWidget.clean()` handles tz aware datetime
 
 3.0.0 (2022-10-18)
 ------------------

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -222,7 +222,7 @@ class DateTimeWidget(Widget):
                 except (ValueError, TypeError):
                     continue
         if dt:
-            if settings.USE_TZ:
+            if settings.USE_TZ and timezone.is_naive(dt):
                 dt = timezone.make_aware(dt)
             return dt
         raise ValueError("Enter a valid date/time.")

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -151,6 +151,11 @@ class DateTimeWidgetTest(TestCase):
         target_dt = timezone.make_aware(self.datetime, pytz.timezone('Europe/Ljubljana'))
         self.assertEqual(target_dt, self.widget.clean(self.datetime))
 
+    @override_settings(USE_TZ=True, TIME_ZONE='Europe/Ljubljana')
+    def test_clean_handles_tz_aware_datetime(self):
+        self.datetime = datetime(2012, 8, 13, 18, 0, 0, tzinfo=pytz.timezone('UTC'))
+        self.assertEqual(self.datetime, self.widget.clean(self.datetime))
+
     @override_settings(DATETIME_INPUT_FORMATS=None)
     def test_default_format(self):
         self.widget = widgets.DateTimeWidget()


### PR DESCRIPTION
**Problem**

Following #1478, DateTimeWidget.clean() will raise `ValueError` when passed a tz aware datetime.  This is because `make_aware()` raises an error if the date already has tz info.

**Solution**

See changes.

**Acceptance Criteria**

- Added test
- Tested with my external app