### PR TITLE
added readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,14 +7,14 @@
 #### Release
 
 - Ensure that all code has been committed and integration tests have run on Github.
-  - If pushing directly to `main` branch, ensure this is done on the correct remote repo. 
-- `make messages` is intended to be run now to keep the translation files up-to-date.  
+  - If pushing directly to `main` branch, ensure this is done on the correct remote repo.
+- `make messages` is intended to be run now to keep the translation files up-to-date.
   - Run this if there have been any translations updates for the release.  It is recommended to run this prior to any minor release.
   - This creates updates to all translation files so there is no need to commit these unless there have been any translation changes.
   - If 'no module named settings' error is seen, try unsetting `DJANGO_SETTINGS_MODULE` environment variable.
 
 ```bash
-# check out clean version 
+# check out clean version
 # all git operations will be run against this source repo
 git clone git@github.com:django-import-export/django-import-export.git django-import-export-rel
 
@@ -27,7 +27,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -U pip setuptools wheel
 
-pip install -r requirements/deploy.txt
+pip install --exists-action=w --no-cache-dir -r requirements/deploy.txt
 
 # zest.releaser pre-release
 # (you can set the correct version in this step)
@@ -36,7 +36,7 @@ prerelease
 
 #### Perform the release
 
-For the first pass you may choose not to upload only to testpypi (not pypi) so that you can check the release. You can check the release by manually downloading the files from testPyPI and checking the contents. 
+For the first pass you may choose not to upload only to testpypi (not pypi) so that you can check the release. You can check the release by manually downloading the files from testPyPI and checking the contents.
 
 Once the test file have been checked, run again to upload to PyPI.
 
@@ -59,3 +59,7 @@ rm -rf django-import-export-rel
 - Enter the version number (e.g. 3.1.0)
 - Select the correct tag
 - Publish the release
+
+### Check readthedocs
+
+Login to readthedocs.org to check that the build ran OK.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,7 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Added `.readthedocs.yaml`
 
 3.3.0 (2023-09-14)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
-- Added `.readthedocs.yaml`
+- Added `.readthedocs.yaml` (#1625)
 
 3.3.0 (2023-09-14)
 ------------------


### PR DESCRIPTION
**Problem**

- Readthedocs build failing due to python version
- [Deprecation warning](https://blog.readthedocs.com/use-build-os-config/)

**Solution**

Added .readthedocs.yaml

