### PR TITLE
Prevent error comparing m2m field of the new objects (#1558)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -139,3 +139,4 @@ The following is a list of much appreciated contributors:
 * Ptosiek (Antonin)
 * samupl (Jakub Szafrański)
 * smunoz-ml (Santiago Muñoz)
+* carlosal0ns0 (Carlos Alonso)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -627,7 +627,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                 # m2m instance values are taken from the 'row' because they
                 # have not been written to the 'instance' at this point
                 instance_values = list(field.clean(row))
-                original_values = list(field.get_value(original).all())
+                original_values = list() if original.pk is None else list(field.get_value(original).all())
                 if len(instance_values) != len(original_values):
                     return False
 

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -1740,6 +1740,21 @@ class ManyToManyWidgetDiffTest(TestCase):
         self.assertEqual(result.rows[0].import_type, results.RowResult.IMPORT_TYPE_UPDATE)
         self.assertEqual(Category.objects.first(), book.categories.first())
 
+    def test_many_to_many_widget_create_with_m2m_being_compared(self):
+        # issue 1558 - when the object is a new instance and m2m is evaluated for differences
+        dataset_headers = ["categories"]
+        dataset_row = ["1"]
+        dataset = tablib.Dataset(headers=dataset_headers)
+        dataset.append(dataset_row)
+        book_resource = BookResource()
+        book_resource._meta.skip_unchanged = True
+
+        result = book_resource.import_data(dataset, dry_run=False)
+
+        self.assertFalse(result.has_errors())
+        self.assertEqual(len(result.rows), 1)
+        self.assertEqual(result.rows[0].import_type, results.RowResult.IMPORT_TYPE_NEW)
+
     def test_many_to_many_widget_update(self):
         # the book is associated with 1 category ('Category 2')
         # when we import a book with category 1, the book


### PR DESCRIPTION
Problem

When importing a resource for a new instance with a many-to-many relation and non-filled fields have been evaluated for differences before the many-to-many field, an error occurs when attempting to retrieve the list of related entities from the original entity to get the differences. This happens because Django returns None when trying to retrieve a related manager for a model with a None primary key.

The specific error message is: `AttributeError: 'NoneType' object has no attribute 'all'. `in  File /venv/lib/python3.9/site-packages/import_export/resources.py", line 630, in skip_row

For more information, you can refer to issue 1558
https://github.com/django-import-export/django-import-export/issues/1558

Solution

The solution is to modify the code to not try to retrieve the list of the many-to-many relation for objects with no primary key (new objects), as they will always have an empty list.

Acceptance Criteria

I have added a new test, `core.tests.test_resources.ManyToManyWidgetDiffTest`, to ensure that the code change works correctly.