### PR TITLE
Add automatic formatting and linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+max_line_length = 88
+
+# Use 2 spaces for the HTML files
+[*.html]
+indent_size = 2
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/django-import-export-ci.yml
+++ b/.github/workflows/django-import-export-ci.yml
@@ -55,14 +55,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: isort
-      uses: jamescurtin/isort-action@master
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,17 @@
+on:
+  #pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit-ci/lite-action@v1.0.1
+      if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+    - id: black
+      exclude: \.py-tpl$
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.13.0
+    hooks:
+      - id: blacken-docs
+        additional_dependencies:
+        - black==23.3.0
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.36.0
+    hooks:
+      - id: eslint
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,15 +12,3 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-
-ci:
-    autofix_commit_msg: |
-        [pre-commit.ci] auto fixes from pre-commit.com hooks
-
-        for more information, see https://pre-commit.ci
-    autofix_prs: true
-    autoupdate_branch: ''
-    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: weekly
-    skip: []
-    submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 23.3.0
     hooks:
     - id: black
-      exclude: \.py-tpl$
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,6 @@ repos:
     hooks:
     - id: black
       exclude: \.py-tpl$
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.13.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies:
-        - black==23.3.0
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:
@@ -18,10 +12,6 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.36.0
-    hooks:
-      - id: eslint
 
 ci:
     autofix_commit_msg: |

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ clean-tests: ## remove pytest artifacts
 	rm -fr htmlcov/
 	rm -fr django-import-export/
 
-lint: ## check style with isort
-	isort --check-only .
-
 test: ## run tests quickly with the default Python
 	$(RUN_TEST_COMMAND)
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -100,6 +100,8 @@ The process should look like:
 * Create a new pull request (based on your branch), including what the problem/feature is, versions of your software
   and referencing any related issues/pull requests.
 
+* We recommend setting up your editor to automatically indicate non-conforming styles (see `Development`_).
+
 In order to be merged into django-import-export, contributions must have the following:
 
 * A solid patch that:
@@ -108,8 +110,7 @@ In order to be merged into django-import-export, contributions must have the fol
 
   * works across all supported versions of Python/Django.
 
-  * follows the existing style of the code base (mostly PEP-8).  We recommend setting up your editor to automatically
-    indicate non-conforming styles (see `Development`_).
+  * follows the existing style of the code base (mostly PEP-8).
 
   * comments included as needed to explain why the code functions as it does
 
@@ -129,10 +130,18 @@ into django-import-export proper, which may take substantial time for the all-vo
 Development
 -----------
 
-To ensure your code follows existing guidelines::
+* All files should be formatted using the black auto-formatter. This will be run by pre-commit if configured.
 
-  python -m pip install pre-commit
+* The project repository includes an ``.editorconfig`` file. We recommend using a text editor with EditorConfig support
+  to avoid indentation and whitespace issues.
 
-Then run::
+* We allow up to 88 characters as this is the line length used by black. This check is included when you run flake8.
+  Documentation, comments, and docstrings should be wrapped at 79 characters, even though PEP 8 suggests 72.
 
-  pre-commit install
+* To install pre-commit::
+
+    python -m pip install pre-commit
+
+  Then run::
+
+    pre-commit install

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -82,7 +82,7 @@ If you're ready to take the plunge and contribute back some code or documentatio
 * For substantial changes, we recommend raising a question_ first so that we can offer any advice or pointers based on
   previous experience.
 
-the process should look like:
+The process should look like:
 
 * Fork the project on GitHub into your own account.
 
@@ -108,7 +108,8 @@ In order to be merged into django-import-export, contributions must have the fol
 
   * works across all supported versions of Python/Django.
 
-  * follows the existing style of the code base (mostly PEP-8).
+  * follows the existing style of the code base (mostly PEP-8).  We recommend setting up your editor to automatically
+    indicate non-conforming styles (see `Development`_).
 
   * comments included as needed to explain why the code functions as it does
 
@@ -124,3 +125,14 @@ If your contribution lacks any of these things, they will have to be added by a 
 into django-import-export proper, which may take substantial time for the all-volunteer team to get to.
 
 .. _`AUTHORS`: https://github.com/django-import-export/django-import-export/blob/main/AUTHORS
