### PR TITLE
Fixed tox build by removing reference to tablib dev

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-3.2.1 (unreleased)
+3.3.0 (unreleased)
 ------------------
 
 - Added support for Django 4.2 (#1570)
 - Refactoring and fix to support filtering exports (#1579)
 - Store ``instance`` and ``original`` object in :class:`~import_export.results.RowResult` (#1584)
+- Removed reference to tablib dev from tox build (#)
 
 3.2.0 (2023-04-12)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 - Added support for Django 4.2 (#1570)
 - Refactoring and fix to support filtering exports (#1579)
 - Store ``instance`` and ``original`` object in :class:`~import_export.results.RowResult` (#1584)
-- Removed reference to tablib dev from tox build (#)
+- Removed reference to tablib dev from tox build (#1603)
 
 3.2.0 (2023-04-12)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
        {py37,py38,py39,py310}-{django32}
        {py38,py39,py310}-{django40}
        {py310,py311}-{django41,django42,djangomain}
-       py311-djangomain-tablibdev
 
 [gh-actions]
 python =


### PR DESCRIPTION
**Problem**

The CI breaks due to a change in the HTML parser used in tablib dev (issue #1602).
This should be a temporary change until the issue with tablib is resolved (raised [here](https://github.com/jazzband/tablib/pull/554#issuecomment-1642347066))

**Solution**

Removed tablib main from tox

**Acceptance Criteria**

Tests should pass