### PR TITLE
Admin: set change_list_template explicitly to fix cooperation with django-adminsortable2

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -35,6 +35,15 @@ logger = logging.getLogger(__name__)
 
 
 class ImportExportMixinBase:
+    @property
+    def change_list_template(self):
+        try:
+            self.base_change_list_template = super().change_list_template
+        except AttributeError:
+            pass
+        self.property_called = True
+        return getattr(self, "import_export_change_list_template", None)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.init_change_list_template()
@@ -45,22 +54,14 @@ class ImportExportMixinBase:
         # `self.change_list_template` is `None` (the default in `ModelAdmin`) or
         # where `self.import_export_change_list_template` is `None` as falling
         # back on the default templates.
-        if getattr(self, "change_list_template", None):
+        self.change_list_template
+        if not hasattr(self, "property_called"):
             self.base_change_list_template = self.change_list_template
-        else:
-            self.base_change_list_template = "admin/change_list.html"
-
-        try:
             self.change_list_template = getattr(
                 self, "import_export_change_list_template", None
             )
-        except AttributeError:
-            logger.warning(
-                "failed to assign change_list_template attribute (see issue 1521)"
-            )
-
-        if self.change_list_template is None:
-            self.change_list_template = self.base_change_list_template
+        if not getattr(self, "base_change_list_template", None):
+            self.base_change_list_template = "admin/change_list.html"
 
     def get_model_info(self):
         app_label = self.model._meta.app_label

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from import_export.admin import (
     ExportActionModelAdmin,
+    ImportExportMixin,
     ImportExportModelAdmin,
     ImportMixin,
 )
@@ -35,6 +36,18 @@ class BookAdmin(ImportExportModelAdmin):
     list_filter = ["categories", "author"]
     resource_classes = [BookResource, BookNameResource]
     change_list_template = "core/admin/change_list.html"
+
+
+class ApplicationAdminMixin:
+    # This simulates another application which overrides change_list change_list
+    # This configuration is taken from django-admin-sortable2
+    @property
+    def change_list_template(self):
+        return "core/admin/change_list.html"
+
+
+class ApplicationModelAdmin(ImportExportMixin, ApplicationAdminMixin, admin.ModelAdmin):
+    pass
 
 
 class CategoryAdmin(ExportActionModelAdmin):


### PR DESCRIPTION
**Problem**

This PR fixes the problem is described in issue #1531
It does so by properly fixing the #1521 issue.

**Solution**

Instead of ignoring the problem and only throwing a warning it properly overrides the `@property change_list_template`.


**Acceptance Criteria**

I added test that simulates the `change_list_view @property` on `django-admin-sortable2`. It should ensure that this will work in the future.
I had to remove the test for the warning which is no longer thrown.

Screenshot of sorting ticks and import/export buttons working together:
![Snímek obrazovky pořízený 2023-08-16 11-41-23](https://github.com/django-import-export/django-import-export/assets/156755/6fe365ad-5fa3-4682-8075-6064488bc8aa)
