### PR TITLE
Fix xss in html export

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,4 +135,5 @@ The following is a list of much appreciated contributors:
 * mpasternak (Michał Pasternak)
 * nikatlas (Nikos Atlas)
 * cocorocho (Erkan Çoban)
-# Ptosiek (Antonin)
+* Ptosiek (Antonin)
+* samupl (Jakub Szafrański)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -120,6 +120,15 @@ Note that if you disable transaction support via configuration (or if your datab
 does not support transactions), then validation errors will still be presented to the user
 but valid rows will have imported.
 
+``IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set to ``True``, export output will be sanitized. By default this is set to ``False``.
+
+Note: currently this only works for ``HTML`` output, and only for exports done via the admin UI.
+
+
+
 .. _exampleapp:
 
 Example app

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -679,7 +679,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             raise PermissionDenied
 
         data = self.get_data_for_export(request, queryset, *args, **kwargs)
-        export_data = file_format.export_data(data)
+        export_data = file_format.export_data(data, escape_output=self.should_escape_output)
         encoding = kwargs.get("encoding")
         if not file_format.is_binary() and encoding:
             export_data = export_data.encode(encoding)

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -1,3 +1,5 @@
+import html
+
 import tablib
 from tablib.formats import registry
 
@@ -144,6 +146,13 @@ class ODS(TextFormat):
 class HTML(TextFormat):
     TABLIB_MODULE = 'tablib.formats._html'
     CONTENT_TYPE = 'text/html'
+
+    def export_data(self, dataset, **kwargs):
+        for _ in dataset:
+            row = dataset.lpop()
+            row = [html.escape(cell) for cell in row]
+            dataset.append(row)
+        return dataset.export(self.get_title(), **kwargs)
 
 
 class XLS(TablibFormat):

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -14,7 +14,7 @@ class Format:
         """
         raise NotImplementedError()
 
-    def export_data(self, dataset, **kwargs):
+    def export_data(self, dataset, escape_output=False, **kwargs):
         """
         Returns format representation for given dataset.
         """
@@ -84,7 +84,7 @@ class TablibFormat(Format):
     def create_dataset(self, in_stream, **kwargs):
         return tablib.import_set(in_stream, format=self.get_title())
 
-    def export_data(self, dataset, **kwargs):
+    def export_data(self, dataset, escape_output=False, **kwargs):
         return dataset.export(self.get_title(), **kwargs)
 
     def get_extension(self):
@@ -147,11 +147,12 @@ class HTML(TextFormat):
     TABLIB_MODULE = 'tablib.formats._html'
     CONTENT_TYPE = 'text/html'
 
-    def export_data(self, dataset, **kwargs):
-        for _ in dataset:
-            row = dataset.lpop()
-            row = [html.escape(cell) for cell in row]
-            dataset.append(row)
+    def export_data(self, dataset, escape_output=False, **kwargs):
+        if escape_output:
+            for _ in dataset:
+                row = dataset.lpop()
+                row = [html.escape(cell) for cell in row]
+                dataset.append(row)
         return dataset.export(self.get_title(), **kwargs)
 
 

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -151,7 +151,7 @@ class HTML(TextFormat):
         if escape_output:
             for _ in dataset:
                 row = dataset.lpop()
-                row = [html.escape(cell) for cell in row]
+                row = [html.escape(str(cell)) for cell in row]
                 dataset.append(row)
         return dataset.export(self.get_title(), **kwargs)
 

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -90,6 +90,11 @@ class BaseImportMixin(BaseImportExportMixin):
 
 class BaseExportMixin(BaseImportExportMixin):
     model = None
+    escape_exported_data = False
+
+    @property
+    def should_escape_output(self):
+        return getattr(settings, 'IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT', self.escape_exported_data)
 
     def get_export_formats(self):
         """
@@ -136,11 +141,6 @@ class BaseExportMixin(BaseImportExportMixin):
 
 class ExportViewMixin(BaseExportMixin):
     form_class = ExportForm
