### PR TITLE
Refactor to support latest escaping logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
     - main
+    # temporary - remove after release 4
+    - release-4
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,7 @@ install-docs-requirements:  ## install requirements for docs
 
 install-requirements: install-base-requirements install-test-requirements install-docs-requirements
 
-build-html-doc: ## builds the project documentation in HTML format
+## builds the project documentation in HTML format
+## run `pip install -e .` first if running locally
+build-html-doc:
 	DJANGO_SETTINGS_MODULE=tests.settings make html -C docs

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -910,27 +910,41 @@ What is the potential risk for exported data?
 Mitigating security risks
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+You should in all cases review `Django security documentation <https://docs.djangoproject.com/en/stable/topics/security/>`_
+before deploying a live Admin interface instance.
+
+Refer to `SECURITY.md <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_ for
+details on how to escalate security issues.
+
+Sanitize exports
+""""""""""""""""
+
 By default, import-export does not sanitize or process imported data.  Malicious content, such as script directives,
 can be imported into the database, and can be exported without any modification.
 
-You can optionally configure import-export to sanitize data on export.  There are two settings which enable this:
-
-#. :ref:`IMPORT_EXPORT_ESCAPE_HTML_ON_EXPORT`
-#. :ref:`IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT`
+You can optionally configure import-export to sanitize Excel formula data on export.  See
+:ref:`IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT`.
 
 .. warning::
 
-    Enabling these settings only sanitizes data exported using the Admin Interface.
+    Enabling this setting only sanitizes data exported using the Admin Interface.
     If exporting data :ref:`programmatically<exporting_data>`, then you will need to apply your own sanitization.
 
-Limiting the available import or export types can be considered. This can be done using either of the following settings:
+Limit formats
+"""""""""""""
+
+Limiting the available import or export types can be considered. This can be done using either of the following
+settings:
 
 #. :ref:`IMPORT_EXPORT_FORMATS`
 #. :ref:`IMPORT_FORMATS`
 #. :ref:`EXPORT_FORMATS`
 
-You should in all cases review `Django security documentation <https://docs.djangoproject.com/en/dev/topics/security/>`_
-before deploying a live Admin interface instance.
+Set permissions
+"""""""""""""""
 
-Please refer to `SECURITY.md <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_ for
-details on how to escalate security issues.
+Consider setting `permissions <https://docs.djangoproject.com/en/stable/topics/auth/default/>`_ to define which
+users can import and export.
+
+#. :ref:`IMPORT_EXPORT_IMPORT_PERMISSION_CODE`
+#. :ref:`IMPORT_EXPORT_EXPORT_PERMISSION_CODE`

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -879,7 +879,7 @@ Security
 --------
 
 Enabling the Admin interface means that you should consider the security implications.  Some or all of the following
-points may be relevant:
+points may be relevant.
 
 Is there potential for untrusted imports?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -907,14 +907,13 @@ What is the potential risk for exported data?
 * Could any exported data be rendered in HTML? For example, csv is exported and then loaded into another
   web application.  In this case, untrusted input could contain malicious code such as active script content.
 
-Mitigating security risks
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
 You should in all cases review `Django security documentation <https://docs.djangoproject.com/en/stable/topics/security/>`_
 before deploying a live Admin interface instance.
 
-Refer to `SECURITY.md <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_ for
-details on how to escalate security issues.
+Mitigating security risks
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Please read the following topics carefully to understand how you can improve the security of your implementation.
 
 Sanitize exports
 """"""""""""""""
@@ -922,19 +921,24 @@ Sanitize exports
 By default, import-export does not sanitize or process imported data.  Malicious content, such as script directives,
 can be imported into the database, and can be exported without any modification.
 
+.. note::
+
+  HTML content, if exported into 'html' format, will be sanitized to remove scriptable content.
+  This sanitization is performed by the ``tablib`` library.
+
 You can optionally configure import-export to sanitize Excel formula data on export.  See
 :ref:`IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT`.
 
-.. warning::
-
-    Enabling this setting only sanitizes data exported using the Admin Interface.
-    If exporting data :ref:`programmatically<exporting_data>`, then you will need to apply your own sanitization.
+Enabling this setting only sanitizes data exported using the Admin Interface.
+If exporting data :ref:`programmatically<exporting_data>`, then you will need to apply your own sanitization.
 
 Limit formats
 """""""""""""
 
-Limiting the available import or export types can be considered. This can be done using either of the following
-settings:
+Limiting the available import or export format types can be considered. For example, if you never need to support
+import or export of spreadsheet data, you can remove this format from the application.
+
+Imports and exports can be restricted using the following settings:
 
 #. :ref:`IMPORT_EXPORT_FORMATS`
 #. :ref:`IMPORT_FORMATS`
