### PR TITLE
add `original` and `instance` objects to `RowResult`

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -98,8 +98,9 @@ For example, suppose you are importing a list of books and you require additiona
 'out of print'.  This will be a one-off operation to take place on the first occasion when the book is set to 'out of
 print'.
 
-To achieve this, we need to check the existing value taken from the persisted instance with the incoming value in the
-dataset row.
+To achieve this, we need to check the existing value taken from the previous persisted instance (i.e. prior to import
+changes) with the incoming value on the updated instance (i.e. ``instance``).
+The ``instance`` is a property of ``row_result``.
 
 You can override the :meth:`~import_export.resources.Resource.after_import_row` method to check if the
 value changes::
@@ -107,8 +108,13 @@ value changes::
   class BookResource(resources.ModelResource):
     def after_import_row(self, row, row_result, row_number=None, original=None, **kwargs):
         # for updates, check to see if the 'out of print' value has changed in the import row
-        if original and original.out_of_print is False and instance.is_out_of_print is True:
+        if original and original.out_of_print is False \
+            and row_result.instance.is_out_of_print is True:
             # add custom workflow...
+
+.. note::
+
+  The ``original`` parameter will be None if :attr:`~import_export.resources.ResourceOptions.skip_diff` is True.
 
 Field widgets
 =============

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -94,28 +94,30 @@ Custom workflow based on import values
 
 You can extend the import process to add workflow based on changes to persisted model instances.
 
-For example, suppose you are importing a list of books and you require additional workflow if the book is set to
-'out of print'.  This will be a one-off operation to take place on the first occasion when the book is set to 'out of
-print'.
+For example, suppose you are importing a list of books and you require additional workflow on the date of publication.
+In this example, we assume there is an existing unpublished book instance which has a null 'published' field.
 
-To achieve this, we need to check the existing value taken from the previous persisted instance (i.e. prior to import
-changes) with the incoming value on the updated instance.  The ``instance`` is an attribute of ``row_result``.
+There will be a one-off operation to take place on the date of publication, which will be identified by the presence of
+the 'published' field in the import file.
+
+To achieve this, we need to test the existing value taken from the persisted instance (i.e. prior to import
+changes) against the incoming value on the updated instance.
+Both ``instance`` and ``original`` are attributes of :class:`~import_export.results.RowResult`.
 
 You can override the :meth:`~import_export.resources.Resource.after_import_row` method to check if the
 value changes::
 
   class BookResource(resources.ModelResource):
 
-    def after_import_row(self, row, row_result, row_number=None, original=None, **kwargs):
-        # for updates, check to see if the 'out of print' value has changed in the import row
-        if original and original.out_of_print is False \
-            and row_result.instance.is_out_of_print is True:
+    def after_import_row(self, row, row_result, **kwargs):
+        if getattr(row_result.original, "published") is None \
+            and getattr(row_result.instance, "published") is not None:
             # import value is different from stored value.
             # exec custom workflow...
 
 .. note::
 
-Refer to the docstring for :meth:`~import_export.resources.Resource.after_import_row` for additional notes.
+  The ``original`` attribute will be null if :attr:`~import_export.resources.ResourceOptions.skip_diff` is True.
 
 Field widgets
 =============

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -99,22 +99,23 @@ For example, suppose you are importing a list of books and you require additiona
 print'.
 
 To achieve this, we need to check the existing value taken from the previous persisted instance (i.e. prior to import
-changes) with the incoming value on the updated instance (i.e. ``instance``).
-The ``instance`` is a property of ``row_result``.
+changes) with the incoming value on the updated instance.  The ``instance`` is an attribute of ``row_result``.
 
 You can override the :meth:`~import_export.resources.Resource.after_import_row` method to check if the
 value changes::
 
   class BookResource(resources.ModelResource):
+
     def after_import_row(self, row, row_result, row_number=None, original=None, **kwargs):
         # for updates, check to see if the 'out of print' value has changed in the import row
         if original and original.out_of_print is False \
             and row_result.instance.is_out_of_print is True:
-            # add custom workflow...
+            # import value is different from stored value.
+            # exec custom workflow...
 
 .. note::
 
-  The ``original`` parameter will be None if :attr:`~import_export.resources.ResourceOptions.skip_diff` is True.
+Refer to the docstring for :meth:`~import_export.resources.Resource.after_import_row` for additional notes.
 
 Field widgets
 =============

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -117,7 +117,8 @@ value changes::
 
 .. note::
 
