### PR TITLE
Respect color scheme override

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -144,3 +144,4 @@ The following is a list of much appreciated contributors:
 * christophehenry (Christophe Henry)
 * bgelov (Oleg Belov)
 * EricOuma (Eric Ouma)
+* ZibingZhang (Zibing Zhang)

--- a/import_export/static/import_export/import.css
+++ b/import_export/static/import_export/import.css
@@ -26,20 +26,28 @@
   z-index: 2;
 }
 
-table.import-preview tr.skip {
+html[data-theme="light"] .validation-error-container {
+  background-color: #ffc1c1;
+}
+
+table.import-preview tr.skip, html[data-theme="light"] table.import-preview tr.skip  {
   background-color: #d2d2d2;
 }
 
-table.import-preview tr.new {
+table.import-preview tr.new, html[data-theme="light"] table.import-preview tr.new {
   background-color: #bdd8b2;
 }
 
-table.import-preview tr.delete {
+table.import-preview tr.delete, html[data-theme="light"] table.import-preview tr.delete {
   background-color: #f9bebf;
 }
 
-table.import-preview tr.update {
+table.import-preview tr.update, html[data-theme="light"] table.import-preview tr.update {
   background-color: #fdfdcf;
+}
+
+table.import-preview td ins, html[data-theme="light"] table.import-preview td ins {
+  background-color: #e6ffe6 !important;
 }
 
 .import-preview td:hover .validation-error-count {
@@ -112,4 +120,36 @@ table.import-preview tr.update {
   table.import-preview td del {
     background-color: #001919 !important;
   }
+}
+
+html[data-theme="dark"] table.import-preview tr.skip {
+  background-color: #2d2d2d;
+}
+
+html[data-theme="dark"] table.import-preview tr.new {
+  background-color: #42274d;
+}
+
+html[data-theme="dark"] table.import-preview tr.delete {
+  background-color: #064140;
+}
+
+html[data-theme="dark"] table.import-preview tr.update {
+  background-color: #020230;
+}
+
+html[data-theme="dark"] .validation-error-container {
+  background-color: #003e3e;
+}
+
+/*
+these declarations are necessary to forcibly override the
+formatting applied by the diff-match-patch python library
+ */
+html[data-theme="dark"] table.import-preview td ins {
+  background-color: #190019 !important;
+}
+
+html[data-theme="dark"] table.import-preview td del {
+  background-color: #001919 !important;
 }


### PR DESCRIPTION
**Problem**

What problem have you solved?

A rendering problem where the import staging table was not respecting the manual choice of color scheme.
Fixes https://github.com/django-import-export/django-import-export/issues/1718.

**Solution**

How did you solve the problem?

I duplicated the CSS rules and checked for `html[data-theme="light/dark"]`. The same thing is done in the Django source code for the admin module: https://github.com/django/django/blob/main/django/contrib/admin/static/admin/css/dark_mode.css

**Acceptance Criteria**

<img width="1331" alt="image" src="https://github.com/django-import-export/django-import-export/assets/44979059/fc322d62-aad2-4154-8367-4e341135d6f3">

We can see with the CSS rules that the manual choice is overriding the preferred color scheme.