@@ -948,3 +952,9 @@ users can import and export.
 
 #. :ref:`IMPORT_EXPORT_IMPORT_PERMISSION_CODE`
 #. :ref:`IMPORT_EXPORT_EXPORT_PERMISSION_CODE`
+
+Raising security issues
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Refer to `SECURITY.md <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_ for
+details on how to escalate security issues you may have found in import-export.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,15 +1,10 @@
 Changelog
 =========
 
-4.0.0-alpha.2 (2023-09-20)
+4.0.0-alpha.5 (2023-09-22)
 --------------------------
 
-- doc updates only
-
-4.0.0-alpha.1 (2023-09-20)
---------------------------
-
-- doc updates only
+- refactor to export HTML / formulae escaping updates (#1638)
 
 4.0.0-alpha.0 (2023-09-20)
 --------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -82,11 +82,31 @@ setting the ``tmp_storage_class`` class attribute.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If set, lists the permission code that is required for users to perform the
-'import' action. Defaults to ``None``, which means everybody can perform
+'import' action. Defaults to ``None``, which means all users can perform
 imports.
 
 Django’s built-in permissions have the codes ``add``, ``change``, ``delete``,
-and ``view``. You can also add your own permissions.
+and ``view``.  You can also add your own permissions.  For example, if you set this
+value to 'import', then you can define an explicit permission for import in the example
+app with:
+
+.. code-block:: python
+
+  from core.models import Book
+  from django.contrib.auth.models import Permission
+  from django.contrib.contenttypes.models import ContentType
+
+  content_type = ContentType.objects.get_for_model(Book)
+  permission = Permission.objects.create(
+    codename="import_book",
+    name="Can import book",
+    content_type=content_type,
+  )
+
+Now only users who are assigned 'import_book' permission will be able to perform
+imports.  For more information refer to the
+`Django auth <https://docs.djangoproject.com/en/stable/topics/auth/default/>`_
+documentation.
 
 .. _IMPORT_EXPORT_EXPORT_PERMISSION_CODE:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -76,6 +76,8 @@ during imports. Defaults to ``import_export.tmp_storages.TempFolderStorage``.
 Can be overridden on a ``ModelAdmin`` class inheriting from ``ImportMixin`` by
 setting the ``tmp_storage_class`` class attribute.
 
+.. _IMPORT_EXPORT_IMPORT_PERMISSION_CODE:
+
 ``IMPORT_EXPORT_IMPORT_PERMISSION_CODE``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -85,6 +87,9 @@ imports.
 
 Django’s built-in permissions have the codes ``add``, ``change``, ``delete``,
 and ``view``. You can also add your own permissions.
+
+
+.. _IMPORT_EXPORT_EXPORT_PERMISSION_CODE:
 
 ``IMPORT_EXPORT_EXPORT_PERMISSION_CODE``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -120,13 +125,7 @@ Note that if you disable transaction support via configuration (or if your datab
 does not support transactions), then validation errors will still be presented to the user
 but valid rows will have imported.
 
-``IMPORT_EXPORT_ESCAPE_HTML_ON_EXPORT``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If set to ``True``, strings will be HTML escaped. By default this is ``False``.
-
-This is deprecated and will be removed in a future release.  Future releases will
-escape strings by default.
+.. _IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT:
 
 ``IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -134,8 +133,10 @@ escape strings by default.
 If set to ``True``, strings will be sanitized by removing any leading '=' character.  This is to prevent execution of
 Excel formulae.  By default this is ``False``.
 
+.. _IMPORT_EXPORT_FORMATS:
+
 ``IMPORT_EXPORT_FORMATS``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A list that defines which file formats will be allowed during imports and exports. Defaults
 to ``import_export.formats.base_formats.DEFAULT_FORMATS``.
@@ -147,9 +148,10 @@ The values must be those provided in ``import_export.formats.base_formats`` e.g
     from import_export.formats.base_formats import XLSX
     IMPORT_EXPORT_FORMATS = [XLSX]
 
+.. _IMPORT_FORMATS:
 
 ``IMPORT_FORMATS``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 A list that defines which file formats will be allowed during imports. Defaults
 to ``IMPORT_EXPORT_FORMATS``.
@@ -161,6 +163,7 @@ The values must be those provided in ``import_export.formats.base_formats`` e.g
     from import_export.formats.base_formats import CSV, XLSX
     IMPORT_FORMATS = [CSV, XLSX]
 
+.. _EXPORT_FORMATS:
 
 ``EXPORT_FORMATS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -82,24 +82,19 @@ setting the ``tmp_storage_class`` class attribute.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If set, lists the permission code that is required for users to perform the
