### PR TITLE
Improve bulk import performance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,3 +135,4 @@ The following is a list of much appreciated contributors:
 * mpasternak (Michał Pasternak)
 * nikatlas (Nikos Atlas)
 * cocorocho (Erkan Çoban)
+# Ptosiek (Antonin)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -683,7 +683,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         pass
 
-    def import_row(self, row, instance_loader, using_transactions=True, dry_run=False, raise_errors=False, **kwargs):
+    def import_row(self, row, instance_loader, using_transactions=True, dry_run=False, **kwargs):
         """
         Imports data from ``tablib.Dataset``. Refer to :doc:`import_workflow`
         for a more complete description of the whole import process.
@@ -761,17 +761,6 @@ class Resource(metaclass=DeclarativeMetaclass):
                 logger.debug(e, exc_info=e)
             tb_info = traceback.format_exc()
             row_result.errors.append(self.get_error_result_class()(e, tb_info, row))
-
-        if self._meta.use_bulk:
-            # persist a batch of rows
-            # because this is a batch, any exceptions are logged and not associated
-            # with a specific row
-            if len(self.create_instances) == self._meta.batch_size:
-                self.bulk_create(using_transactions, dry_run, raise_errors, batch_size=self._meta.batch_size)
-            if len(self.update_instances) == self._meta.batch_size:
-                self.bulk_update(using_transactions, dry_run, raise_errors, batch_size=self._meta.batch_size)
-            if len(self.delete_instances) == self._meta.batch_size:
-                self.bulk_delete(using_transactions, dry_run, raise_errors)
 
         return row_result
 
@@ -852,16 +841,29 @@ class Resource(metaclass=DeclarativeMetaclass):
             result.add_dataset_headers(dataset.headers)
 
         for i, row in enumerate(dataset.dict, 1):
-            with atomic_if_using_transaction(using_transactions, using=db_connection):
+            with atomic_if_using_transaction(using_transactions and not self._meta.use_bulk, using=db_connection):
                 row_result = self.import_row(
                     row,
                     instance_loader,
                     using_transactions=using_transactions,
                     dry_run=dry_run,
                     row_number=i,
-                    raise_errors=raise_errors,
                     **kwargs
                 )
+            if self._meta.use_bulk:
+                # persist a batch of rows
+                # because this is a batch, any exceptions are logged and not associated
+                # with a specific row
+                if len(self.create_instances) == self._meta.batch_size:
+                    with atomic_if_using_transaction(using_transactions, using=db_connection):
+                        self.bulk_create(using_transactions, dry_run, raise_errors, batch_size=self._meta.batch_size)
+                if len(self.update_instances) == self._meta.batch_size:
+                    with atomic_if_using_transaction(using_transactions, using=db_connection):
+                        self.bulk_update(using_transactions, dry_run, raise_errors, batch_size=self._meta.batch_size)
+                if len(self.delete_instances) == self._meta.batch_size:
+                    with atomic_if_using_transaction(using_transactions, using=db_connection):
+                        self.bulk_delete(using_transactions, dry_run, raise_errors)
+
             result.increment_row_result_total(row_result)
 
             if row_result.errors:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import traceback
+import warnings
 from collections import OrderedDict
 from copy import deepcopy
 
@@ -683,7 +684,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         pass
 
-    def import_row(self, row, instance_loader, using_transactions=True, dry_run=False, **kwargs):
+    def import_row(self, row, instance_loader, using_transactions=True, dry_run=False, raise_errors=None, **kwargs):
         """
         Imports data from ``tablib.Dataset``. Refer to :doc:`import_workflow`
         for a more complete description of the whole import process.
@@ -698,6 +699,12 @@ class Resource(metaclass=DeclarativeMetaclass):
         :param dry_run: If ``dry_run`` is set, or error occurs, transaction
             will be rolled back.
         """
+        if raise_errors is not None:
+            warnings.warn(
+                "raise_errors argument is deprecated and will be removed in a future release.",
+                category=DeprecationWarning
+            )
+
         skip_diff = self._meta.skip_diff
         row_result = self.get_row_result_class()()
         if self._meta.store_row_values:

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -2080,6 +2080,17 @@ class BulkCreateTest(BulkTest):
         resource = _BookResource()
         self.assertIsNotNone(resource.get_or_init_instance(ModelInstanceLoader(resource), self.dataset[0]))
 
+    @mock.patch('import_export.resources.atomic_if_using_transaction')
+    def test_no_sub_transaction_on_row_for_bulk(self, mock_atomic_if_using_transaction):
+        class _BookResource(resources.ModelResource):
+            class Meta:
+                model = Book
+                use_bulk = True
+
+        resource = _BookResource()
+        resource.import_data(self.dataset)
+        self.assertIn(False, [x.args[0] for x in mock_atomic_if_using_transaction.call_args_list])
+
 
 class BulkUpdateTest(BulkTest):
     class _BookResource(resources.ModelResource):


### PR DESCRIPTION
**Problem**
When transactions are supported, import_data_inner will create a subtransaction for each row.
In bulk mode, no db operations are made anyway so there's no need to for the extra db queries of creating and releasing a save point.

**Solution**

Do not create save point for each row when bulk mode is enabled.

**Acceptance Criteria**
Sample bulk_import results (on postgres):

**before the changes:**
do_create()
Time   6.004
Memory 2.21875
Max 82.12890625 Min 79.91015625

do_update()
Time   5.205
Memory 3.9375
Max 103.12890625 Min 99.19140625

do_delete()
Time   3.548
Memory 0.01171875
Max 105.78125 Min 105.76953125

**after the changes:**
do_create()
Time   2.2
Memory 2.890625
Max 79.8125 Min 76.921875

do_update()
Time   1.616
Memory 7.921875
Max 101.4609375 Min 93.5390625

do_delete()
Time   0.9456
Memory 0.00390625
Max 104.59765625 Min 104.59375

Significant time decrease. The memory delta is increased, but as you can see with added Max/Min in the output, the overall memory used has not.