+
+Development
+-----------
+
+To ensure your code follows existing guidelines::
+
+  python -m pip install pre-commit
+
+Then run::
+
+  pre-commit install

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -29,6 +29,8 @@ Philosophy
 Questions
 ---------
 
+Please check the :ref:`common issues <common_issues>` section of the :doc:`FAQ <faq>` to see if your question already has an answer.
+
 For general questions about usage, we recommend posting to Stack Overflow, using the
 `django-import-export <https://stackoverflow.com/questions/tagged/django-import-export/>`_ tag.  Please search existing
 answers to see if any match your problem.  If not, post a new question including as much relevant detail as you can.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -25,6 +25,8 @@ You can help in the following ways:
 
 We encourage you to read the :doc:`contributing guidelines <contributing>`.
 
+.. _common_issues:
+
 Common issues
 =============
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
-isort
 psycopg2-binary
 mysqlclient
 chardet

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,11 @@ python-file-with-version = import_export/__init__.py
 [isort]
 profile = black
 
+[flake8]
+exclude = build,.git,.tox
+extend-ignore = E203
+max-line-length = 88
+
 [coverage:run]
 parallel = true
 source = import_export

--- a/setup.py
+++ b/setup.py
@@ -5,49 +5,51 @@ from setuptools import find_packages, setup
 VERSION = __import__("import_export").__version__
 
 CLASSIFIERS = [
-    'Framework :: Django',
-    'Framework :: Django :: 3.2',
-    'Framework :: Django :: 4.0',
-    'Framework :: Django :: 4.1',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3 :: Only',
-    'Topic :: Software Development',
+    "Framework :: Django",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development",
 ]
 
 install_requires = [
-    'diff-match-patch',
-    'Django>=3.2',
-    'tablib[html,ods,xls,xlsx,yaml]>=3.4.0',
+    "diff-match-patch",
+    "Django>=3.2",
+    "tablib[html,ods,xls,xlsx,yaml]>=3.4.0",
 ]
 
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
+with open(os.path.join(os.path.dirname(__file__), "README.rst")) as f:
     readme = f.read()
 
 
 setup(
     name="django-import-export",
     description="Django application and library for importing and exporting"
-                " data with included admin integration.",
+    " data with included admin integration.",
     long_description=readme,
     version=VERSION,
     author="Bojan Mihelač",
     author_email="djangoimportexport@gmail.com",
-    license='BSD License',
-    platforms=['OS Independent'],
+    maintainer="Matthew Hegarty",
+    maintainer_email="djangoimportexport@gmail.com",
+    license="BSD License",
+    platforms=["OS Independent"],
     url="https://github.com/django-import-export/django-import-export",
     project_urls={
         "Documentation": "https://django-import-export.readthedocs.io/en/stable/",
-        "Changelog": "https://django-import-export.readthedocs.io/en/stable/changelog.html",
+        "Changelog": "https://django-import-export.readthedocs.io/en/stable/changelog.html",  # noqa: E501
     },
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 min_version = 4.0
 envlist =
-       isort
        {py37,py38,py39,py310}-{django32}
        {py38,py39,py310}-{django40}
        {py310,py311}-{django41,djangomain}
@@ -34,8 +33,3 @@ passenv =
     IMPORT_EXPORT_MYSQL_USER
     IMPORT_EXPORT_MYSQL_PASSWORD
     IMPORT_EXPORT_TEST_TYPE
-
-[testenv:isort]
-skip_install = True
-deps = isort
-commands = isort --check-only import_export tests


### PR DESCRIPTION
**Problem**

We have a long-standing issue in that we don't follow best practices by not having automatic linting / formatting.  This PR adds rules to apply black formatting and flake8 checks.

**Solution**

- Added `.pre-commit-config.yaml` to include rules for formatting using black, flake8 and isort
  - values such as line length of 88 are [black defaults](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#)  
  - I matched [Django formatting for flake8](https://github.com/django/django/blob/53aee470d5b35e2708864d5221d2b5655e10c091/setup.cfg#L56)
  - I will enable auto formatting on PRs after the global reformat has been applied.
- pre-commit checks should automatically be run for PRs using [pre-commit.ci](https://pre-commit.ci)
- removed isort from tox:  it is now redundant and replaced by pre-commit hooks
- Updated documentation on how to install pre-commit
- Added `.editorconfig`

I will apply global reformatting in a separate PR.

- Test linting works on PR submit

**Acceptance Criteria**

- Have ran tests