### PR TITLE
Add field optional dehydrate method param

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -133,3 +133,4 @@ The following is a list of much appreciated contributors:
 * TheRealVizard (Eduardo Leyva)
 * mpasternak (Michał Pasternak)
 * nikatlas (Nikos Atlas)
+* cocorocho (Erkan Çoban)

--- a/import_export/exceptions.py
+++ b/import_export/exceptions.py
@@ -1,8 +1,3 @@
-import warnings
-
-warnings.warn("the exceptions module is deprecated and will be removed in a future release", DeprecationWarning)
-
-
 class ImportExportError(Exception):
     """A generic exception for all others to extend."""
     pass

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -1,9 +1,9 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.fields import NOT_PROVIDED
 from django.db.models.manager import Manager
-from .exceptions import FieldError
 
 from . import widgets
+from .exceptions import FieldError
 
 
 class Field:

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.fields import NOT_PROVIDED
 from django.db.models.manager import Manager
+from .exceptions import FieldError
 
 from . import widgets
 
@@ -135,6 +136,6 @@ class Field:
         DEFAULT_DEHYDRATE_METHOD_PREFIX = "dehydrate_"
 
         if not self.dehydrate_method and not field_name:
-            raise AttributeError("Both `dehydrate_method` and `field_name` are not supplied.")
+            raise FieldError("Both `dehydrate_method` and `field_name` are not supplied.")
 
         return self.dehydrate_method or DEFAULT_DEHYDRATE_METHOD_PREFIX + field_name

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -127,7 +127,7 @@ class Field:
             return ""
         return self.widget.render(value, obj)
 
-    def _get_dehydrate_method(self, field_name=None):
+    def get_dehydrate_method(self, field_name=None):
         """
         Returns method name to be used for dehydration of the field.
         Defaults to `dehydrate_{field_name}`

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -131,11 +131,11 @@ class Field:
     def get_dehydrate_method(self, field_name=None):
         """
         Returns method name to be used for dehydration of the field.
-        Defaults to 'dehydrate_{field_name}'
+        Defaults to `dehydrate_{field_name}`
         """
         DEFAULT_DEHYDRATE_METHOD_PREFIX = "dehydrate_"
 
         if not self.dehydrate_method and not field_name:
-            raise FieldError("Both `dehydrate_method` and `field_name` are not supplied.")
+            raise FieldError("Both dehydrate_method and field_name are not supplied.")
 
         return self.dehydrate_method or DEFAULT_DEHYDRATE_METHOD_PREFIX + field_name

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -27,11 +27,13 @@ class Field:
         not return an adequate value.
 
     :param saves_null_values: Controls whether null values are saved on the object
+    :param dehydrate_method: Lets you choose your own method for dehydration rather
+        than using `dehydrate_{field_name}` syntax.
     """
     empty_values = [None, '']
 
     def __init__(self, attribute=None, column_name=None, widget=None,
-                 default=NOT_PROVIDED, readonly=False, saves_null_values=True):
+                 default=NOT_PROVIDED, readonly=False, saves_null_values=True, dehydrate_method=None):
         self.attribute = attribute
         self.default = default
         self.column_name = column_name
@@ -40,6 +42,7 @@ class Field:
         self.widget = widget
         self.readonly = readonly
         self.saves_null_values = saves_null_values
+        self.dehydrate_method = dehydrate_method
 
     def __repr__(self):
         """
@@ -123,3 +126,15 @@ class Field:
         if value is None:
             return ""
         return self.widget.render(value, obj)
+
+    def _get_dehydrate_method(self, field_name=None):
+        """
+        Returns method name to be used for dehydration of the field.
+        Defaults to `dehydrate_{field_name}`
+        """
+        DEFAULT_DEHYDRATE_METHOD_PREFIX = "dehydrate_"
+
+        if not self.dehydrate_method and not field_name:
+            raise AttributeError("Both `dehydrate_method` and `field_name` are not supplied.")
+
+        return self.dehydrate_method or DEFAULT_DEHYDRATE_METHOD_PREFIX + field_name

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -131,7 +131,7 @@ class Field:
     def get_dehydrate_method(self, field_name=None):
         """
         Returns method name to be used for dehydration of the field.
-        Defaults to `dehydrate_{field_name}`
+        Defaults to 'dehydrate_{field_name}'
         """
         DEFAULT_DEHYDRATE_METHOD_PREFIX = "dehydrate_"
 

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -924,7 +924,7 @@ class Resource(metaclass=DeclarativeMetaclass):
 
     def export_field(self, field, obj):
         field_name = self.get_field_name(field)
-        dehydrate_method = field._get_dehydrate_method(field_name)
+        dehydrate_method = field.get_dehydrate_method(field_name)
 
         method = getattr(self, dehydrate_method, None)
         if method is not None:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -924,7 +924,9 @@ class Resource(metaclass=DeclarativeMetaclass):
 
     def export_field(self, field, obj):
         field_name = self.get_field_name(field)
-        method = getattr(self, 'dehydrate_%s' % field_name, None)
+        dehydrate_method = field._get_dehydrate_method(field_name)
+
+        method = getattr(self, dehydrate_method, None)
         if method is not None:
             return method(obj)
         return field.export(obj)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -160,7 +160,8 @@ class DateWidget(Widget):
     """
     Widget for converting date fields.
 
