### PR TITLE
A space was added after the comma

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -141,3 +141,4 @@ The following is a list of much appreciated contributors:
 * smunoz-ml (Santiago Muñoz)
 * carlosal0ns0 (Carlos Alonso)
 * travenin (Lauri Virtanen)
+* bgelov (Oleg Belov)

--- a/import_export/locale/ru/LC_MESSAGES/django.po
+++ b/import_export/locale/ru/LC_MESSAGES/django.po
@@ -79,7 +79,7 @@ msgid ""
 "Below is a preview of data to be imported. If you are satisfied with the "
 "results, click 'Confirm import'"
 msgstr ""
-"Ниже показано то, что будет импортировано. Нажмите 'Подтвердить импорт',если "
+"Ниже показано то, что будет импортировано. Нажмите 'Подтвердить импорт', если "
 "Вас устраивает результат"
 
 #: templates/admin/import_export/import.html:33


### PR DESCRIPTION
A space was added after the comma: ...импорт', если...

What problem have you solved?

There was no space after the comma in the translation.

How did you solve the problem?

Added a space

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 

Just added a space after the comma in the translation