-“import” action. Defaults to ``None``, which means everybody can perform
+'import' action. Defaults to ``None``, which means everybody can perform
 imports.
 
 Django’s built-in permissions have the codes ``add``, ``change``, ``delete``,
 and ``view``. You can also add your own permissions.
-
 
 .. _IMPORT_EXPORT_EXPORT_PERMISSION_CODE:
 
 ``IMPORT_EXPORT_EXPORT_PERMISSION_CODE``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If set, lists the permission code that is required for users to perform the
-“export” action. Defaults to ``None``, which means everybody can perform
-exports.
-
-Django’s built-in permissions have the codes ``add``, ``change``, ``delete``,
-and ``view``. You can also add your own permissions.
+Defines the same behaviour as :ref:`IMPORT_EXPORT_IMPORT_PERMISSION_CODE`, but for
+export.
 
 ``IMPORT_EXPORT_CHUNK_SIZE``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -623,9 +623,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             *args,
             **kwargs,
         )
-        export_data = file_format.export_data(
-            data, **{"escape": True} if self.should_escape_formulae else {}
-        )
+        export_data = file_format.export_data(data)
         encoding = kwargs.get("encoding")
         if not file_format.is_binary() and encoding:
             export_data = export_data.encode(encoding)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -621,11 +621,10 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             request,
             queryset,
             *args,
-            escape_formulae=self.should_escape_formulae,
             **kwargs,
         )
         export_data = file_format.export_data(
-            data,
+            data, **{"escape": True} if self.should_escape_formulae else {}
         )
         encoding = kwargs.get("encoding")
         if not file_format.is_binary() and encoding:

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -617,10 +617,15 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         if not self.has_export_permission(request):
             raise PermissionDenied
 
-        data = self.get_data_for_export(request, queryset, *args, **kwargs)
+        data = self.get_data_for_export(
+            request,
+            queryset,
+            *args,
+            escape_formulae=self.should_escape_formulae,
+            **kwargs,
+        )
         export_data = file_format.export_data(
             data,
-            escape_formulae=self.should_escape_formulae,
         )
         encoding = kwargs.get("encoding")
         if not file_format.is_binary() and encoding:

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -1,5 +1,3 @@
-import html
-
 import tablib
 from tablib.formats import registry
 
@@ -85,10 +83,6 @@ class TablibFormat(Format):
         return tablib.import_set(in_stream, format=self.get_title(), **kwargs)
 
     def export_data(self, dataset, **kwargs):
-        if kwargs.pop("escape_html", None):
-            self._escape_html(dataset)
-        if kwargs.pop("escape_formulae", None):
-            self._escape_formulae(dataset)
         return dataset.export(self.get_title(), **kwargs)
 
     def get_extension(self):
@@ -102,21 +96,6 @@ class TablibFormat(Format):
 
     def can_export(self):
         return hasattr(self.get_format(), "export_set")
-
-    def _escape_html(self, dataset):
-        for _ in dataset:
-            row = dataset.lpop()
-            row = [html.escape(str(cell)) for cell in row]
-            dataset.append(row)
-
-    def _escape_formulae(self, dataset):
-        def _do_escape(s):
-            return s.replace("=", "", 1) if s.startswith("=") else s
-
-        for _ in dataset:
-            row = dataset.lpop()
-            row = [_do_escape(str(cell)) for cell in row]
-            dataset.append(row)
 
 
 class TextFormat(TablibFormat):

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -196,9 +196,8 @@ class XLSX(TablibFormat):
         return dataset
 
     def export_data(self, dataset, **kwargs):
