### PR TITLE
Return cleaned form data as kwargs and pass to resource

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -426,12 +426,12 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
     def get_import_data_kwargs(self, request, *args, **kwargs):
         """
-        Prepare kwargs for import_data.
+        Return form data as kwargs for import_data.
         """
         form = kwargs.get('form')
         if form:
             kwargs.pop('form')
-            return kwargs
+            return form.cleaned_data
         return {}
 
     def write_to_tmp_storage(self, import_file, input_format):


### PR DESCRIPTION
**Problem**

The data from `ImportForm` and `ConfirmImportForm` is not passed to the resource. With this proposed change the form data is passed as kwargs to the resource, and the functionality will work as described in [advanced usages: customize admin import forms](https://django-import-export.readthedocs.io/en/stable/advanced_usage.html#customize-admin-import-forms)

**Solution**

I return the cleaned_data field from the import form in `get_import_data_kwargs()`