### PR TITLE
Use get_list_select_related (fix #1493)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -131,3 +131,4 @@ The following is a list of much appreciated contributors:
 * HaPyTeX (Willem Van Onsem)
 * nikhaldi (Nik Haldimann)
 * TheRealVizard (Eduardo Leyva)
+* mpasternak (Michał Pasternak)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Support Python 3.11
+- use ``get_list_select_related`` in ``ExportMixin``
 
 3.0.1 (2022-10-18)
 ------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -608,6 +608,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         """
         list_display = self.get_list_display(request)
         list_display_links = self.get_list_display_links(request, list_display)
+        list_select_related = self.get_list_select_related(request)
         list_filter = self.get_list_filter(request)
         search_fields = self.get_search_fields(request)
         if self.get_actions(request):
@@ -622,7 +623,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             'list_filter': list_filter,
             'date_hierarchy': self.date_hierarchy,
             'search_fields': search_fields,
-            'list_select_related': self.list_select_related,
+            'list_select_related': list_select_related,
             'list_per_page': self.list_per_page,
             'list_max_show_all': self.list_max_show_all,
             'list_editable': self.list_editable,


### PR DESCRIPTION
**Problem**

To be honest, this is not exactly a problem, as long as you don't heavily modify Django admin and write classes inheriting from ``ExportMixin``. Since some time Django has a special utility function for getting ``list_select_related``, which is called ``get_list_select_related`` and it should be used to override some settings. 

In my application I used it to implement dynamic Django admin columns (https://github.com/iplweb/bpp/blob/dev/src/dynamic_columns/mixins.py#L8) and it occurred, that ``ExportMixin`` (that I also use, that's a quite big project) doesn't play nicely with it, so well, here I am. 

**Solution**

All this needs is to analogically call to ``get_*``, just like we already do in ``get_list_display`` and such. 

**Acceptance Criteria**

No additional tests, Django 3.2 and 4.0 pass. 

Screenshots of my changes... are identical to the changes.

I documented the changes in the changelog.rst and added myself to the deep bottom of ``AUTHORS``. 