### PR TITLE
Include allowed formats settings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -143,3 +143,4 @@ The following is a list of much appreciated contributors:
 * travenin (Lauri Virtanen)
 * christophehenry (Christophe Henry)
 * bgelov (Oleg Belov)
+* EricOuma (Eric Ouma)

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -891,6 +891,12 @@ You can optionally configure import-export to sanitize data on export.  There ar
     Enabling these settings only sanitizes data exported using the Admin Interface.
     If exporting data :ref:`programmatically<exporting_data>`, then you will need to apply your own sanitization.
 
+Limiting the available import or export types can be considered. This can be done using either of the following settings:
+
+#. :ref:`IMPORT_EXPORT_FORMATS`
+#. :ref:`IMPORT_FORMATS`
+#. :ref:`EXPORT_FORMATS`
+
 You should in all cases review `Django security documentation <https://docs.djangoproject.com/en/dev/topics/security/>`_
 before deploying a live Admin interface instance.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -140,6 +140,18 @@ If set to ``True``, strings will be HTML escaped. By default this is ``False``.
 If set to ``True``, strings will be sanitized by removing any leading '=' character.  This is to prevent execution of
  Excel formulae.  By default this is ``False``.
 
+``IMPORT_FORMATS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Defines which file formats will be allowed during imports. Defaults
+to ``import_export.formats.base_formats.DEFAULT_FORMATS``.
+
+``EXPORT_FORMATS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Defines which file formats will be allowed during exports. Defaults
+to ``import_export.formats.base_formats.DEFAULT_FORMATS``.
+
 .. _exampleapp:
 
 Example app

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -143,20 +143,44 @@ If set to ``True``, strings will be sanitized by removing any leading '=' charac
 ``IMPORT_EXPORT_FORMATS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Defines which file formats will be allowed during imports and exports. Defaults
+A list that defines which file formats will be allowed during imports and exports. Defaults
 to ``import_export.formats.base_formats.DEFAULT_FORMATS``.
+The values must be those provided in ``import_export.formats.base_formats`` e.g
+
+.. code-block:: python
+
+    # settings.py
+    from import_export.formats.base_formats import XLSX
+    IMPORT_EXPORT_FORMATS = [XLSX]
+
 
 ``IMPORT_FORMATS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Defines which file formats will be allowed during imports. Defaults
+A list that defines which file formats will be allowed during imports. Defaults
 to ``IMPORT_EXPORT_FORMATS``.
+The values must be those provided in ``import_export.formats.base_formats`` e.g
+
+.. code-block:: python
+
+    # settings.py
+    from import_export.formats.base_formats import CSV, XLSX
+    IMPORT_FORMATS = [CSV, XLSX]
+
 
 ``EXPORT_FORMATS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Defines which file formats will be allowed during exports. Defaults
+A list that defines which file formats will be allowed during exports. Defaults
 to ``IMPORT_EXPORT_FORMATS``.
+The values must be those provided in ``import_export.formats.base_formats`` e.g
+
+.. code-block:: python
+
+    # settings.py
+    from import_export.formats.base_formats import XLSX
+    EXPORT_FORMATS = [XLSX]
+
 
 .. _exampleapp:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -140,17 +140,23 @@ If set to ``True``, strings will be HTML escaped. By default this is ``False``.
 If set to ``True``, strings will be sanitized by removing any leading '=' character.  This is to prevent execution of
  Excel formulae.  By default this is ``False``.
 
+``IMPORT_EXPORT_FORMATS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Defines which file formats will be allowed during imports and exports. Defaults
+to ``import_export.formats.base_formats.DEFAULT_FORMATS``.
+
 ``IMPORT_FORMATS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Defines which file formats will be allowed during imports. Defaults
-to ``import_export.formats.base_formats.DEFAULT_FORMATS``.
+to ``IMPORT_EXPORT_FORMATS``.
 
 ``EXPORT_FORMATS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Defines which file formats will be allowed during exports. Defaults
