### PR TITLE
Update method reference in get_actions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 3.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- `.export_admin_action` can be overridden by subclassing it in the `ModelAdmin`.
 
 
 3.3.2 (2023-11-09)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -918,7 +918,7 @@ class ExportActionMixin(ExportMixin):
         actions = super().get_actions(request)
         actions.update(
             export_admin_action=(
-                ExportActionMixin.export_admin_action,
+                type(self).export_admin_action,
                 "export_admin_action",
                 _("Export selected %(verbose_name_plural)s"),
             )

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -36,6 +36,7 @@ class BookAdmin(ImportExportModelAdmin):
     resource_classes = [BookResource, BookNameResource]
     change_list_template = "core/admin/change_list.html"
 
+
 class CategoryAdmin(ExportActionModelAdmin):
     def export_admin_action(self, request, queryset):
         return super().export_admin_action(request, queryset)

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from import_export.admin import (
     ExportActionModelAdmin,
     ImportExportModelAdmin,
-    ImportMixin, ExportActionMixin,
+    ImportMixin,
 )
 from import_export.resources import ModelResource
 
@@ -30,17 +30,15 @@ class BookNameResource(ModelResource):
         name = "Export/Import only book names"
 
 
-class BookAdmin(ExportActionMixin, ImportExportModelAdmin):
+class BookAdmin(ImportExportModelAdmin):
     list_display = ("name", "author", "added")
     list_filter = ["categories", "author"]
     resource_classes = [BookResource, BookNameResource]
     change_list_template = "core/admin/change_list.html"
 
+class CategoryAdmin(ExportActionModelAdmin):
     def export_admin_action(self, request, queryset):
         return super().export_admin_action(request, queryset)
-
-class CategoryAdmin(ExportActionModelAdmin):
-    pass
 
 
 class AuthorAdmin(ImportMixin, admin.ModelAdmin):

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -37,8 +37,6 @@ class BookAdmin(ExportActionMixin, ImportExportModelAdmin):
     change_list_template = "core/admin/change_list.html"
 
     def export_admin_action(self, request, queryset):
-        # just to mock
-        print('bla')
         return super().export_admin_action(request, queryset)
 
 class CategoryAdmin(ExportActionModelAdmin):

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from import_export.admin import (
     ExportActionModelAdmin,
     ImportExportModelAdmin,
-    ImportMixin,
+    ImportMixin, ExportActionMixin,
 )
 from import_export.resources import ModelResource
 
@@ -30,12 +30,16 @@ class BookNameResource(ModelResource):
         name = "Export/Import only book names"
 
 
-class BookAdmin(ImportExportModelAdmin):
+class BookAdmin(ExportActionMixin, ImportExportModelAdmin):
     list_display = ("name", "author", "added")
     list_filter = ["categories", "author"]
     resource_classes = [BookResource, BookNameResource]
     change_list_template = "core/admin/change_list.html"
 
+    def export_admin_action(self, request, queryset):
+        # just to mock
+        print('bla')
+        return super().export_admin_action(request, queryset)
 
 class CategoryAdmin(ExportActionModelAdmin):
     pass

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -33,6 +33,7 @@ from import_export.tmp_storages import TempFolderStorage
 
 
 class AdminTestMixin(object):
+    book_change_url = "/admin/core/book/"
     book_import_url = "/admin/core/book/import/"
     book_process_import_url = "/admin/core/book/process_import/"
     legacybook_import_url = "/admin/core/legacybook/import/"
@@ -255,6 +256,15 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertContains(
             response, "Import finished, with 0 new and 1 updated legacy books."
         )
+
+    def test_export_admin_action(self):
+        with mock.patch("core.admin.BookAdmin.export_admin_action") as mock_export_admin_action:
+            response = self.client.post(
+                self.book_change_url,
+                {'action': 'export_admin_action', 'index': '0', 'selected_across': '0', '_selected_action': '0'}
+            )
+            assert 200 <= response.status_code <= 399
+            mock_export_admin_action.assert_called()
 
     def test_import_action_handles_UnicodeDecodeError_as_form_error(self):
         with mock.patch(

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -258,10 +258,17 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
         )
 
     def test_export_admin_action(self):
-        with mock.patch("core.admin.BookAdmin.export_admin_action") as mock_export_admin_action:
+        with mock.patch(
+            "core.admin.BookAdmin.export_admin_action"
+        ) as mock_export_admin_action:
             response = self.client.post(
                 self.book_change_url,
-                {'action': 'export_admin_action', 'index': '0', 'selected_across': '0', '_selected_action': '0'}
+                {
+                    "action": "export_admin_action",
+                    "index": "0",
+                    "selected_across": "0",
+                    "_selected_action": "0",
+                },
             )
             assert 200 <= response.status_code <= 399
             mock_export_admin_action.assert_called()

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -33,7 +33,7 @@ from import_export.tmp_storages import TempFolderStorage
 
 
 class AdminTestMixin(object):
-    book_change_url = "/admin/core/book/"
+    category_change_url = "/admin/core/category/"
     book_import_url = "/admin/core/book/import/"
     book_process_import_url = "/admin/core/book/process_import/"
     legacybook_import_url = "/admin/core/legacybook/import/"
@@ -259,10 +259,10 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
 
     def test_export_admin_action(self):
         with mock.patch(
-            "core.admin.BookAdmin.export_admin_action"
+            "core.admin.CategoryAdmin.export_admin_action"
         ) as mock_export_admin_action:
             response = self.client.post(
-                self.book_change_url,
+                self.category_change_url,
                 {
                     "action": "export_admin_action",
                     "index": "0",


### PR DESCRIPTION
The method reference in get_actions within import_export/admin.py was updated from using ExportActionMixin.export_admin_action to type(self).export_admin_action. This change ensures that the function call always refers to the current instance's class method. This is particularly important in situations where the class has been inherited and the method overridden. Fixing #1680.

**Problem**

Subclassing `.export_admin_action` did not work: the old method was still triggered.

**Solution**

Allow subclassing `.export_admin_action` by using `type(self)` instead of `ExportActionMixin`.