### PR TITLE
updated FAQ to include workaround for `RelatedObjectDoesNotExist` exception

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -163,3 +163,10 @@ How to use field other than `id` in Foreign Key lookup
 ------------------------------------------------------
 
 See :ref:`advanced_usage:Foreign key relations`.
+
+``RelatedObjectDoesNotExist`` exception during import
+-----------------------------------------------------
+
+This can occur if a model defines a ``__str__()`` method which references a primary key or
+foreign key relation, and which is ``None`` during import.  There is a workaround to deal
+with this issue.  Refer to `this comment <https://github.com/django-import-export/django-import-export/issues/1556#issuecomment-1466980421>`_.

--- a/security.md
+++ b/security.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+ **Please report security issues by emailing djangoimportexport@gmail.com**.
+
+ The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.


### PR DESCRIPTION
**Problem**

Added documentation to FAQ to clarify workaround for `RelatedObjectDoesNotExist` exception (see #1556).

**Solution**

FAQ entry

**Acceptance Criteria**

N/A