### PR TITLE
feat: report skipped rows properly - including the instance info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,3 +132,4 @@ The following is a list of much appreciated contributors:
 * nikhaldi (Nik Haldimann)
 * TheRealVizard (Eduardo Leyva)
 * mpasternak (Michał Pasternak)
+* nikatlas (Nikos Atlas)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Support Python 3.11 (#1508)
 - use ``get_list_select_related`` in ``ExportMixin`` (#1511)
 - bugfix: handle crash on start-up when ``change_list_template`` is a property (#1523)
+- bugfix: include instance info in row result when row is skipped (#1526)
 
 3.0.1 (2022-10-18)
 ------------------

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -737,7 +737,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                     self.validate_instance(instance, import_validation_errors)
                     self.save_instance(instance, new, using_transactions, dry_run)
                     self.save_m2m(instance, row, using_transactions, dry_run)
-                    row_result.add_instance_info(instance)
+                row_result.add_instance_info(instance)
                 if not skip_diff:
                     diff.compare_with(self, instance, dry_run)
 

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -987,7 +987,7 @@ class ModelResourceTest(TestCase):
         self.assertTrue(result.rows[0].diff)
         self.assertEqual(result.rows[0].import_type,
                          results.RowResult.IMPORT_TYPE_SKIP)
-        self.assertEqual(result.rows[0].object_id, cat1.pk)
+        self.assertEqual(result.rows[0].object_id, self.book.pk)
 
         # Test that we can suppress reporting of skipped rows
         resource._meta.report_skipped = False

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -987,6 +987,7 @@ class ModelResourceTest(TestCase):
         self.assertTrue(result.rows[0].diff)
         self.assertEqual(result.rows[0].import_type,
                          results.RowResult.IMPORT_TYPE_SKIP)
+        self.assertEqual(result.rows[0].object_id, cat1.pk)
 
         # Test that we can suppress reporting of skipped rows
         resource._meta.report_skipped = False


### PR DESCRIPTION
**Problem**

What problem have you solved?

The RowResults in the case of skipped rows during import do not include the skipped instance's information.
There are several use-cases when the primary keys of the imported rows are needed. These use-cases usually include hooks that are running alongside the import but have no access to the Resource class or are isolated/separated or even the caller method which invokes the import process in code. 

**Solution**

How did you solve the problem?

Invoked the `add_instance_info` method in both cases of new/udpated rows and skipped ones.

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 

After the change the reported RowResult includes instance information:
<img width="568" alt="Screenshot 2022-12-09 at 4 46 18 PM" src="https://user-images.githubusercontent.com/6645981/206727951-a46011f5-b660-44d9-9a7f-ca666648a146.png">
