### PR TITLE
Customizable storage

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -794,8 +794,6 @@ There are three mechanisms for temporary storage.
 
 To modify which storage mechanism is used, please refer to the setting :ref:`import_export_tmp_storage_class`.
 
-Temporary resources are removed when data is successfully imported after the confirmation step.
-
 Your choice of temporary storage will be influenced by the following factors:
 
 * Sensitivity of the data being imported.
@@ -803,12 +801,47 @@ Your choice of temporary storage will be influenced by the following factors:
 * File upload size.
 * Use of containers or load-balanced servers.
 
+Temporary resources are removed when data is successfully imported after the confirmation step.
+
 .. warning::
 
     If users do not complete the confirmation step of the workflow,
     or if there are errors during import, then temporary resources may not be deleted.
     This will need to be understood and managed in production settings.
     For example, using a cache expiration policy or cron job to clear stale resources.
+
+Customizable storage
+^^^^^^^^^^^^^^^^^^^^^
+
+If using :class:`~import_export.tmp_storages.MediaStorage` as a storage module, then you can define which storage
+backend implementation is used to handle create / read / delete operations on the persisted data.
+
+If using Django 4.2 or greater, use the `STORAGES <https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-STORAGES>`_
+setting to define the backend, otherwise use :ref:`import_export_default_file_storage`.
+
+You can either supply a path to your own custom storage backend, or use pre-existing backends such as
+`django-storages <https://django-storages.readthedocs.io/>`_.
+
+If no custom storage implementation is supplied, then the Django default handler is used.
+
+For example, if using django-storages, you can configure s3 as a temporary storage location with the following::
+
+    IMPORT_EXPORT_TMP_STORAGE_CLASS = "import_export.tmp_storages.MediaStorage"
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "import_export": {
+            "BACKEND": "storages.backends.s3.S3Storage",
+            "OPTIONS": {
+                "bucket_name": "<your bucket name>",
+                "region_name": "<your region>",
+                "access_key": "<your key>",
+                "secret_key": "<your secret>"
+            },
+        },
+    }
 
 Exporting
 ---------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Please refer to :doc:`release notes<release_notes>`.
 -------------------------
 
 - Fix issue where declared Resource fields not defined in ``fields`` are still imported (#1702)
+- Added customizable ``MediaStorage`` (#1708)
 
 4.0.0-beta.2 (2023-12-09)
 -------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,11 +71,23 @@ setting the ``skip_admin_log`` class attribute.
 ``IMPORT_EXPORT_TMP_STORAGE_CLASS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+A string path to the preferred temporary storage module.
+
 Controls which storage class to use for storing the temporary uploaded file
 during imports. Defaults to ``import_export.tmp_storages.TempFolderStorage``.
 
 Can be overridden on a ``ModelAdmin`` class inheriting from ``ImportMixin`` by
 setting the ``tmp_storage_class`` class attribute.
+
+.. _import_export_default_file_storage:
+
+``IMPORT_EXPORT_DEFAULT_FILE_STORAGE``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A string path to a customized storage implementation.
+
+This setting is deprecated and only applies if using Django with a version less than 4.2,
+and will be removed in a future release.
 
 .. _import_export_import_permission_code:
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -107,6 +107,10 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             tmp_storage_class = import_string(tmp_storage_class)
         return tmp_storage_class
 
+    def get_tmp_storage_class_kwargs(self):
+        """Override this method to provide additional kwargs to temp storage class."""
+        return {}
+
     def has_import_permission(self, request):
         """
         Returns whether a request has import permission.
@@ -158,6 +162,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                 name=confirm_form.cleaned_data["import_file_name"],
                 encoding=encoding,
                 read_mode=input_format.get_read_mode(),
+                **self.get_tmp_storage_class_kwargs(),
             )
 
             data = tmp_storage.read()
@@ -395,7 +400,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
         tmp_storage_cls = self.get_tmp_storage_class()
         tmp_storage = tmp_storage_cls(
-            encoding=encoding, read_mode=input_format.get_read_mode()
+            encoding=encoding,
+            read_mode=input_format.get_read_mode(),
+            **self.get_tmp_storage_class_kwargs(),
         )
         data = bytes()
         for chunk in import_file.chunks():

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -36,9 +36,6 @@ class BookAdmin(ImportExportModelAdmin):
     resource_classes = [BookResource, BookNameResource]
     change_list_template = "core/admin/change_list.html"
 
-    def get_tmp_storage_class_kwargs(self):
-        return {"MEDIA_FOLDER": None}
-
 
 class CategoryAdmin(ExportActionModelAdmin):
     pass

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -36,6 +36,9 @@ class BookAdmin(ImportExportModelAdmin):
     resource_classes = [BookResource, BookNameResource]
     change_list_template = "core/admin/change_list.html"
 
+    def get_tmp_storage_class_kwargs(self):
+        return {"MEDIA_FOLDER": None}
+
 
 class CategoryAdmin(ExportActionModelAdmin):
     pass

--- a/tests/core/tests/test_tmp_storages.py
+++ b/tests/core/tests/test_tmp_storages.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import mock_open, patch
 
 from django.core.cache import cache
-from django.core.files.storage import default_storage
+from django.core.files.storage import FileSystemStorage, default_storage
 from django.test import TestCase
 
 from import_export.tmp_storages import (
@@ -108,6 +108,6 @@ id,name,author,author_email,imported,published,price,categories
     def test_media_storage_read_with_encoding(self):
         tmp_storage = TestMediaStorage()
         tmp_storage.name = "f"
-        with patch("import_export.tmp_storages.default_storage.open") as mock_open:
+        with patch.object(FileSystemStorage, "open") as mock_open:
             tmp_storage.read()
             mock_open.assert_called_with("f", mode="rb")

--- a/tests/core/tests/test_tmp_storages.py
+++ b/tests/core/tests/test_tmp_storages.py
@@ -1,9 +1,13 @@
+import io
 import os
+from unittest import skipUnless
 from unittest.mock import mock_open, patch
 
+import django
 from django.core.cache import cache
 from django.core.files.storage import FileSystemStorage, default_storage
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from import_export.tmp_storages import (
     BaseStorage,
@@ -111,3 +115,67 @@ id,name,author,author_email,imported,published,price,categories
         with patch.object(FileSystemStorage, "open") as mock_open:
             tmp_storage.read()
             mock_open.assert_called_with("f", mode="rb")
+
+
+class CustomizedStorage(object):
+    save_count = 0
+    open_count = 0
+    delete_count = 0
+
+    def __init__(self, **kwargs):
+        pass
+
+    def save(self, path, data):
+        self.save_count += 1
+
+    def open(self, path, mode=None):
+        self.open_count += 1
+        return io.StringIO("a")
+
+    def delete(self, path):
+        self.delete_count += 1
+
+
+@skipUnless(django.VERSION <= (4, 2), "Django 4.2")
+class CustomizedMediaStorageTestDjango42(TestCase):
+    @override_settings(IMPORT_EXPORT_DEFAULT_FILE_STORAGE=CustomizedStorage)
+    def test_MediaStorage_uses_custom_storage_implementation(self):
+        tmp_storage = TestMediaStorage()
+        tmp_storage.save(b"a")
+        self.assertEqual(1, tmp_storage._storage.save_count)
+        tmp_storage.read()
+        self.assertEqual(1, tmp_storage._storage.open_count)
+        tmp_storage.remove()
+        self.assertEqual(1, tmp_storage._storage.delete_count)
+
+
+@skipUnless(django.VERSION >= (5, 0), "Django 5.0")
+class CustomizedMediaStorageTestDjango50(TestCase):
+    @override_settings(
+        STORAGES={
+            "import_export": {
+                "BACKEND": "tests.core.tests.test_tmp_storages.CustomizedStorage"
+            }
+        }
+    )
+    def test_MediaStorage_uses_custom_storage_implementation(self):
+        tmp_storage = TestMediaStorage()
+        tmp_storage.save(b"a")
+        self.assertEqual(1, tmp_storage._storage.save_count)
+        tmp_storage.read()
+        self.assertEqual(1, tmp_storage._storage.open_count)
+        tmp_storage.remove()
+        self.assertEqual(1, tmp_storage._storage.delete_count)
+
+    @override_settings(
+        STORAGES={
+            "import_export": {
+                "BACKEND": "tests.core.tests.test_tmp_storages.CustomizedStorage"
+            }
+        }
+    )
+    def test_disable_media_folder(self):
+        tmp_storage = MediaStorage(MEDIA_FOLDER=None)
+        tmp_storage.name = "TESTNAME"
+        self.assertIsNone(tmp_storage.MEDIA_FOLDER)
+        self.assertEqual("TESTNAME", tmp_storage.get_full_path())

--- a/tests/core/tests/test_tmp_storages.py
+++ b/tests/core/tests/test_tmp_storages.py
@@ -179,3 +179,7 @@ class CustomizedMediaStorageTestDjango50(TestCase):
         tmp_storage.name = "TESTNAME"
         self.assertIsNone(tmp_storage.MEDIA_FOLDER)
         self.assertEqual("TESTNAME", tmp_storage.get_full_path())
+
+    def test_media_folder(self):
+        tmp_storage = MediaStorage()
+        self.assertEqual("django-import-export", tmp_storage.MEDIA_FOLDER)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -102,28 +102,8 @@ LOGGING = {
     },
 }
 
-
 USE_TZ = False
 if django.VERSION >= (4, 1):
     FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
 if django.VERSION >= (5, 0):
     FORM_RENDERER = "django.forms.renderers.DjangoTemplates"
-
-
-# STORAGES = {
-#     "default": {
-#         "BACKEND": "django.core.files.storage.FileSystemStorage",
-#     },
-#     "import_export": {
-#         "BACKEND": "storages.backends.s3.S3Storage",
-#         "OPTIONS": {
-#             "bucket_name": "import-export-access-test",
-#             "region_name": "eu-west-1",
-#             "access_key": "some_key",
-#             "secret_key": "some_secret"
-#         },
-#     },
-# }
-#
-#
-# IMPORT_EXPORT_TMP_STORAGE_CLASS = "import_export.tmp_storages.MediaStorage"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -108,3 +108,22 @@ if django.VERSION >= (4, 1):
     FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
 if django.VERSION >= (5, 0):
     FORM_RENDERER = "django.forms.renderers.DjangoTemplates"
+
+
+# STORAGES = {
+#     "default": {
+#         "BACKEND": "django.core.files.storage.FileSystemStorage",
+#     },
+#     "import_export": {
+#         "BACKEND": "storages.backends.s3.S3Storage",
+#         "OPTIONS": {
+#             "bucket_name": "import-export-access-test",
+#             "region_name": "eu-west-1",
+#             "access_key": "some_key",
+#             "secret_key": "some_secret"
+#         },
+#     },
+# }
+#
+#
+# IMPORT_EXPORT_TMP_STORAGE_CLASS = "import_export.tmp_storages.MediaStorage"


### PR DESCRIPTION
**Problem**

Closes issue #1210 

**Solution**

Allows for configuration of a custom storage backend using existing Django config mechanisms

**Acceptance Criteria**

- Have added integration tests
- Have tested manually, including upload to s3 bucket using django-storages.