-    escape_exported_data = False
-
-    @property
-    def should_escape_output(self):
-        return getattr(settings, 'IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT', self.escape_exported_data)
 
     def get_export_data(self, file_format, queryset, *args, **kwargs):
         """

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -1,5 +1,6 @@
 import warnings
 
+from django.conf import settings
 from django.http import HttpResponse
 from django.utils.timezone import now
 from django.views.generic.edit import FormView
@@ -135,13 +136,18 @@ class BaseExportMixin(BaseImportExportMixin):
 
 class ExportViewMixin(BaseExportMixin):
     form_class = ExportForm
+    escape_exported_data = False
+
+    @property
+    def should_escape_output(self):
+        return getattr(settings, 'IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT', self.escape_exported_data)
 
     def get_export_data(self, file_format, queryset, *args, **kwargs):
         """
         Returns file_format representation for given queryset.
         """
         data = self.get_data_for_export(self.request, queryset, *args, **kwargs)
-        export_data = file_format.export_data(data)
+        export_data = file_format.export_data(data, escape_output=self.should_escape_output)
         return export_data
 
     def get_context_data(self, **kwargs):

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -205,3 +205,33 @@ class TextFormatTest(TestCase):
 
     def test_is_binary(self):
         self.assertFalse(self.format.is_binary())
+
+
+class HTMLFormatTest(TestCase):
+
+    def setUp(self):
+        self.format = base_formats.HTML()
+        self.dataset = tablib.Dataset(headers=['id', 'username', 'name'])
+        self.dataset.append(('1', 'good_user', 'John Doe'))
+        self.dataset.append(('2', 'evil_user', '<script>alert("I want to steal your credit card data")</script>'))
+
+    def test_export_data(self):
+        res = self.format.export_data(self.dataset)
+        self.assertEqual(
+            (
+                "<table>\n"
+                "<thead>\n"
+                "<tr><th>id</th>\n"
+                "<th>username</th>\n"
+                "<th>name</th></tr>\n"
+                "</thead>\n"
+                "<tr><td>1</td>\n"
+                "<td>good_user</td>\n"
+                "<td>John Doe</td></tr>\n"
+                "<tr><td>2</td>\n"
+                "<td>evil_user</td>\n"
+                "<td>&lt;script&gt;alert(&quot;I want to steal your credit card data&quot;)&lt;/script&gt;</td></tr>\n"
+                "</table>"
+            ),
+            res
+        )

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -212,7 +212,7 @@ class HTMLFormatTest(TestCase):
     def setUp(self):
         self.format = base_formats.HTML()
         self.dataset = tablib.Dataset(headers=['id', 'username', 'name'])
-        self.dataset.append(('1', 'good_user', 'John Doe'))
+        self.dataset.append((1, 'good_user', 'John Doe'))
         self.dataset.append(('2', 'evil_user', '<script>alert("I want to steal your credit card data")</script>'))
 
     def test_export_data_escape(self):

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -215,8 +215,8 @@ class HTMLFormatTest(TestCase):
         self.dataset.append(('1', 'good_user', 'John Doe'))
         self.dataset.append(('2', 'evil_user', '<script>alert("I want to steal your credit card data")</script>'))
 
-    def test_export_data(self):
-        res = self.format.export_data(self.dataset)
+    def test_export_data_escape(self):
+        res = self.format.export_data(self.dataset, escape_output=True)
         self.assertEqual(
             (
                 "<table>\n"
@@ -231,6 +231,27 @@ class HTMLFormatTest(TestCase):
                 "<tr><td>2</td>\n"
                 "<td>evil_user</td>\n"
                 "<td>&lt;script&gt;alert(&quot;I want to steal your credit card data&quot;)&lt;/script&gt;</td></tr>\n"
+                "</table>"
+            ),
+            res
+        )
+
+    def test_export_data_no_escape(self):
+        res = self.format.export_data(self.dataset)
+        self.assertEqual(
+            (
+                "<table>\n"
+                "<thead>\n"
+                "<tr><th>id</th>\n"
+                "<th>username</th>\n"
+                "<th>name</th></tr>\n"
+                "</thead>\n"
+                "<tr><td>1</td>\n"
+                "<td>good_user</td>\n"
+                "<td>John Doe</td></tr>\n"
+                "<tr><td>2</td>\n"
+                "<td>evil_user</td>\n"
+                "<td><script>alert(\"I want to steal your credit card data\")</script></td></tr>\n"
                 "</table>"
             ),
             res

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -217,42 +217,28 @@ class HTMLFormatTest(TestCase):
 
     def test_export_data_escape(self):
         res = self.format.export_data(self.dataset, escape_output=True)
-        self.assertEqual(
+        self.assertIn(
             (
-                "<table>\n"
-                "<thead>\n"
-                "<tr><th>id</th>\n"
-                "<th>username</th>\n"
-                "<th>name</th></tr>\n"
-                "</thead>\n"
                 "<tr><td>1</td>\n"
                 "<td>good_user</td>\n"
                 "<td>John Doe</td></tr>\n"
                 "<tr><td>2</td>\n"
                 "<td>evil_user</td>\n"
                 "<td>&lt;script&gt;alert(&quot;I want to steal your credit card data&quot;)&lt;/script&gt;</td></tr>\n"
-                "</table>"
             ),
             res
         )
 
     def test_export_data_no_escape(self):
         res = self.format.export_data(self.dataset)
-        self.assertEqual(
+        self.assertIn(
             (
-                "<table>\n"
-                "<thead>\n"
-                "<tr><th>id</th>\n"
-                "<th>username</th>\n"
-                "<th>name</th></tr>\n"
-                "</thead>\n"
                 "<tr><td>1</td>\n"
                 "<td>good_user</td>\n"
                 "<td>John Doe</td></tr>\n"
                 "<tr><td>2</td>\n"
                 "<td>evil_user</td>\n"
                 "<td><script>alert(\"I want to steal your credit card data\")</script></td></tr>\n"
-                "</table>"
             ),
             res
         )


### PR DESCRIPTION
**Problem**

HTML Export did not sanitize the output, resulting in a potential XSS attack. (reported: https://github.com/django-import-export/django-import-export/issues/1547)

Consider the following scenario:

* There's an users table,
* A user changes his name to a malicious string (like `<script>alert('hello')</script>`), 
* An admin triggers an export of the users table
* An admin views the export, the javascript code gets executed in his browser

This is especially risky if there's an in-place viewer for the HTML reports in django admin, under the same domain as the app.

**Solution**

I modified the HTML format to go through every cell of the export and run `html.escape` on it. 
I figured out that `export_data` would be the correct place to do it, since this is the last method that gets called in the chain - this reassures that however we trigger the export, the data will be sanitized.

**Acceptance Criteria**

I've written a test for the HTML format export that includes the potential XSS attack in the test data.