-        kwargs.setdefault(
-            "escape",
-            getattr(settings, "IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT", False),
+        kwargs.update(
+            escape=getattr(settings, "IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT", False)
         )
         return super().export_data(dataset, **kwargs)
 

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -1,4 +1,5 @@
 import tablib
+from django.conf import settings
 from tablib.formats import registry
 
 
@@ -144,9 +145,6 @@ class HTML(TextFormat):
     TABLIB_MODULE = "tablib.formats._html"
     CONTENT_TYPE = "text/html"
 
-    def export_data(self, dataset, **kwargs):
-        return super().export_data(dataset, **kwargs)
-
 
 class XLS(TablibFormat):
     TABLIB_MODULE = "tablib.formats._xls"
@@ -196,6 +194,13 @@ class XLSX(TablibFormat):
             row_values = [cell.value for cell in row]
             dataset.append(row_values)
         return dataset
+
+    def export_data(self, dataset, **kwargs):
+        kwargs.setdefault(
+            "escape",
+            getattr(settings, "IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT", False),
+        )
+        return super().export_data(dataset, **kwargs)
 
 
 #: These are the default formats for import and export. Whether they can be

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -84,7 +84,7 @@ class TablibFormat(Format):
         return tablib.import_set(in_stream, format=self.get_title(), **kwargs)
 
     def export_data(self, dataset, **kwargs):
-        if getattr(settings, "IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT") is True:
+        if getattr(settings, "IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT", False) is True:
             self._escape_formulae(dataset)
         return dataset.export(self.get_title(), **kwargs)
 

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -79,8 +79,6 @@ class BaseImportMixin(BaseImportExportMixin):
 
 class BaseExportMixin(BaseImportExportMixin):
     model = None
-    escape_exported_data = False
-    escape_html = False
     escape_formulae = False
 
     @property

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -79,16 +79,6 @@ class BaseImportMixin(BaseImportExportMixin):
 
 class BaseExportMixin(BaseImportExportMixin):
     model = None
-    escape_formulae = False
-
-    @property
-    def should_escape_formulae(self):
-        v = getattr(
-            settings, "IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT", self.escape_formulae
-        )
-        if v is True:
-            logger.debug("IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT is enabled")
-        return v
 
     def get_export_formats(self):
         """

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1100,21 +1100,9 @@ class Resource(metaclass=DeclarativeMetaclass):
         for obj in self.iter_queryset(queryset):
             dataset.append(self.export_resource(obj))
 
-        if kwargs.get("escape_formulae") is True:
-            self._escape_formulae(dataset)
-
         self.after_export(queryset, dataset, *args, **kwargs)
 
         return dataset
-
-    def _escape_formulae(self, dataset):
-        def _do_escape(s):
-            return s.replace("=", "", 1) if s.startswith("=") else s
-
-        for _ in dataset:
-            row = dataset.lpop()
-            row = [_do_escape(str(cell)) for cell in row]
-            dataset.append(row)
 
     def _get_ordered_field_names(self, order_field):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 
+# tablib temporarily using master before v4
 dependencies = [
     "diff-match-patch",
     "Django>=3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
     "diff-match-patch",
     "Django>=3.2",
-    "tablib[html,ods,xls,xlsx,yaml]==3.5.0",
+    "tablib[html,ods,xls,xlsx,yaml]@git+https://github.com/jazzband/tablib.git@master#egg=tablib"
 ]
 
 [project.urls]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 Django>=3.2
+# # tablib temporarily using master before v4
 tablib[html,ods,xls,xlsx,yaml]@git+https://github.com/jazzband/tablib.git@master#egg=tablib
 diff-match-patch

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
 Django>=3.2
-# tablib temporarily pinned to 3.5.0 - see issue #1602
-tablib[html,ods,xls,xlsx,yaml]==3.5.0
+tablib[html,ods,xls,xlsx,yaml]@git+https://github.com/jazzband/tablib.git@master#egg=tablib
 diff-match-patch

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -211,31 +211,16 @@ class HTMLFormatTest(TestCase):
         )
 
     def test_export_html_escape(self):
-        res = self.format.export_data(self.dataset, escape_html=True)
-        self.assertIn(
-            (
-                "<tr><td>1</td>\n"
-                "<td>good_user</td>\n"
-                "<td>John Doe</td></tr>\n"
-                "<tr><td>2</td>\n"
-                "<td>evil_user</td>\n"
-                "<td>&lt;script&gt;alert(&quot;I want to steal your credit card data"
-                "&quot;)&lt;/script&gt;</td></tr>\n"
-            ),
-            res,
-        )
-
-    def test_export_data_no_escape(self):
         res = self.format.export_data(self.dataset)
         self.assertIn(
             (
-                "<tr><td>1</td>\n"
-                "<td>good_user</td>\n"
-                "<td>John Doe</td></tr>\n"
-                "<tr><td>2</td>\n"
-                "<td>evil_user</td>\n"
-                '<td><script>alert("I want to steal your credit card data")'
-                "</script></td></tr>\n"
+                "<tr><td>1</td>"
+                "<td>good_user</td>"
+                "<td>John Doe</td></tr>"
+                "<tr><td>2</td>"
+                "<td>evil_user</td>"
+                '<td>&lt;script&gt;alert("I want to steal your credit card data")'
+                "&lt;/script&gt;</td></tr>"
             ),
             res,
         )


### PR DESCRIPTION
**Problem**

The latest version of tablib supports HTML and Excel escaping, so removed the logic from our codebase.

**Solution**

Also, upgraded to latest version of tablib (i.e. master) so that HTML escaping is supported by default.

**Acceptance Criteria**

- Updated tests