### PR TITLE
change_list.html: add default base_template value to fix django-compress

### DIFF
--- a/import_export/templates/admin/import_export/change_list.html
+++ b/import_export/templates/admin/import_export/change_list.html
@@ -1,4 +1,4 @@
-{% extends ie_base_change_list_template %}
+{% extends ie_base_change_list_template|default:"admin/change_list.html" %}
 
 {# Original template renders object-tools only when has_add_permission is True. #}
 {# This hack allows sub templates to add to object-tools #}

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -1464,7 +1464,7 @@ class TestImportSkipConfirm(AdminTestMixin, TransactionTestCase):
 
 
 class MockModelAdmin(ImportExportMixinBase, ModelAdmin):
-    pass
+    change_list_template = "admin/import_export/change_list.html"
 
 
 class TestChangeListView(TestCase):
@@ -1480,7 +1480,7 @@ class TestChangeListView(TestCase):
         request.user = self.user
 
         # Call the changelist_view method
-        self.model_admin.base_change_list_template = None
+        self.model_admin.ie_base_change_list_template = None
         response = self.model_admin.changelist_view(request)
 
         # Render will throw an exception if the default for {% extends %} is not set

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -10,10 +10,13 @@ import django
 import tablib
 from core.admin import AuthorAdmin, BookAdmin, CustomBookAdmin, ImportMixin
 from core.models import Author, Book, Category, EBook, Parent
+from django.contrib import admin
 from django.contrib.admin.models import DELETION, LogEntry
+from django.contrib.admin.options import ModelAdmin
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
+from django.test import RequestFactory
 from django.test.testcases import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
@@ -26,6 +29,7 @@ from import_export.admin import (
     ExportActionModelAdmin,
     ExportMixin,
     ImportExportActionModelAdmin,
+    ImportExportMixinBase,
 )
 from import_export.formats import base_formats
 from import_export.formats.base_formats import DEFAULT_FORMATS
@@ -1456,4 +1460,34 @@ class TestImportSkipConfirm(AdminTestMixin, TransactionTestCase):
             "1",
             follow=True,
             str_in_response="Import finished, with 1 new and 0 updated books.",
+        )
+
+
+class MockModelAdmin(ImportExportMixinBase, ModelAdmin):
+    pass
+
+
+class TestChangeListView(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_superuser(
+            username="testuser", password="password", email="test@example.com"
+        )
+        self.model_admin = MockModelAdmin(User, admin.site)
+
+    def test_changelist_view_context(self):
+        request = self.factory.get("/admin/")
+        request.user = self.user
+
+        # Call the changelist_view method
+        self.model_admin.base_change_list_template = None
+        response = self.model_admin.changelist_view(request)
+
+        # Render will throw an exception if the default for {% extends %} is not set
+        response.render()
+
+        # Check if the base_change_list_template context variable is set to None
+        self.assertIsNone(response.context_data.get("base_change_list_template"))
+        self.assertContains(
+            response, '<a href="/admin/">Django administration</a>', html=True
         )


### PR DESCRIPTION
**Problem**

The django-compress raises following errors during run of `compress` management command:
```
# python manage.py compress
Compressing... 
Error parsing template admin/import_export/change_list_import.html: Invalid template name in 'extends' tag: ''. Got this from the 'base_change_list_template' variable.
Error parsing template admin/import_export/change_list_import_export.html: Invalid template name in 'extends' tag: ''. Got this from the 'base_change_list_template' variable.
Error parsing template admin/import_export/change_list_export.html: Invalid template name in 'extends' tag: ''. Got this from the 'base_change_list_template' variable.
Error parsing template admin/import_export/change_list.html: Invalid template name in 'extends' tag: ''. Got this from the 'base_change_list_template' variable.
```

The problem is, that the parser in `django-compress` doesn't set the `base_change_list_template` variable.

**Solution**

I set default value for the variable in the template.

**Acceptance Criteria**

I have added test that would fail if the default value is not set.