### PR TITLE
Enable CharWidget to return string

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 - Removed reference to tablib dev from tox build (#1603)
 - Add customizable blocks in import.html (#1598)
 - Updated ru translation (#1604)
+- Add kwargs to enable CharWidget to return values as strings (#1623)
 
 3.2.0 (2023-04-12)
 ------------------

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -110,17 +110,25 @@ class DecimalWidget(NumberWidget):
 class CharWidget(Widget):
     """
     Widget for converting text fields.
+
+    :param coerce_to_string: If True, the value returned by clean() is cast to a
+        string.
+    :param allow_blank:  If True, and if coerce_to_string is True, then clean() will
+        return null values as empty strings, otherwise as null.
     """
 
-    def __init__(self, coerce_to_string=False):
+    def __init__(self, coerce_to_string=False, allow_blank=False):
         self.coerce_to_string = coerce_to_string
+        self.allow_blank = allow_blank
 
     def clean(self, value, row=None, **kwargs):
         val = super().clean(value, row, **kwargs)
         if self.coerce_to_string is True:
             if val is None:
-                return ""
-            return force_str(val)
+                if self.allow_blank is True:
+                    return ""
+            else:
+                return force_str(val)
         return val
 
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -112,7 +112,16 @@ class CharWidget(Widget):
     Widget for converting text fields.
     """
 
-    pass
+    def __init__(self, coerce_to_string=False):
+        self.coerce_to_string = coerce_to_string
+
+    def clean(self, value, row=None, **kwargs):
+        val = super().clean(value, row, **kwargs)
+        if self.coerce_to_string is True:
+            if val is None:
+                return ""
+            return force_str(val)
+        return val
 
 
 class BooleanWidget(Widget):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -43,7 +43,15 @@ class CharWidgetTest(TestCase):
 
     def test_clean_coerce_to_string_None(self):
         self.widget = widgets.CharWidget(coerce_to_string=True)
+        self.assertIsNone(self.widget.clean(None))
+
+    def test_clean_coerce_to_string_with_allow_blank(self):
+        self.widget = widgets.CharWidget(coerce_to_string=True, allow_blank=True)
         self.assertEqual("", self.widget.clean(None))
+
+    def test_clean_coerce_to_string_is_False_with_allow_blank(self):
+        self.widget = widgets.CharWidget(coerce_to_string=False, allow_blank=True)
+        self.assertIsNone(self.widget.clean(None))
 
 
 class BooleanWidgetTest(TestCase):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -34,6 +34,17 @@ class CharWidgetTest(TestCase):
     def test_render(self):
         self.assertEqual("1", self.widget.render(1))
 
+    def test_clean_coerce_to_string(self):
+        self.widget = widgets.CharWidget(coerce_to_string=True)
+        self.assertEqual("1", self.widget.clean(1))
+
+    def test_clean_no_coerce_to_string(self):
+        self.assertEqual(1, self.widget.clean(1))
+
+    def test_clean_coerce_to_string_None(self):
+        self.widget = widgets.CharWidget(coerce_to_string=True)
+        self.assertEqual("", self.widget.clean(None))
+
 
 class BooleanWidgetTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
**Problem**

Issue #1573.

This adds options to force CharWidget to return its values as strings.  This seems logical because the other widgets use `clean()` to return their values as underlying types.

However, this could break existing implementations, so I have preserved the current default behaviour, and made it optional to return values as strings, also handling the 'null' case either as empty string or as `None`.

Maybe we will make this mandatory behaviour of CharWidget in a future release.

**Solution**

- Updated constructor to accept kwargs
- Modified clean()

**Acceptance Criteria**

Full unit tests added.