-  The ``original`` attribute will be null if :attr:`~import_export.resources.ResourceOptions.skip_diff` is True.
+  * The ``original`` attribute will be null if :attr:`~import_export.resources.ResourceOptions.skip_diff` is True.
+  * The ``instance`` attribute will be null if :attr:`~import_export.resources.ResourceOptions.store_instance` is False.
 
 Field widgets
 =============

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -115,6 +115,10 @@ value changes::
             # import value is different from stored value.
             # exec custom workflow...
 
+    class Meta:
+        model = Book
+        store_instance = True
+
 .. note::
 
   * The ``original`` attribute will be null if :attr:`~import_export.resources.ResourceOptions.skip_diff` is True.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -97,7 +97,7 @@ You can extend the import process to add workflow based on changes on incoming r
 For example, suppose you are importing a list of books and you require additional workflow if the book is set to
 'out of print'.
 
-You can override the :meth:`~import_export.resources.ModelResource.after_import_instance` method to check if the
+You can override the :meth:`~import_export.resources.Resource.after_import_instance` method to check if the
 value changes::
 
   class BookResource(resources.ModelResource):

--- a/docs/api_results.rst
+++ b/docs/api_results.rst
@@ -9,3 +9,15 @@ Result
 
 .. autoclass:: import_export.results.Result
    :members:
