### PR TITLE
Handle python3.12 datetime utc deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
     services:
       postgres:
         image: postgres

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Please refer to :doc:`release notes<release_notes>`.
 - Refactored :module:`~import_export.resources` into separate modules for ``declarative`` and ``options`` (#1695)
 - fix multiple inheritance not setting options (#1696)
 - Refactored tests to remove dependencies between tests (#1703)
+- Handle python3.12 datetime deprecations (#1705)
 
 4.0.0-beta.1 (2023-11-16)
 --------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -70,8 +70,9 @@ Documentation
 ------------------
 
 - Added support for django5 (#1634)
-- Added `CONTRIBUTING.md`
 - Show list of exported fields in Admin UI (#1685)
+- Added `CONTRIBUTING.md`
+- Added support for python 3.12 (#1698)
 - Update Finnish translations (#1701)
 
 3.3.3 (2023-11-11)

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -1,3 +1,5 @@
+import warnings
+
 import tablib
 from django.conf import settings
 from tablib.formats import registry
@@ -205,6 +207,13 @@ class XLSX(TablibFormat):
             row_values = [cell.value for cell in row]
             dataset.append(row_values)
         return dataset
+
+    def export_data(self, dataset, **kwargs):
+        # #1698 temporary catch for deprecation warning in openpyxl
+        # this catch block must be removed when openpyxl updated
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return super().export_data(dataset, **kwargs)
 
 
 #: These are the default formats for import and export. Whether they can be

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 from io import BytesIO
 from unittest import mock
@@ -141,7 +142,11 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
         response = self.client.post("/admin/core/book/export/", data)
         self.assertEqual(response.status_code, 200)
         content = response.content
-        wb = load_workbook(filename=BytesIO(content))
+        # #1698 temporary catch for deprecation warning in openpyxl
+        # this catch block must be removed when openpyxl updated
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            wb = load_workbook(filename=BytesIO(content))
         self.assertEqual("<script>alert(1)</script>", wb.active["B2"].value)
         self.assertEqual("SUM(1+1)", wb.active["B3"].value)
 

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -1,4 +1,3 @@
-import warnings
 from datetime import datetime
 from io import BytesIO
 from unittest import mock
@@ -132,6 +131,7 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )
 
+    @ignore_utcnow_deprecation_warning
     @override_settings(IMPORT_EXPORT_ESCAPE_FORMULAE_ON_EXPORT=True)
     @ignore_widget_deprecation_warning
     def test_export_escape_formulae(self):
@@ -145,11 +145,7 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
         response = self.client.post("/admin/core/book/export/", data)
         self.assertEqual(response.status_code, 200)
         content = response.content
-        # #1698 temporary catch for deprecation warning in openpyxl
-        # this catch block must be removed when openpyxl updated
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            wb = load_workbook(filename=BytesIO(content))
+        wb = load_workbook(filename=BytesIO(content))
         self.assertEqual("<script>alert(1)</script>", wb.active["B2"].value)
         self.assertEqual("SUM(1+1)", wb.active["B3"].value)
 

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -8,7 +8,10 @@ import chardet
 import tablib
 from core.models import Author, Book
 from core.tests.admin_integration.mixins import AdminTestMixin
-from core.tests.utils import ignore_widget_deprecation_warning
+from core.tests.utils import (
+    ignore_utcnow_deprecation_warning,
+    ignore_widget_deprecation_warning,
+)
 from django.http import HttpRequest
 from django.test.testcases import TestCase
 from django.test.utils import override_settings
@@ -259,6 +262,7 @@ class TestExportEncoding(TestCase):
                 encoding="bad-encoding",
             )
 
+    @ignore_utcnow_deprecation_warning
     def test_to_encoding_not_set_for_binary_file(self):
         self.export_mixin = self.TestMixin(test_str="teststr")
         self.file_format = formats.base_formats.XLSX()

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 
 import tablib
+from core.tests.utils import ignore_utcnow_deprecation_warning
 from django.test import TestCase
 from django.utils.encoding import force_str
 from tablib.core import UnsupportedFormat
@@ -94,6 +95,7 @@ class XLSXTest(TestCase):
     def test_binary_format(self):
         self.assertTrue(self.format.is_binary())
 
+    @ignore_utcnow_deprecation_warning
     def test_import(self):
         with open(self.filename, self.format.get_read_mode()) as in_stream:
             dataset = self.format.create_dataset(in_stream.read())

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -5,8 +5,8 @@ from unittest import mock, skipUnless
 from unittest.mock import patch
 
 import django
-import pytz
 from core.models import Author, Book, Category
+from core.tests.utils import ignore_utcnow_deprecation_warning
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
@@ -196,14 +196,20 @@ class DateTimeWidgetTest(TestCase, RowDeprecationTestMixin):
             "time data '2021-05-01' does not match format 'x'"
         )
 
+    @ignore_utcnow_deprecation_warning
     @override_settings(USE_TZ=True, TIME_ZONE="Europe/Ljubljana")
     def test_use_tz(self):
+        import pytz
+
         utc_dt = timezone.make_aware(self.datetime, pytz.UTC)
         self.assertEqual(self.widget.render(utc_dt), "13.08.2012 20:00:00")
         self.assertEqual(self.widget.clean("13.08.2012 20:00:00"), utc_dt)
 
+    @ignore_utcnow_deprecation_warning
     @override_settings(USE_TZ=True, TIME_ZONE="Europe/Ljubljana")
     def test_clean_returns_tz_aware_datetime_when_naive_datetime_passed(self):
+        import pytz
+
         # issue 1165
         if django.VERSION >= (5, 0):
             from zoneinfo import ZoneInfo
@@ -214,8 +220,11 @@ class DateTimeWidgetTest(TestCase, RowDeprecationTestMixin):
         target_dt = timezone.make_aware(self.datetime, tz)
         self.assertEqual(target_dt, self.widget.clean(self.datetime))
 
+    @ignore_utcnow_deprecation_warning
     @override_settings(USE_TZ=True, TIME_ZONE="Europe/Ljubljana")
     def test_clean_handles_tz_aware_datetime(self):
+        import pytz
+
         self.datetime = datetime(2012, 8, 13, 18, 0, 0, tzinfo=pytz.timezone("UTC"))
         self.assertEqual(self.datetime, self.widget.clean(self.datetime))
 

--- a/tests/core/tests/utils.py
+++ b/tests/core/tests/utils.py
@@ -20,3 +20,20 @@ def ignore_widget_deprecation_warning(fn):
             fn(*args, **kwargs)
 
     return inner
+
+
+def ignore_utcnow_deprecation_warning(fn):
+    """
+    Ignore the specific deprecation warning occurring due to openpyxl and python3.12.
+    """
+
+    @functools.wraps(fn)
+    def inner(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+            )
+            fn(*args, **kwargs)
+
+    return inner

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ commands = python ./runtests.py
 deps =
     tablibdev: -egit+https://github.com/jazzband/tablib.git@master\#egg=tablib
     django32: Django>=3.2,<4.0
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<6.0
     djangomain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
**Problem**

Handles deprecation warnings from python3.12

**Solution**

- Added catches for warnings where required.

**Acceptance Criteria**

- Integration test coverage