### PR TITLE
`NumberWidget.render()` returns None as string

### DIFF
--- a/docs/api_widgets.rst
+++ b/docs/api_widgets.rst
@@ -5,6 +5,9 @@ Widgets
 .. autoclass:: import_export.widgets.Widget
    :members:
 
+.. autoclass:: import_export.widgets.NumberWidget
+   :members:
+
 .. autoclass:: import_export.widgets.IntegerWidget
    :members:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Updated Spanish translations (#1639)
 - Added documentation and tests for retrieving instance information after import (#1643)
+- :meth:`~import_export.widgets.NumberWidget.render` returns ``None`` as empty string
+  if ``coerce_to_string`` is True (#)
 
 
 3.3.1 (2023-09-14)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -56,9 +56,10 @@ class Widget:
 
 class NumberWidget(Widget):
     """
-    Takes optional ``coerce_to_string`` parameter, set to ``True`` the
-    :meth:`~import_export.widgets.Widget.render` method will return a string
-    else it will return a value.
+    Widget for converting numeric fields.
+
+    :param coerce_to_string: If True, render will return a string representation
+        of the value (None is returned as ""), otherwise the value is returned.
     """
 
     def __init__(self, coerce_to_string=False):
@@ -71,12 +72,14 @@ class NumberWidget(Widget):
         return value is None or value == ""
 
     def render(self, value, obj=None):
-        return number_format(value) if self.coerce_to_string else value
+        if self.coerce_to_string:
+            return "" if value is None else number_format(value)
+        return value
 
 
 class FloatWidget(NumberWidget):
     """
-    Widget for converting floats fields.
+    Widget for converting float fields.
     """
 
     def clean(self, value, row=None, **kwargs):
@@ -112,12 +115,13 @@ class CharWidget(Widget):
     Widget for converting text fields.
 
     :param coerce_to_string: If True, the value returned by clean() is cast to a
-        string.
+      string.
     :param allow_blank:  If True, and if coerce_to_string is True, then clean() will
-        return null values as empty strings, otherwise as null.
+      return null values as empty strings, otherwise as null.
     """
 
     def __init__(self, coerce_to_string=False, allow_blank=False):
+        """ """
         self.coerce_to_string = coerce_to_string
         self.allow_blank = allow_blank
 
@@ -499,5 +503,7 @@ class ManyToManyWidget(Widget):
         return self.model.objects.filter(**{"%s__in" % self.field: ids})
 
     def render(self, value, obj=None):
+        if value is None:
+            return ""
         ids = [smart_str(getattr(obj, self.field)) for obj in value.all()]
         return self.separator.join(ids)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -503,7 +503,5 @@ class ManyToManyWidget(Widget):
         return self.model.objects.filter(**{"%s__in" % self.field: ids})
 
     def render(self, value, obj=None):
-        if value is None:
-            return ""
         ids = [smart_str(getattr(obj, self.field)) for obj in value.all()]
         return self.separator.join(ids)

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -300,14 +300,14 @@ class NumberWidgetTest(TestCase):
         self.assertFalse(self.widget.is_empty(0))
 
     def test_render(self):
-        self.assertEqual(self.widget.render(self.value), self.value)
+        self.assertEqual(self.value, self.widget.render(self.value))
 
     @skipUnless(
         django.VERSION[0] < 4, f"skipping django {django.VERSION} version specific test"
     )
     @override_settings(LANGUAGE_CODE="fr-fr", USE_L10N=True)
     def test_locale_render_coerce_to_string_lt4(self):
-        self.assertEqual(self.widget_coerce_to_string.render(self.value), "11,111")
+        self.assertEqual("11,111", self.widget_coerce_to_string.render(self.value))
 
     @skipUnless(
         django.VERSION[0] >= 4,
@@ -315,7 +315,10 @@ class NumberWidgetTest(TestCase):
     )
     @override_settings(LANGUAGE_CODE="fr-fr")
     def test_locale_render_coerce_to_string_gte4(self):
-        self.assertEqual(self.widget_coerce_to_string.render(self.value), "11,111")
+        self.assertEqual("11,111", self.widget_coerce_to_string.render(self.value))
+
+    def test_coerce_to_string_value_is_None(self):
+        self.assertEqual("", self.widget_coerce_to_string.render(None))
 
 
 class FloatWidgetTest(TestCase):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -302,6 +302,9 @@ class NumberWidgetTest(TestCase):
     def test_render(self):
         self.assertEqual(self.value, self.widget.render(self.value))
 
+    def test_render_None_coerce_to_string_False(self):
+        self.assertIsNone(self.widget.render(None))
+
     @skipUnless(
         django.VERSION[0] < 4, f"skipping django {django.VERSION} version specific test"
     )


### PR DESCRIPTION
**Problem**

`NumberWidget.render()` returns 'None' as string if value is None and `coerce to string` is set.

**Solution**

Add specific check for this

**Acceptance Criteria**

Test added.