### PR TITLE
update docker-compose command to docker compose V2 syntax

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,7 @@ Enhancements
 Fixes
 #####
 
+- Updated `docker-compose` command with latest version syntax in `runtests.sh` (#1686)
 - dynamic widget parameters for CharField fixes 'NOT NULL constraint' error in xlsx (#1485)
 - fix cooperation with adminsortable2 (#1633)
 - Removed unused method ``utils.original()``

--- a/runtests.sh
+++ b/runtests.sh
@@ -14,7 +14,7 @@ export IMPORT_EXPORT_MYSQL_USER=mysqluser
 export IMPORT_EXPORT_MYSQL_PASSWORD=mysqluserpass
 
 echo "starting local database instances"
-docker-compose -f tests/docker-compose.yml up -d
+docker compose -f tests/docker-compose.yml up -d
 
 echo "waiting for db initialization"
 sleep 45
@@ -31,4 +31,4 @@ export IMPORT_EXPORT_TEST_TYPE=postgres
 tox
 
 echo "removing local database instances"
-docker-compose -f tests/docker-compose.yml down -v
+docker compose -f tests/docker-compose.yml down -v


### PR DESCRIPTION
Updated `docker-compose` command to docker compose V2 syntax which is `docker compose` without dash.

#1686