+
+RowResult
+---------
+
+.. autoclass:: import_export.results.RowResult
+   :members:
+
+InvalidRow
+---------
+
+.. autoclass:: import_export.results.InvalidRow
+   :members:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,7 @@ Changelog
 
 - Added support for Django 4.2 (#1570)
 - Refactoring and fix to support filtering exports (#1579)
-- pass `row` dict to :meth:`~import_export.resources.Resource.after_import_instance` (#1584)
-
+- pass `original` object to :meth:`~import_export.resources.Resource.after_import_row` (#1584)
 
 3.2.0 (2023-04-12)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Added support for Django 4.2 (#1570)
 - Refactoring and fix to support filtering exports (#1579)
+- pass `row` dict to :meth:`~import_export.resources.Resource.after_import_instance` (#1584)
 
 
 3.2.0 (2023-04-12)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Added support for Django 4.2 (#1570)
 - Refactoring and fix to support filtering exports (#1579)
-- pass `original` object to :meth:`~import_export.resources.Resource.after_import_row` (#1584)
+- Store ``instance`` and ``original`` object in :class:`~import_export.results.RowResult` (#1584)
 
 3.2.0 (2023-04-12)
 ------------------

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -195,8 +195,8 @@ class ResourceOptions:
 
     store_instance = False
     """
-    If True, the created, updated or deleted instance will be stored in
-    each :class:`~import_export.results.RowResult`.
+    If True, the row instance will be stored in each
+    :class:`~import_export.results.RowResult`.
     Enabling this parameter will increase the memory usage during import
     which should be considered when importing large datasets.
     """

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -699,13 +699,25 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         pass
 
-    def after_import_row(self, row, row_result, row_number=None, **kwargs):
+    def after_import_row(
+        self, row, row_result, row_number=None, original=None, **kwargs
+    ):
         """
         Override to add additional logic. Does nothing by default.
+
+        :param row: A ``dict`` of the import row.
+
+        :param row_result: A ``RowResult`` instance.
+
+        :param row_number: The row number from the dataset.
+
+        :param original: The model instance read from db prior to changes
+          (may be None).
+          This value will be None if ``skip_diff`` is enabled.
         """
         pass
 
-    def after_import_instance(self, instance, new, row_number=None, row=None, **kwargs):
+    def after_import_instance(self, instance, new, row_number=None, **kwargs):
         """
         Override to add additional logic. Does nothing by default.
         """
@@ -741,6 +753,8 @@ class Resource(metaclass=DeclarativeMetaclass):
 
         :param dry_run: If ``dry_run`` is set, or error occurs, transaction
             will be rolled back.
+
+        :param row_number: The row number.
         """
         if raise_errors is not None:
             warnings.warn(
@@ -801,7 +815,7 @@ class Resource(metaclass=DeclarativeMetaclass):
 
             if not skip_diff and not self._meta.skip_html_diff:
                 row_result.diff = diff.as_html()
-            self.after_import_row(row, row_result, **kwargs)
+            self.after_import_row(row, row_result, original=original, **kwargs)
 
         except ValidationError as e:
             row_result.import_type = RowResult.IMPORT_TYPE_INVALID

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -129,7 +129,7 @@ class ResourceOptions:
     Controls whether or not an instance should be diffed following import.
     By default, an instance is copied prior to insert, update or delete.
     After each row is processed, the instance's copy is diffed against the original,
-    and the value stored in each ``RowResult``.
+    and the value stored in each :class:`~import_export.results.RowResult`.
     If diffing is not required, then disabling the diff operation by setting this value
     to ``True`` improves performance, because the copy and comparison operations are
     skipped for each row.
@@ -143,7 +143,8 @@ class ResourceOptions:
     """
     Controls whether or not a HTML report is generated after each row.
     By default, the difference between a stored copy and an imported instance
-    is generated in HTML form and stored in each ``RowResult``.
+    is generated in HTML form and stored in each
+    :class:`~import_export.results.RowResult`.
     The HTML report is used to present changes on the confirmation screen in the admin
     site, hence when this value is ``True``, then changes will not be presented on the
     confirmation screen.

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -708,6 +708,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         :param row: A ``dict`` of the import row.
 
         :param row_result: A ``RowResult`` instance.
+          References the persisted ``instance`` as an attribute.
 
         :param row_number: The row number from the dataset.
 

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -753,8 +753,6 @@ class Resource(metaclass=DeclarativeMetaclass):
 
         :param dry_run: If ``dry_run`` is set, or error occurs, transaction
             will be rolled back.
-
-        :param row_number: The row number.
         """
         if raise_errors is not None:
             warnings.warn(
@@ -771,7 +769,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         try:
             self.before_import_row(row, **kwargs)
             instance, new = self.get_or_init_instance(instance_loader, row)
-            self.after_import_instance(instance, new, row=row, **kwargs)
+            self.after_import_instance(instance, new, **kwargs)
             if new:
                 row_result.import_type = RowResult.IMPORT_TYPE_NEW
             else:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -699,9 +699,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         pass
 
-    def after_import_row(
-        self, row, row_result, row_number=None, original=None, **kwargs
-    ):
+    def after_import_row(self, row, row_result, row_number=None, **kwargs):
         """
         Override to add additional logic. Does nothing by default.
 
@@ -711,10 +709,6 @@ class Resource(metaclass=DeclarativeMetaclass):
           References the persisted ``instance`` as an attribute.
 
         :param row_number: The row number from the dataset.
-
-        :param original: The model instance read from db prior to changes
-          (may be None).
-          This value will be None if ``skip_diff`` is enabled.
         """
         pass
 
@@ -789,6 +783,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                     row_result.add_instance_info(instance)
                     self.delete_instance(instance, using_transactions, dry_run)
                     if not skip_diff:
+                        row_result.original = original
                         diff.compare_with(self, None, dry_run)
             else:
                 import_validation_errors = {}
@@ -810,11 +805,12 @@ class Resource(metaclass=DeclarativeMetaclass):
                     self.save_m2m(instance, row, using_transactions, dry_run)
                 row_result.add_instance_info(instance)
                 if not skip_diff:
+                    row_result.original = original
                     diff.compare_with(self, instance, dry_run)
 
             if not skip_diff and not self._meta.skip_html_diff:
                 row_result.diff = diff.as_html()
-            self.after_import_row(row, row_result, original=original, **kwargs)
+            self.after_import_row(row, row_result, **kwargs)
 
         except ValidationError as e:
             row_result.import_type = RowResult.IMPORT_TYPE_INVALID

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -186,7 +186,16 @@ class ResourceOptions:
 
     store_row_values = False
     """
-    If True, each row's raw data will be stored in each row result.
+    If True, each row's raw data will be stored in each
+    :class:`~import_export.results.RowResult`.
+    Enabling this parameter will increase the memory usage during import
+    which should be considered when importing large datasets.
+    """
+
+    store_instance = False
+    """
+    If True, the created, updated or deleted instance will be stored in
+    each :class:`~import_export.results.RowResult`.
     Enabling this parameter will increase the memory usage during import
     which should be considered when importing large datasets.
     """
@@ -781,6 +790,8 @@ class Resource(metaclass=DeclarativeMetaclass):
                 else:
                     row_result.import_type = RowResult.IMPORT_TYPE_DELETE
                     row_result.add_instance_info(instance)
+                    if self._meta.store_instance:
+                        row_result.instance = instance
                     self.delete_instance(instance, using_transactions, dry_run)
                     if not skip_diff:
                         diff.compare_with(self, None, dry_run)
@@ -803,6 +814,8 @@ class Resource(metaclass=DeclarativeMetaclass):
                     self.save_instance(instance, new, using_transactions, dry_run)
                     self.save_m2m(instance, row, using_transactions, dry_run)
                 row_result.add_instance_info(instance)
+                if self._meta.store_instance:
+                    row_result.instance = instance
                 if not skip_diff:
                     diff.compare_with(self, instance, dry_run)
                     if not new:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -705,7 +705,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         pass
 
-    def after_import_instance(self, instance, new, row_number=None, **kwargs):
+    def after_import_instance(self, instance, new, row_number=None, row=None, **kwargs):
         """
         Override to add additional logic. Does nothing by default.
         """

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -783,7 +783,6 @@ class Resource(metaclass=DeclarativeMetaclass):
                     row_result.add_instance_info(instance)
                     self.delete_instance(instance, using_transactions, dry_run)
                     if not skip_diff:
-                        row_result.original = original
                         diff.compare_with(self, None, dry_run)
             else:
                 import_validation_errors = {}
@@ -805,8 +804,9 @@ class Resource(metaclass=DeclarativeMetaclass):
                     self.save_m2m(instance, row, using_transactions, dry_run)
                 row_result.add_instance_info(instance)
                 if not skip_diff:
-                    row_result.original = original
                     diff.compare_with(self, instance, dry_run)
+                    if not new:
+                        row_result.original = original
 
             if not skip_diff and not self._meta.skip_html_diff:
                 row_result.diff = diff.as_html()

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -757,7 +757,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         try:
             self.before_import_row(row, **kwargs)
             instance, new = self.get_or_init_instance(instance_loader, row)
-            self.after_import_instance(instance, new, **kwargs)
+            self.after_import_instance(instance, new, row=row, **kwargs)
             if new:
                 row_result.import_type = RowResult.IMPORT_TYPE_NEW
             else:

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -13,6 +13,8 @@ class Error:
 
 
 class RowResult:
+    """Container for values relating to a row import."""
+
     IMPORT_TYPE_UPDATE = "update"
     IMPORT_TYPE_NEW = "new"
     IMPORT_TYPE_DELETE = "delete"
@@ -30,14 +32,34 @@ class RowResult:
     )
 
     def __init__(self):
+        #: An instance of :class:`~import_export.results.Error` which may have been
+        #: raised during import.
         self.errors = []
+
+        #: Contains any ValidationErrors which may have been raised during import.
         self.validation_error = None
+
+        #: A HTML representation of the difference between the 'original' and
+        #: 'updated' model instance.
         self.diff = None
+
+        #: A string identifier which identifies what type of import was performed.
         self.import_type = None
+
+        #: Can the raw values associated with each imported row.
         self.row_values = {}
+
+        #: The instance id (used in Admin UI)
         self.object_id = None
+
+        #: The object representation (used in Admin UI)
         self.object_repr = None
+
+        #: A reference to the model instance which was created, updated or deleted.
         self.instance = None
+
+        #: A reference to the model instance before updates were applied.
+        #: This value is only set for updates.
         self.original = None
 
     def add_instance_info(self, instance):

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -62,12 +62,16 @@ class RowResult:
         #: This value is only set for updates.
         self.original = None
 
+        #: A boolean flag indicating whether the record is `new` or not.
+        #: Deprecated: use the value of ``import_type`` instead.
+        #: See issue 1586.
+        self.new_record = None
+
     def add_instance_info(self, instance):
         if instance is not None:
             # Add object info to RowResult (e.g. for LogEntry)
             self.object_id = getattr(instance, "pk", None)
             self.object_repr = force_str(instance)
-            self.instance = instance
 
 
 class InvalidRow:

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -37,12 +37,15 @@ class RowResult:
         self.row_values = {}
         self.object_id = None
         self.object_repr = None
+        self.instance = None
+        self.original = None
 
     def add_instance_info(self, instance):
         if instance is not None:
             # Add object info to RowResult (e.g. for LogEntry)
             self.object_id = getattr(instance, "pk", None)
             self.object_repr = force_str(instance)
+            self.instance = instance
 
 
 class InvalidRow:

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -316,6 +316,12 @@ class BookResource(resources.ModelResource):
         exclude = ("imported",)
 
 
+class BookResourceWithStoreInstance(resources.ModelResource):
+    class Meta:
+        model = Book
+        store_instance = True
+
+
 class BookResourceWithLineNumberLogger(BookResource):
     def __init__(self, *args, **kwargs):
         self.before_lines = []
@@ -666,9 +672,9 @@ class ModelResourceTest(TestCase):
         self.assertEqual(instance.price, Decimal("10.25"))
 
     def test_import_data_new_store_instance(self):
+        self.resource = BookResourceWithStoreInstance()
         Book.objects.all().delete()
         self.assertEqual(0, Book.objects.count())
-        self.resource._meta.store_instance = True
         result = self.resource.import_data(self.dataset, raise_errors=True)
 
         self.assertEqual(result.rows[0].import_type, results.RowResult.IMPORT_TYPE_NEW)
@@ -676,7 +682,7 @@ class ModelResourceTest(TestCase):
         self.assertIsNone(result.rows[0].original)
 
     def test_import_data_update_store_instance(self):
-        self.resource._meta.store_instance = True
+        self.resource = BookResourceWithStoreInstance()
         result = self.resource.import_data(self.dataset, raise_errors=True)
         self.assertEqual(
             result.rows[0].import_type, results.RowResult.IMPORT_TYPE_UPDATE

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -477,20 +477,24 @@ class ModelResourceTest(TestCase):
         instance = resource.get_instance(instance_loader, self.dataset.dict[0])
         self.assertEqual(instance, self.book)
 
-    def test_after_import_instance_row_param(self):
-        # issue 1583 - assert that row is passed to after_import_instance()
+    def test_after_import_row_kwargs(self):
+        # issue 1583 - assert that `original` object passed to after_import_row()
+        # issue 1585 - assert that row_number is passed
         class BookResource(resources.ModelResource):
-            row = None
+            original = None
+            row_number = None
 
-            def after_import_instance(self, instance, new, row_number=None, **kwargs):
-                self.row = kwargs["row"]
+            def after_import_row(self, row, row_result, original=None, **kwargs):
+                self.original = original
+                self.row_number = kwargs["row_number"]
 
             class Meta:
                 model = Book
 
         resource = BookResource()
         resource.import_data(self.dataset, raise_errors=True)
-        self.assertEqual(self.dataset.dict[0], resource.row)
+        self.assertEqual(self.book.pk, resource.original.pk)
+        self.assertEqual(1, resource.row_number)
 
     def test_get_instance_import_id_fields_with_custom_column_name(self):
         class BookResource(resources.ModelResource):

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -477,6 +477,21 @@ class ModelResourceTest(TestCase):
         instance = resource.get_instance(instance_loader, self.dataset.dict[0])
         self.assertEqual(instance, self.book)
 
+    def test_after_import_instance_row_param(self):
+        # issue 1583 - assert that row is passed to after_import_instance()
+        class BookResource(resources.ModelResource):
+            row = None
+
+            def after_import_instance(self, instance, new, row_number=None, **kwargs):
+                self.row = kwargs["row"]
+
+            class Meta:
+                model = Book
+
+        resource = BookResource()
+        resource.import_data(self.dataset, raise_errors=True)
+        self.assertEqual(self.dataset.dict[0], resource.row)
+
     def test_get_instance_import_id_fields_with_custom_column_name(self):
         class BookResource(resources.ModelResource):
             name = fields.Field(

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -479,14 +479,12 @@ class ModelResourceTest(TestCase):
 
     def test_after_import_row_kwargs(self):
         # issue 1583 - assert that `original` object passed to after_import_row()
-        # issue 1585 - assert that row_number is passed
         class BookResource(resources.ModelResource):
             original = None
             row_number = None
 
             def after_import_row(self, row, row_result, original=None, **kwargs):
                 self.original = original
-                self.row_number = kwargs["row_number"]
 
             class Meta:
                 model = Book

--- a/tests/core/tests/test_resources.py
+++ b/tests/core/tests/test_resources.py
@@ -492,7 +492,6 @@ class ModelResourceTest(TestCase):
         resource = BookResource()
         resource.import_data(self.dataset, raise_errors=True)
         self.assertEqual(self.book.pk, resource.original.pk)
-        self.assertEqual(1, resource.row_number)
 
     def test_get_instance_import_id_fields_with_custom_column_name(self):
         class BookResource(resources.ModelResource):


### PR DESCRIPTION
**Problem**

#1583.  It was previously not possible to add workflow if incoming values change.

**Solution**

- <s>The row dict is passed into `after_import_instance()` as a kwarg (meaning it will be backwards compatible).</s>
- <s>I added `original` to `after_import_row()`</s>
  - <s>I think this is cleaner because it means the comparison can take place after the instance has been successfully persisted.</s>
  - <s>We can use the instantiated `original` instance instead of checking values in `row`.</s>
- I settled on adding `original` and `instance` to `RowResult`
  -  I feel this is cleaner
  - It will potentially increase memory usage for large imports, but this can be mitigated with `skip_diff`. 
  - Added new `store_instance` option so that users can opt-in to this feature

**Acceptance Criteria**

- Added test.
- Manual testing.
- Added documentation.