### PR TITLE
Fix RelatedObjectDoesNotExist error when an instance with an unassigned foreign key is added to a Result (#1556)

### DIFF
--- a/import_export/results.py
+++ b/import_export/results.py
@@ -40,7 +40,11 @@ class RowResult:
         if instance is not None:
             # Add object info to RowResult (e.g. for LogEntry)
             self.object_id = getattr(instance, "pk", None)
-            self.object_repr = force_str(instance)
+            try:
+                # instance with incomplete data may raise error
+                self.object_repr = force_str(instance)
+            except:
+                pass
 
 
 class InvalidRow:

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -1,4 +1,4 @@
-from core.models import Book
+from core.models import Book, Child
 from django.core.exceptions import ValidationError
 from django.test.testcases import TestCase
 from tablib import Dataset
@@ -63,3 +63,9 @@ class ResultTest(TestCase):
         row_result.add_instance_info(BookWithObjectRepr(pk=1, name="some book"))
         self.assertEqual(1, row_result.object_id)
         self.assertEqual("some book", row_result.object_repr)
+
+    def test_add_instance_info_missing_fk(self):
+        row_result = RowResult()
+        row_result.add_instance_info(Child(name="child"))
+        self.assertIsNone(row_result.object_id)
+        self.assertIsNone(row_result.object_repr)


### PR DESCRIPTION
**Problem**

See https://github.com/django-import-export/django-import-export/issues/1556#issuecomment-1459356602

**Solution**

Catch exception raised by `force_str` on the instance with an unassigned foreign key

**Acceptance Criteria**

Test case https://github.com/django-import-export/django-import-export/commit/8f9fcbdc99e98745b537d47679026b76eeb42ba1