-    Takes optional ``format`` parameter.
+    Takes optional ``format`` parameter. If none is set, either
+    ``settings.DATE_INPUT_FORMATS`` or ``"%Y-%m-%d"`` is used.
     """
 
     def __init__(self, format=None):
@@ -239,7 +240,8 @@ class TimeWidget(Widget):
     """
     Widget for converting time fields.
 
-    Takes optional ``format`` parameter.
+    Takes optional ``format`` parameter. If none is set, either
+    ``settings.DATETIME_INPUT_FORMATS`` or ``"%H:%M:%S"`` is used.
     """
 
     def __init__(self, format=None):

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -84,3 +84,26 @@ class FieldTest(TestCase):
         self.assertEqual(repr(self.field), '<import_export.fields.Field: name>')
         self.field.column_name = None
         self.assertEqual(repr(self.field), '<import_export.fields.Field>')
+
+    def test_get_dehydrate_method_default(self):
+        field = fields.Field(attribute="foo", column_name="bar")
+
+        # `field_name` is the variable name defined in `Resource`
+        resource_field_name = "field"
+        method_name = field._get_dehydrate_method(resource_field_name)
+        self.assertEqual(f"dehydrate_{resource_field_name}", method_name)
+
+    def test_get_dehydrate_method_with_custom_method_name(self):
+        custom_dehydrate_method = "custom_method_name"
+        field = fields.Field(attribute="foo", column_name="bar", dehydrate_method=custom_dehydrate_method)
+        resource_field_name = "field"
+        method_name = field._get_dehydrate_method(resource_field_name)
+        self.assertEqual(method_name, custom_dehydrate_method)
+
+    def test_get_dehydrate_method_without_params_raises_attribute_error(self):
+        field = fields.Field(attribute="foo", column_name="bar")
+
+        self.assertRaises(
+            AttributeError,
+            field._get_dehydrate_method
+        )

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from django.test import TestCase
 
+from import_export.exceptions import FieldError
 from import_export import fields
 
 
@@ -104,6 +105,6 @@ class FieldTest(TestCase):
         field = fields.Field(attribute="foo", column_name="bar")
 
         self.assertRaises(
-            AttributeError,
+            FieldError,
             field.get_dehydrate_method
         )

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -85,25 +85,25 @@ class FieldTest(TestCase):
         self.field.column_name = None
         self.assertEqual(repr(self.field), '<import_export.fields.Field>')
 
-    def test_get_dehydrate_method_default(self):
+    def testget_dehydrate_method_default(self):
         field = fields.Field(attribute="foo", column_name="bar")
 
         # `field_name` is the variable name defined in `Resource`
         resource_field_name = "field"
-        method_name = field._get_dehydrate_method(resource_field_name)
+        method_name = field.get_dehydrate_method(resource_field_name)
         self.assertEqual(f"dehydrate_{resource_field_name}", method_name)
 
-    def test_get_dehydrate_method_with_custom_method_name(self):
+    def testget_dehydrate_method_with_custom_method_name(self):
         custom_dehydrate_method = "custom_method_name"
         field = fields.Field(attribute="foo", column_name="bar", dehydrate_method=custom_dehydrate_method)
         resource_field_name = "field"
-        method_name = field._get_dehydrate_method(resource_field_name)
+        method_name = field.get_dehydrate_method(resource_field_name)
         self.assertEqual(method_name, custom_dehydrate_method)
 
-    def test_get_dehydrate_method_without_params_raises_attribute_error(self):
+    def testget_dehydrate_method_without_params_raises_attribute_error(self):
         field = fields.Field(attribute="foo", column_name="bar")
 
         self.assertRaises(
             AttributeError,
-            field._get_dehydrate_method
+            field.get_dehydrate_method
         )

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -2,8 +2,8 @@ from datetime import date
 
 from django.test import TestCase
 
-from import_export.exceptions import FieldError
 from import_export import fields
+from import_export.exceptions import FieldError
 
 
 class Obj:

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -838,6 +838,28 @@ class ModelResourceTest(TestCase):
         self.assertEqual(full_title, '%s by %s' % (self.book.name,
                                                    self.book.author.name))
 
+    def test_dehydrate_field_using_custom_dehydrate_field_method(self):
+        
+        class B(resources.ModelResource):
+            full_title = fields.Field(column_name="Full title", dehydrate_method="foo_dehydrate_full_title")
+
+            class Meta:
+                model = Book
+                fields = ("full_title")
+
+            def foo_dehydrate_full_title(self, obj):
+                return f"{obj.name} by {obj.author.name}"
+
+        author = Author.objects.create(name="Author")
+        self.book.author = author
+        resource = B()   
+
+        full_title = resource.export_field(resource.get_fields()[0], self.book)
+        self.assertEqual(
+            full_title,
+            f"{self.book.name} by {self.book.author.name}"
+        )
+
     def test_invalid_relation_field_name(self):
 
         class B(resources.ModelResource):


### PR DESCRIPTION
**Problem**

Defining custom methods for dehydration of the field

I have had situations where I had to dynamically generate new fields during export. In this case I wasn't able to pre-define dehydration methods in `ModelResource` so I added `dehydrate_method` parameter to `Field` which solved this issue.

**Solution**

I have added `dehydrate_method` parameter to `fields.Field` so custom methods 

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?

I have written tests.

Did you document your changes? 
Added docstrings.


Let me know if anything needs to be changed!