### PR TITLE
support python 3.11

### DIFF
--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -26,6 +26,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
     services:
       postgres:
         image: postgres

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,7 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Support Python 3.11
 
 3.0.1 (2022-10-18)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3 :: Only',
     'Topic :: Software Development',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
        isort
        {py37,py38,py39,py310}-{django32}
        {py38,py39,py310}-{django40,django41,djangomain}
-       py310-djangomain-tablibdev
+       {py311}-{django41,djangomain}
+       py311-djangomain-tablibdev
 
 [gh-actions]
 python =
@@ -11,6 +12,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/tests


### PR DESCRIPTION
**Problem**

Python 3.11 is released.

> [Django 4.1 will be the first version to support Python 3.11](https://code.djangoproject.com/ticket/33173)

**Solution**

Update tox, `setup.py`, CI script to support python 3.11

**Acceptance Criteria**

- Updated tox and tested locally by running `./runtests.sh`