### PR TITLE
Added deprecation warning for ``LogEntry``

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 - :meth:`~import_export.widgets.NumberWidget.render` returns ``None`` as empty string
   if ``coerce_to_string`` is True (#1650)
 - Updated documentation to describe how to select for export in Admin UI (#1670)
-- Added catch for django5 deprecation warning (#)
+- Added catch for django5 deprecation warning (#1676)
 
 3.3.1 (2023-09-14)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 - :meth:`~import_export.widgets.NumberWidget.render` returns ``None`` as empty string
   if ``coerce_to_string`` is True (#1650)
 - Updated documentation to describe how to select for export in Admin UI (#1670)
+- Added catch for django5 deprecation warning (#)
 
 3.3.1 (2023-09-14)
 ------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -230,14 +230,18 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     row.import_type != row.IMPORT_TYPE_ERROR
                     and row.import_type != row.IMPORT_TYPE_SKIP
                 ):
-                    LogEntry.objects.log_action(
-                        user_id=request.user.pk,
-                        content_type_id=content_type_id,
-                        object_id=row.object_id,
-                        object_repr=row.object_repr,
-                        action_flag=logentry_map[row.import_type],
-                        change_message=_("%s through import_export" % row.import_type),
-                    )
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings("ignore", category=DeprecationWarning)
+                        LogEntry.objects.log_action(
+                            user_id=request.user.pk,
+                            content_type_id=content_type_id,
+                            object_id=row.object_id,
+                            object_repr=row.object_repr,
+                            action_flag=logentry_map[row.import_type],
+                            change_message=_(
+                                "%s through import_export" % row.import_type
+                            ),
+                        )
 
     def add_success_message(self, result, request):
         opts = self.model._meta

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -231,7 +231,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     and row.import_type != row.IMPORT_TYPE_SKIP
                 ):
                     with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=DeprecationWarning)
+                        warnings.filterwarnings(
+                            "ignore", category=PendingDeprecationWarning
+                        )
                         LogEntry.objects.log_action(
                             user_id=request.user.pk,
                             content_type_id=content_type_id,


### PR DESCRIPTION
**Problem**

Closes #1673 

This just ignores the deprecation for now.
(see #1674 for the complete fix which will go into v4)

**Solution**

Added deprecation warning so that tests pass in `main`

**Acceptance Criteria**

All tests pass.