### PR TITLE
Update getting_started.rst (added a warning)

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -909,6 +909,11 @@ Refer to `this issue <https://github.com/django-import-export/django-import-expo
 
 .. _admin_security:
 
+.. warning::
+    If you use django-import-export using with `django-debug-toolbar <https://pypi.org/project/django-debug-toolbar>`_.
+    then you need to configure debug_toolbar=False or DEBUG=False,
+    otherwise the import/export time will increase ~10 times.
+
 Security
 --------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -148,3 +148,7 @@ we can export books::
     Data exported programmatically is not sanitized for malicious content.
     You will need to understand the implications of this and handle accordingly.
     See :ref:`admin_security`.
+
+    If you use django-import-export using with https://pypi.org/project/django-debug-toolbar
+    then you need to configure debug_toolbar=False or DEBUG=False,
+    otherwise the import/export time will increase ~10 times.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -148,7 +148,3 @@ we can export books::
     Data exported programmatically is not sanitized for malicious content.
     You will need to understand the implications of this and handle accordingly.
     See :ref:`admin_security`.
-
-    If you use django-import-export using with https://pypi.org/project/django-debug-toolbar
-    then you need to configure debug_toolbar=False or DEBUG=False,
-    otherwise the import/export time will increase ~10 times.


### PR DESCRIPTION
**Problem**

Added a warning that if debug_toolbar=True is used in the project, then the library's running time increases ~ 10 times.

**Solution**

It is necessary to use debug_toolbar=False.