### PR TITLE
fix declaring existing model fields in ModelResrouce altering export …

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,7 @@ Enhancements
 Fixes
 #####
 
+- fix declaring existing model field(s) in ModelResource altering export order (#1663)
 - dynamic widget parameters for CharField fixes 'NOT NULL constraint' error in xlsx (#1485)
 - fix cooperation with adminsortable2 (#1633)
 - Removed unused method ``utils.original()``

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1357,7 +1357,8 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                     continue
 
                 if f.name in declared_fields:
-                    # If model field is declared in `ModelResource`, remove it from `declared_fields`
+                    # If model field is declared in `ModelResource`,
+                    # remove it from `declared_fields`
                     # to keep exact order of model fields
                     field = declared_fields.pop(f.name)
                 else:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1355,14 +1355,14 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                     continue
                 if opts.exclude and f.name in opts.exclude:
                     continue
-                
+
                 if f.name in declared_fields:
                     # If model field is declared in `ModelResource`, remove it from `declared_fields`
                     # to keep exact order of model fields
                     field = declared_fields.pop(f.name)
                 else:
                     field = new_class.field_from_django_field(f.name, f, readonly=False)
-                
+
                 field_list.append(
                     (
                         f.name,
@@ -1371,10 +1371,7 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                 )
 
             # Order as model fields first then declared fields by default
-            new_class.fields = OrderedDict([
-                *field_list,
-                *new_class.fields.items()
-            ])
+            new_class.fields = OrderedDict([*field_list, *new_class.fields.items()])
 
             # add fields that follow relationships
             if opts.fields is not None:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1355,10 +1355,14 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                     continue
                 if opts.exclude and f.name in opts.exclude:
                     continue
+                
                 if f.name in declared_fields:
-                    continue
-
-                field = new_class.field_from_django_field(f.name, f, readonly=False)
+                    # If model field is declared in `ModelResource`, remove it from `declared_fields`
+                    # to keep exact order of model fields
+                    field = declared_fields.pop(f.name)
+                else:
+                    field = new_class.field_from_django_field(f.name, f, readonly=False)
+                
                 field_list.append(
                     (
                         f.name,
@@ -1366,7 +1370,11 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                     )
                 )
 
-            new_class.fields.update(OrderedDict(field_list))
+            # Order as model fields first then declared fields by default
+            new_class.fields = OrderedDict([
+                *field_list,
+                *new_class.fields.items()
+            ])
 
             # add fields that follow relationships
             if opts.fields is not None:

--- a/tests/core/tests/test_resources/test_import_export.py
+++ b/tests/core/tests/test_resources/test_import_export.py
@@ -1,8 +1,8 @@
-from unittest.mock import patch
 from datetime import date
+from unittest.mock import patch
 
 import tablib
-from core.models import Book, Author, Category
+from core.models import Author, Book, Category
 from core.tests.resources import BookResource
 from core.tests.utils import ignore_widget_deprecation_warning
 from django.test import TestCase
@@ -83,7 +83,6 @@ class ImportExportFieldOrderTest(TestCase):
             model = Book
 
     class DeclaredModelFieldBookResource(BaseBookResource):
-            
         # Non-model field, should come after model fields by default
         author_full_name = fields.Field(
             attribute="author",
@@ -94,20 +93,14 @@ class ImportExportFieldOrderTest(TestCase):
         categories = fields.Field(
             attribute="categories",
             column_name="categories",
-            widget=widgets.ManyToManyWidget(
-                model=Category,
-                field="name"
-            )
+            widget=widgets.ManyToManyWidget(model=Category, field="name"),
         )
         published = fields.Field(
             attribute="published",
             column_name="published",
-            widget=widgets.DateWidget("%d.%m.%Y")
+            widget=widgets.DateWidget("%d.%m.%Y"),
         )
-        author = fields.Field(
-            attribute="author__name",
-            column_name="author"
-        )
+        author = fields.Field(attribute="author__name", column_name="author")
 
         class Meta:
             model = Book
@@ -115,7 +108,7 @@ class ImportExportFieldOrderTest(TestCase):
         def dehydrate_author_full_name(self, obj):
             if obj.author:
                 return f"{obj.author.name} Bar"
-            
+
             return ""
 
     def setUp(self):
@@ -200,41 +193,39 @@ class ImportExportFieldOrderTest(TestCase):
 
         categories = [
             Category.objects.create(name="sci-fi"),
-            Category.objects.create(name="romance")
+            Category.objects.create(name="romance"),
         ]
         author = Author.objects.create(name="Foo")
         book = Book.objects.create(
-            name="The Lord Of The Rings",
-            author=author,
-            published=date(2022, 2, 2)
+            name="The Lord Of The Rings", author=author, published=date(2022, 2, 2)
         )
         book.categories.set(categories)
 
         self.resource = ImportExportFieldOrderTest.DeclaredModelFieldBookResource()
         declared_field_names = (
             "published",
-            "author", # FK
-            "categories", # M2M
+            "author",  # FK
+            "categories",  # M2M
         )
-        export_order  = self.resource.get_export_order()
-        model_fields_names = [field.name for field in self.resource._meta.model._meta.get_fields()]
+        export_order = self.resource.get_export_order()
+        model_fields_names = [
+            field.name for field in self.resource._meta.model._meta.get_fields()
+        ]
 
         for declared_field_name in declared_field_names:
             self.assertEqual(
                 model_fields_names.index(declared_field_name),
-                export_order.index(declared_field_name)
+                export_order.index(declared_field_name),
             )
 
         # Validate non-model field is exported last unless specified
-        self.assertEqual(
-            export_order[-1],
-            "author_full_name"
-        )
+        self.assertEqual(export_order[-1], "author_full_name")
 
     @ignore_widget_deprecation_warning
     def test_meta_fields_not_alter_export_order(self):
-        class DeclaredModelFieldBookResource(ImportExportFieldOrderTest.BaseBookResource):
-            
+        class DeclaredModelFieldBookResource(
+            ImportExportFieldOrderTest.BaseBookResource
+        ):
             # Non-model field, should come after model fields by default
             author_full_name = fields.Field(
                 attribute="author",
@@ -245,36 +236,34 @@ class ImportExportFieldOrderTest(TestCase):
             categories = fields.Field(
                 attribute="categories",
                 column_name="categories",
-                widget=widgets.ManyToManyWidget(
-                    model=Category,
-                    field="name"
-                )
+                widget=widgets.ManyToManyWidget(model=Category, field="name"),
             )
             published = fields.Field(
                 attribute="published",
                 column_name="published",
-                widget=widgets.DateWidget("%d.%m.%Y")
+                widget=widgets.DateWidget("%d.%m.%Y"),
             )
-            author = fields.Field(
-                attribute="author__name",
-                column_name="author"
-            )
+            author = fields.Field(attribute="author__name", column_name="author")
 
             class Meta:
                 model = Book
-                fields = ("id", "author__name", "author", "author_full_name", "categories", "published")
+                fields = (
+                    "id",
+                    "author__name",
+                    "author",
+                    "author_full_name",
+                    "categories",
+                    "published",
+                )
 
             def dehydrate_author_full_name(self, obj):
                 if obj.author:
                     return f"{obj.author.name} Bar"
-                
+
                 return ""
-        
+
         self.resource = DeclaredModelFieldBookResource()
-        self.assertEqual(
-            self.resource.get_export_order(),
-            self.resource._meta.fields
-        )
+        self.assertEqual(self.resource.get_export_order(), self.resource._meta.fields)
 
 
 class ImportIdFieldsTestCase(TestCase):

--- a/tests/core/tests/test_resources/test_import_export.py
+++ b/tests/core/tests/test_resources/test_import_export.py
@@ -1,12 +1,13 @@
 from unittest.mock import patch
+from datetime import date
 
 import tablib
-from core.models import Book
+from core.models import Book, Author, Category
 from core.tests.resources import BookResource
 from core.tests.utils import ignore_widget_deprecation_warning
 from django.test import TestCase
 
-from import_export import exceptions, fields, resources
+from import_export import exceptions, fields, resources, widgets
 
 
 class AfterImportComparisonTest(TestCase):
@@ -80,6 +81,42 @@ class ImportExportFieldOrderTest(TestCase):
         class Meta:
             fields = ["id", "price", "name"]
             model = Book
+
+    class DeclaredModelFieldBookResource(BaseBookResource):
+            
+        # Non-model field, should come after model fields by default
+        author_full_name = fields.Field(
+            attribute="author",
+            column_name="author full name",
+        )
+
+        # Order of declared fields in `ModelResource` shouldn't change export order
+        categories = fields.Field(
+            attribute="categories",
+            column_name="categories",
+            widget=widgets.ManyToManyWidget(
+                model=Category,
+                field="name"
+            )
+        )
+        published = fields.Field(
+            attribute="published",
+            column_name="published",
+            widget=widgets.DateWidget("%d.%m.%Y")
+        )
+        author = fields.Field(
+            attribute="author__name",
+            column_name="author"
+        )
+
+        class Meta:
+            model = Book
+
+        def dehydrate_author_full_name(self, obj):
+            if obj.author:
+                return f"{obj.author.name} Bar"
+            
+            return ""
 
     def setUp(self):
         super().setUp()
@@ -156,6 +193,88 @@ class ImportExportFieldOrderTest(TestCase):
         data = self.resource.export()
         target = f"id,price,name\r\n{self.pk},1.99,Ulysses\r\n"
         self.assertEqual(target, data.csv)
+
+    @ignore_widget_deprecation_warning
+    def test_declared_model_fields_not_alter_export_order(self):
+        # Issue (#1663)
+
+        categories = [
+            Category.objects.create(name="sci-fi"),
+            Category.objects.create(name="romance")
+        ]
+        author = Author.objects.create(name="Foo")
+        book = Book.objects.create(
+            name="The Lord Of The Rings",
+            author=author,
+            published=date(2022, 2, 2)
+        )
+        book.categories.set(categories)
+
+        self.resource = ImportExportFieldOrderTest.DeclaredModelFieldBookResource()
+        declared_field_names = (
+            "published",
+            "author", # FK
+            "categories", # M2M
+        )
+        export_order  = self.resource.get_export_order()
+        model_fields_names = [field.name for field in self.resource._meta.model._meta.get_fields()]
+
+        for declared_field_name in declared_field_names:
+            self.assertEqual(
+                model_fields_names.index(declared_field_name),
+                export_order.index(declared_field_name)
+            )
+
+        # Validate non-model field is exported last unless specified
+        self.assertEqual(
+            export_order[-1],
+            "author_full_name"
+        )
+
+    @ignore_widget_deprecation_warning
+    def test_meta_fields_not_alter_export_order(self):
+        class DeclaredModelFieldBookResource(ImportExportFieldOrderTest.BaseBookResource):
+            
+            # Non-model field, should come after model fields by default
+            author_full_name = fields.Field(
+                attribute="author",
+                column_name="author full name",
+            )
+
+            # Order of declared fields in `ModelResource` shouldn't change export order
+            categories = fields.Field(
+                attribute="categories",
+                column_name="categories",
+                widget=widgets.ManyToManyWidget(
+                    model=Category,
+                    field="name"
+                )
+            )
+            published = fields.Field(
+                attribute="published",
+                column_name="published",
+                widget=widgets.DateWidget("%d.%m.%Y")
+            )
+            author = fields.Field(
+                attribute="author__name",
+                column_name="author"
+            )
+
+            class Meta:
+                model = Book
+                fields = ("id", "author__name", "author", "author_full_name", "categories", "published")
+
+            def dehydrate_author_full_name(self, obj):
+                if obj.author:
+                    return f"{obj.author.name} Bar"
+                
+                return ""
+        
+        self.resource = DeclaredModelFieldBookResource()
+        self.assertEqual(
+            self.resource.get_export_order(),
+            self.resource._meta.fields
+        )
 
 
 class ImportIdFieldsTestCase(TestCase):

--- a/tests/core/tests/test_resources/test_import_export.py
+++ b/tests/core/tests/test_resources/test_import_export.py
@@ -187,7 +187,6 @@ class ImportExportFieldOrderTest(TestCase):
         target = f"id,price,name\r\n{self.pk},1.99,Ulysses\r\n"
         self.assertEqual(target, data.csv)
 
-    @ignore_widget_deprecation_warning
     def test_declared_model_fields_not_alter_export_order(self):
         # Issue (#1663)
 
@@ -221,7 +220,6 @@ class ImportExportFieldOrderTest(TestCase):
         # Validate non-model field is exported last unless specified
         self.assertEqual(export_order[-1], "author_full_name")
 
-    @ignore_widget_deprecation_warning
     def test_meta_fields_not_alter_export_order(self):
         class DeclaredModelFieldBookResource(
             ImportExportFieldOrderTest.BaseBookResource

--- a/tests/core/tests/test_resources/test_resources.py
+++ b/tests/core/tests/test_resources/test_resources.py
@@ -309,11 +309,11 @@ class ModelResourceTest(TestCase):
         self.assertEqual(
             headers,
             [
-                "published_date",
                 "id",
                 "name",
                 "author",
                 "author_email",
+                "published_date",
                 "published_time",
                 "price",
                 "added",


### PR DESCRIPTION
#1663 

**Problem**

Declaring existing model field(s) in `ModelResource` changes export order

**Solution**

On `ModelDeclarativeMetaclass` definition, if resource field exists in model fields, keep the order instead of pushing all declared fields before model fields.

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Yes

Did you document your changes? 
Yes