### PR TITLE
Update advanced_usage.rst

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -918,6 +918,11 @@ Refer to `this issue <https://github.com/django-import-export/django-import-expo
 
 .. _admin_security:
 
+.. warning::
+    If you use django-import-export using with `django-debug-toolbar <https://pypi.org/project/django-debug-toolbar>`_.
+    then you need to configure debug_toolbar=False or DEBUG=False,
+    otherwise the import/export time will increase ~10 times.
+
 Security
 --------
 


### PR DESCRIPTION
Problem

Added a warning that if debug_toolbar=True is used in the project, then the library's running time increases ~ 10 times.

Solution

It is necessary to use debug_toolbar=False.