### PR TITLE
Fix escaping to support escape of XLSX formulae

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,11 @@ Changelog
 - Prevent error comparing m2m field of the new objects (#1560)
 - Add documentation for passing data from admin form to Resource  (#1555)
 - Added new translations to Spanish and Spanish (Argentina) (#1552)
+
 - Escape formulae on export to XLSX ()
+
+  - This includes deprecation of :ref:`IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT`
+    Refer to :ref:`installation` for alternatives.
 
 3.1.0 (2023-02-21)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Changelog
 - Prevent error comparing m2m field of the new objects (#1560)
 - Add documentation for passing data from admin form to Resource  (#1555)
 - Added new translations to Spanish and Spanish (Argentina) (#1552)
+- Escape formulae on export to XLSX ()
 
 3.1.0 (2023-02-21)
 ------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -679,7 +679,10 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             raise PermissionDenied
 
         data = self.get_data_for_export(request, queryset, *args, **kwargs)
-        export_data = file_format.export_data(data, escape_output=self.should_escape_output)
+        export_data = file_format.export_data(data,
+                                              escape_output=self.should_escape_output,
+                                              escape_html=self.should_escape_html,
+                                              escape_formulae=self.should_escape_formulae)
         encoding = kwargs.get("encoding")
         if not file_format.is_binary() and encoding:
             export_data = export_data.encode(encoding)

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -202,6 +202,9 @@ class XLSX(TablibFormat):
             dataset.append(row_values)
         return dataset
 
+    def export_data(self, dataset, escape_output=False, **kwargs):
+        return dataset.export(self.get_title(), escape=escape_output, **kwargs)
+
 
 #: These are the default formats for import and export. Whether they can be
 #: used or not is depending on their implementation in the tablib library.

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -91,10 +91,26 @@ class BaseImportMixin(BaseImportExportMixin):
 class BaseExportMixin(BaseImportExportMixin):
     model = None
     escape_exported_data = False
+    escape_html = False
+    escape_formulae = False
 
     @property
     def should_escape_output(self):
+        if hasattr(settings, 'IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT'):
+            warnings.warn(
+                "IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT will be deprecated in a future release. "
+                "Refer to docs for new attributes.",
+                DeprecationWarning,
+            )
         return getattr(settings, 'IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT', self.escape_exported_data)
+
+    @property
+    def should_escape_html(self):
+        return getattr(settings, 'IMPORT_EXPORT_ESCAPE_HTML_ON_EXPORT', self.escape_html)
+
+    @property
+    def should_escape_formulae(self):
+        return getattr(settings, 'IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT', self.escape_formulae)
 
     def get_export_formats(self):
         """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 Django>=3.2
-tablib[html,ods,xls,xlsx,yaml]>=3.2.1
+tablib[html,ods,xls,xlsx,yaml]>=3.4.0
 diff-match-patch

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
 install_requires = [
     'diff-match-patch',
     'Django>=3.2',
-    'tablib[html,ods,xls,xlsx,yaml]>=3.2.1',
+    'tablib[html,ods,xls,xlsx,yaml]>=3.4.0',
 ]
 
 

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -462,7 +462,6 @@ class ImportExportAdminIntegrationTest(AdminTestMixin, TestCase):
         wb = load_workbook(filename=BytesIO(content))
         self.assertEqual('SUM(1+1)', wb.active['B2'].value)
 
-
     def test_import_export_buttons_visible_without_add_permission(self):
         # issue 38 - Export button not visible when no add permission
         original = BookAdmin.has_add_permission


### PR DESCRIPTION
**Problem**

Issue #1543

**Solution**

I have introduced two new settings attributes:

- `IMPORT_EXPORT_ESCAPE_HTML_ON_EXPORT`
- `IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT`

I have deprecated: `IMPORT_EXPORT_ESCAPE_OUTPUT_ON_EXPORT`

The reason for the change is that malicious strings can be present exported to a variety of formats and still be an issue.  For example, exporting bad HTML to CSV might still be an issue if the user opens the exported csv into a browser somehow.

Likewise, dodgy excel formulae could be exported to csv, tsv, ods, xls and xlsx and opened in Excel, so this need addressing for all formats.

I decided that it might be better for users to have more control over escaping, hence why two settings are used.  I can envisage that if someone only ever exports to HTML, there could be cases where they don't want any leading '=' characters replaced.

**Acceptance Criteria**

- Integration tests
- Manual testing
- Documentation updates