### PR TITLE
collect errors on bulk operations

### DIFF
--- a/docs/bulk_import.rst
+++ b/docs/bulk_import.rst
@@ -28,8 +28,8 @@ Caveats
   then that batch will fail.  It's also possible that transactions can be left in a corrupted state.  Other batches may
   be successfully persisted, meaning that you may have a partially successful import.
 
-* In bulk mode, exceptions are not linked to a row.  Any exceptions raised by bulk operations are logged (and
-  re-raised if ``raise_errors`` is true).
+* In bulk mode, exceptions are not linked to a row.  Any exceptions raised by bulk operations are logged and returned
+  as critical (non-validation) errors (and re-raised if ``raise_errors`` is true).
 
 * If you use :class:`~import_export.widgets.ForeignKeyWidget` then this can affect performance, because it reads from
   the database for each row.  If this is an issue then create a subclass which caches ``get_queryset()`` results rather

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -18,10 +18,7 @@ from django.core.paginator import Paginator
 from django.db import connections, router
 from django.db.models.fields.related import ForeignObjectRel
 from django.db.models.query import QuerySet
-from django.db.transaction import (
-    TransactionManagementError,
-    set_rollback,
-)
+from django.db.transaction import TransactionManagementError, set_rollback
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 
@@ -313,6 +310,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         return Diff
 
+    @classmethod
     def get_db_connection_name(self):
         if self._meta.using_db is None:
             return router.db_for_write(self._meta.model)


### PR DESCRIPTION
**Problem**

Errors during bulk operations are not returned to the user in dry_run mode. Instead the exception is caught and logged and user can proceed to real import (which fails).

An extra savepoint is also used to rollback the transaction on dry_run/errors, but we can used the current transaction block instead to achieve the same.

**Solution**

Make errors raised during bulk operation part of result.base_errors so they can be returned to the user.

Remove extra savepoint.

**Acceptance Criteria**

Tests were written + documentation updated.
