### PR TITLE
add information about field's dehydrate method being called on import…

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -130,6 +130,8 @@ class ResourceOptions:
     improves performance, because the copy and comparison operations are skipped for each row.
     If enabled, then ``skip_row()`` checks do not execute, because 'skip' logic requires
     comparison between the stored and imported versions of a row.
+    Custom `dehydrate` methods for fields will be called during import process while skip_diff
+    is set to ``False``.
     If enabled, then HTML row reports are also not generated (see ``skip_html_diff``).
     The default value is False.
     """


### PR DESCRIPTION
Hey there,

The other day my imports were taking somewhat long so I wanted the investigate the cause. Even though documentation somewhat mentions that `dehydrate_{field}` is for _export_, I realized It was being called on import. I though this would be a bug so I dug deeper and realized `dehydrate_{field}` was being called in order to show _diff_ for changes. 

I added documentation mentioning this behavior for `resource.Meta.skip_diff` attribute. I have spent probably more than an hour trying to find the reason, so hopefully this saves time for other users who wonder why this happens.

**Problem**
Documentation says `dehydrate_field` is for export process, it is also called on import depending on `resource.Meta.skip_diff`

**Solution**
Added documentation for this behavior.

**Acceptance Criteria**
No tests.

Did you document your changes? 
Yes.