-to ``import_export.formats.base_formats.DEFAULT_FORMATS``.
+to ``IMPORT_EXPORT_FORMATS``.
 
 .. _exampleapp:
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -17,7 +17,6 @@ from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 
-from .formats.base_formats import DEFAULT_FORMATS
 from .forms import (
     ConfirmImportForm,
     ExportForm,
@@ -84,8 +83,6 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     import_export_change_list_template = "admin/import_export/change_list_import.html"
     #: template for import view
     import_template_name = "admin/import_export/import.html"
-    #: available import formats
-    formats = DEFAULT_FORMATS
     #: form class to use for the initial import step
     import_form_class = ImportForm
     #: form class to use for the confirm import step

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -14,6 +14,36 @@ from .signals import post_export
 logger = logging.getLogger(__name__)
 
 
+if getattr(settings, "EXPORT_FORMATS", None):
+    export_formats = settings.EXPORT_FORMATS
+
+    if not isinstance(export_formats, list):
+        raise Exception("The EXPORT_FORMATS value must be a list")
+
+    if not set(export_formats).issubset(set(base_formats.DEFAULT_FORMATS)):
+        raise Exception(
+            "The provided EXPORT_FORMATS values must be one of the available "
+            "formats in 'base_formats.DEFAULT_FORMATS'"
+        )
+else:
+    export_formats = base_formats.DEFAULT_FORMATS
+
+
+if getattr(settings, "IMPORT_FORMATS", None):
+    import_formats = settings.IMPORT_FORMAT
+
+    if not isinstance(import_formats, list):
+        raise Exception("The IMPORT_FORMATS value must be a list")
+
+    if not set(export_formats).issubset(set(base_formats.DEFAULT_FORMATS)):
+        raise Exception(
+            "The provided IMPORT_FORMATS values must be one of the available "
+            "formats in 'base_formats.DEFAULT_FORMATS'"
+        )
+else:
+    import_formats = base_formats.DEFAULT_FORMATS
+
+
 class BaseImportExportMixin:
     formats = base_formats.DEFAULT_FORMATS
     resource_class = None
@@ -65,6 +95,8 @@ class BaseImportExportMixin:
 
 
 class BaseImportMixin(BaseImportExportMixin):
+    formats = import_formats
+
     def get_import_resource_classes(self):
         """
         Returns ResourceClass subscriptable (list, tuple, ...) to use for import.
@@ -100,6 +132,7 @@ class BaseExportMixin(BaseImportExportMixin):
     escape_exported_data = False
     escape_html = False
     escape_formulae = False
+    formats = export_formats
 
     @property
     def should_escape_output(self):

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -111,8 +111,12 @@ class BaseImportMixinTest(TestCase):
             def __init__(self):
                 super().__init__(2, False)
 
-        m = mixins.BaseImportMixin()
-        m.formats = [CanImportFormat, CannotImportFormat]
+        class TestBaseImportMixin(mixins.BaseImportMixin):
+            @property
+            def import_formats(self):
+                return [CanImportFormat, CannotImportFormat]
+
+        m = TestBaseImportMixin()
 
         formats = m.get_import_formats()
         self.assertEqual(1, len(formats))
@@ -337,8 +341,12 @@ class BaseExportMixinTest(TestCase):
             def __init__(self):
                 super().__init__(False)
 
-        m = mixins.BaseExportMixin()
-        m.formats = [CanExportFormat, CannotExportFormat]
+        class TestBaseExportMixin(mixins.BaseExportMixin):
+            @property
+            def export_formats(self):
+                return [CanExportFormat, CannotExportFormat]
+
+        m = TestBaseExportMixin()
 
         formats = m.get_export_formats()
         self.assertEqual(1, len(formats))


### PR DESCRIPTION
**Problem**

XLS is becoming obsolete and is introducing problems such as #1592 and #1601

**Solution**

Having settings that can be used by developers to specify what formats one wants to be available to end users who know nothing about such errors.

**Acceptance Criteria**

Yes I have added tests and documented my changes

Settings
![code](https://github.com/django-import-export/django-import-export/assets/33061220/937d9b0b-189f-44c4-b41e-7601aacc3a8a)

Import Formats Available
![WhatsApp Image 2023-08-10 at 03 10 24](https://github.com/django-import-export/django-import-export/assets/33061220/09d6b0f0-3cf1-42ce-9a12-f21f9109c9f6)

Export Formats Available
![export](https://github.com/django-import-export/django-import-export/assets/33061220/09b3429f-0121-44c1-ba98-fb2683b49f72)

Export Action Formats Available
![export_action](https://github.com/django-import-export/django-import-export/assets/33061220/e1c4cec0-515d-48f1-aaab-e5530f83d870)
