### PR TITLE
fix cooperation with adminsortable2 (workaround needed)

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -46,9 +46,9 @@ class ImportExportMixinBase:
         # where `self.import_export_change_list_template` is `None` as falling
         # back on the default templates.
         if getattr(self, "change_list_template", None):
-            self.base_change_list_template = self.change_list_template
+            self.ie_base_change_list_template = self.change_list_template
         else:
-            self.base_change_list_template = "admin/change_list.html"
+            self.ie_base_change_list_template = "admin/change_list.html"
 
         try:
             self.change_list_template = getattr(
@@ -60,7 +60,7 @@ class ImportExportMixinBase:
             )
 
         if self.change_list_template is None:
-            self.change_list_template = self.base_change_list_template
+            self.change_list_template = self.ie_base_change_list_template
 
     def get_model_info(self):
         app_label = self.model._meta.app_label
@@ -68,7 +68,7 @@ class ImportExportMixinBase:
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
-        extra_context["base_change_list_template"] = self.base_change_list_template
+        extra_context["ie_base_change_list_template"] = self.ie_base_change_list_template
         return super().changelist_view(request, extra_context)
 
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -68,7 +68,9 @@ class ImportExportMixinBase:
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
-        extra_context["ie_base_change_list_template"] = self.ie_base_change_list_template
+        extra_context[
+            "ie_base_change_list_template"
+        ] = self.ie_base_change_list_template
         return super().changelist_view(request, extra_context)
 
 

--- a/import_export/templates/admin/import_export/change_list.html
+++ b/import_export/templates/admin/import_export/change_list.html
@@ -1,4 +1,4 @@
-{% extends base_change_list_template %}
+{% extends ie_base_change_list_template %}
 
 {# Original template renders object-tools only when has_add_permission is True. #}
 {# This hack allows sub templates to add to object-tools #}


### PR DESCRIPTION
**Problem**

This is partial fix for #1531
One of the problems is, that the `base_change_list_template` clashes with variable of same name used in `django-adminsortable2`.

**Solution**

I renamed the variable to be specific to this project.

**Acceptance Criteria**

Not sure if tests are needed and how they should work.