### PR TITLE
Refactor invalid method declarations

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -111,6 +111,8 @@ When importing using the Admin site, it can be that the ids of the imported inst
 in the preview step.  This occurs because the rows are imported during 'confirm', and then the transaction is rolled
 back prior to the confirm step.  Database implementations mean that sequence numbers may not be reused.
 
+Consider enabling :ref:`IMPORT_EXPORT_SKIP_ADMIN_CONFIRM` as a workaround.
+
 See `this issue <https://github.com/django-import-export/django-import-export/issues/560>`_ for more detailed
 discussion.
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -299,7 +299,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                 category=DeprecationWarning
             )
             return form_class(formats, **kwargs)
-        return form_class(formats, self.get_import_resource_classes(), **kwargs)
+        return form_class(formats, resources=self.get_import_resource_classes(), **kwargs)
 
     def get_import_form_class(self, request):
         """
@@ -480,9 +480,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             if issubclass(form_class, ImportExportFormBase):
                 import_form = form_class(
                     import_formats,
-                    self.get_import_resource_classes(),
                     request.POST or None,
                     request.FILES or None,
+                    resources=self.get_import_resource_classes(),
                     **form_kwargs
                 )
             else:
@@ -723,7 +723,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         else:
             form_type = self.get_export_form()
         formats = self.get_export_formats()
-        form = form_type(formats, self.get_export_resource_classes(), request.POST or None)
+        form = form_type(formats,  request.POST or None, resources=self.get_export_resource_classes())
         if form.is_valid():
             file_format = formats[
                 int(form.cleaned_data['file_format'])

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -174,9 +174,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
     def process_dataset(self, dataset, confirm_form, request, *args, rollback_on_validation_errors=False, **kwargs):
 
-        res_kwargs = self.get_import_resource_kwargs(request, form=confirm_form, *args, **kwargs)
+        res_kwargs = self.get_import_resource_kwargs(request, *args, form=confirm_form, **kwargs)
         resource = self.choose_import_resource_class(confirm_form)(**res_kwargs)
-        imp_kwargs = self.get_import_data_kwargs(request, form=confirm_form, *args, **kwargs)
+        imp_kwargs = self.get_import_data_kwargs(request, *args, form=confirm_form, **kwargs)
 
         return resource.import_data(dataset,
                                     dry_run=False,
@@ -544,12 +544,12 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
                 if not import_form.errors:
                     # prepare kwargs for import data, if needed
-                    res_kwargs = self.get_import_resource_kwargs(request, form=import_form, *args, **kwargs)
+                    res_kwargs = self.get_import_resource_kwargs(request, *args, form=import_form, **kwargs)
                     resource = self.choose_import_resource_class(import_form)(**res_kwargs)
                     resources = [resource]
 
                     # prepare additional kwargs for import_data, if needed
-                    imp_kwargs = self.get_import_data_kwargs(request, form=import_form, *args, **kwargs)
+                    imp_kwargs = self.get_import_data_kwargs(request, *args, form=import_form, **kwargs)
                     result = resource.import_data(dataset, dry_run=True,
                                                   raise_errors=False,
                                                   file_name=import_file.name,
@@ -571,7 +571,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                                 initial=self.get_form_kwargs(form=import_form, **initial)
                             )
         else:
-            res_kwargs = self.get_import_resource_kwargs(request, form=import_form, *args, **kwargs)
+            res_kwargs = self.get_import_resource_kwargs(request, *args, form=import_form, **kwargs)
             resource_classes = self.get_import_resource_classes()
             resources = [resource_class(**res_kwargs) for resource_class in resource_classes]
 

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -1,4 +1,5 @@
 import os.path
+import warnings
 
 from django import forms
 from django.conf import settings
@@ -13,8 +14,17 @@ class ImportExportFormBase(forms.Form):
         required=False,
     )
 
-    def __init__(self, resources=None, *args, **kwargs):
+    def __init__(self,  *args, resources=None, **kwargs):
         super().__init__(*args, **kwargs)
+        if len(args) > 0 and resources is None:
+            # issue 1565: definition of __init__() was incorrect
+            # this check can be removed in a future release
+            warnings.warn(
+                "resources must be supplied as a named parameter - this will be enforced in a future release",
+                category=DeprecationWarning
+            )
+            resources = args
+
         if resources and len(resources) > 1:
             resource_choices = []
             for i, resource in enumerate(resources):
@@ -34,7 +44,8 @@ class ImportForm(ImportExportFormBase):
     )
 
     def __init__(self, import_formats, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        resources = kwargs.pop("resources", None)
+        super().__init__(*args, resources=resources, **kwargs)
         choices = [
             (str(i), f().get_title())
             for i, f in enumerate(import_formats)
@@ -77,7 +88,8 @@ class ExportForm(ImportExportFormBase):
         )
 
     def __init__(self, formats, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        resources = kwargs.pop("resources", None)
+        super().__init__(*args, resources=resources, **kwargs)
         choices = []
         for i, f in enumerate(formats):
             choices.append((str(i), f().get_title(),))

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -129,7 +129,7 @@ class BaseExportMixin(BaseImportExportMixin):
         export_form = kwargs.pop('export_form', None)
         return self.choose_export_resource_class(export_form)\
             (**self.get_export_resource_kwargs(request, *args, **kwargs))\
-            .export(queryset, *args, **kwargs)
+            .export(*args, queryset=queryset, **kwargs)
 
     def get_export_filename(self, file_format):
         date_str = now().strftime('%Y-%m-%d')

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -966,10 +966,20 @@ class Resource(metaclass=DeclarativeMetaclass):
         else:
             yield from queryset.iterator(chunk_size=self.get_chunk_size())
 
-    def export(self, queryset=None, *args, **kwargs):
+    def export(self, *args, queryset=None, **kwargs):
         """
         Exports a resource.
+        :returns: Dataset object.
         """
+        if len(args) == 1 and (isinstance(args[0], QuerySet) or isinstance(args[0], list)):
+            # issue 1565: definition of export() was incorrect
+            # if queryset is being passed, it must be as the first arg or named parameter
+            # this check can be removed in a future release
+            warnings.warn(
+                "queryset must be supplied as a named parameter - this will be enforced in a future release",
+                category=DeprecationWarning
+            )
+            queryset = args[0]
 
         self.before_export(queryset, *args, **kwargs)
 

--- a/tests/core/tests/test_forms.py
+++ b/tests/core/tests/test_forms.py
@@ -22,7 +22,7 @@ class FormTest(TestCase):
 
     def test_formbase_init_two_resources(self):
         resource_list = [resources.ModelResource, MyResource]
-        form = forms.ImportExportFormBase(resource_list)
+        form = forms.ImportExportFormBase(resources=resource_list)
         self.assertEqual(
             form.fields['resource'].choices,
             [(0, 'ModelResource'), (1, "My super resource")],


### PR DESCRIPTION
**Problem**

Some of the methods are declared incorrectly.  A named parameter appears before the *args declaration which is invalid (e.g. #1565).

**Solution**

Refactor the methods and add deprecation warnings where appropriate.

**Acceptance Criteria**

Tests and documentation included.