### PR TITLE
Add documentation for passing data from admin form to Resource 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ django-import-export
 .. image:: https://img.shields.io/pypi/djversions/django-import-export
     :alt: PyPI - Django Version
 
-.. image:: https://static.pepy.tech/personalized-badge/django-import-export?period=week&units=international_system&left_color=black&right_color=blue&left_text=Downloads
+.. image:: https://static.pepy.tech/personalized-badge/django-import-export?period=month&units=international_system&left_color=black&right_color=blue&left_text=Downloads/month
     :target: https://pepy.tech/project/django-import-export
 
 django-import-export is a Django application and library for importing

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,3 +51,11 @@ deactivate
 cd ..
 rm -rf django-import-export-rel
 ```
+
+#### Add Release to Github
+
+- Go to [Github releases](https://github.com/django-import-export/django-import-export/releases)
+- Click 'Draft a new release'
+- Enter the version number (e.g. 3.1.0)
+- Select the correct tag
+- Publish the release

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -600,13 +600,16 @@ To use your customized form(s), change the respective attributes on your
 For example, imagine you want to import books for a specific author. You can
 extend the import forms to include ``author`` field to select the author from.
 
+.. note::
+
+    Importing an E-Book using the :ref:`example application<exampleapp>`
+    demonstrates this.
+
 .. figure:: _static/images/custom-import-form.png
 
    A screenshot of a customized import view.
 
-Customize forms::
-
-    from django import forms
+Customize forms (for example see ``tests/core/forms.py``)::
 
     class CustomImportForm(ImportForm):
         author = forms.ModelChoiceField(
@@ -618,7 +621,7 @@ Customize forms::
             queryset=Author.objects.all(),
             required=True)
 
-Customize ``ModelAdmin``::
+Customize ``ModelAdmin`` (for example see ``tests/core/admin.py``)::
 
     class CustomBookAdmin(ImportMixin, admin.ModelAdmin):
         resource_classes = [BookResource]
@@ -643,6 +646,23 @@ To further customize the import forms, you might like to consider overriding the
 * :meth:`~import_export.admin.ImportMixin.get_import_form_initial`
 * :meth:`~import_export.admin.ImportMixin.get_confirm_form_class`
 * :meth:`~import_export.admin.ImportMixin.get_confirm_form_kwargs`
+
+For example, to pass extract form values (so that they get passed to the import process)::
+
+    def get_import_data_kwargs(self, request, *args, **kwargs):
+        """
+        Return form data as kwargs for import_data.
+        """
+        form = kwargs.get('form')
+        if form:
+            return form.cleaned_data
+        return {}
+
+This means that form values are extracted and get passed to the import process.
+The parameters can then be read from ``Resource`` methods, such as:
+
+* :meth:`~import_export.resources.Resource.before_import`
+* :meth:`~import_export.resources.Resource.before_import_row`
 
 .. seealso::
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -658,7 +658,6 @@ For example, to pass extract form values (so that they get passed to the import 
             return form.cleaned_data
         return {}
 
-This means that form values are extracted and get passed to the import process.
 The parameters can then be read from ``Resource`` methods, such as:
 
 * :meth:`~import_export.resources.Resource.before_import`


### PR DESCRIPTION
**Problem**

It's not clear how to pass data from a custom form to the Resource.  (e.g. #1553).

**Solution**

Updated the 'advanced usage' documentation to give an example.

**Acceptance Criteria**

Tested by building docs locally and checking.