### PR TITLE
Improve Admin UI import error messages

### DIFF
--- a/docs/admin_integration.rst
+++ b/docs/admin_integration.rst
@@ -37,7 +37,7 @@ dropdown in the UI.
 .. figure:: _static/images/django-import-export-change.png
 
    A screenshot of the change view with Import and Export buttons.
-   
+
 Importing
 ---------
 
@@ -136,6 +136,14 @@ For example, if using django-storages, you can configure s3 as a temporary stora
             },
         },
     }
+
+.. _format_ui_error_messages:
+
+How to format UI error messages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Admin UI import error messages can be formatted using the :attr:`~import_export.admin.ImportMixin.import_error_display`
+attribute.
 
 Exporting
 ---------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Please refer to :doc:`release notes<release_notes>`.
 - Fix issue where declared Resource fields not defined in ``fields`` are still imported (#1702)
 - Added customizable ``MediaStorage`` (#1708)
 - Relocated admin integration section from advanced_usage.rst into new file (#1713)
+- Added customization of Admin UI import error messages (#1727)
 
 4.0.0-beta.2 (2023-12-09)
 -------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -104,7 +104,7 @@ Please refer to `this issue <https://github.com/django-import-export/django-impo
 How to hide stack trace in UI error messages
 --------------------------------------------
 
-Please refer to `this issue <https://github.com/django-import-export/django-import-export/issues/1257#issuecomment-952276485>`_.
+Please refer to :ref:`format_ui_error_messages`.
 
 Ids incremented twice during import
 -----------------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -97,6 +97,21 @@ Success message
 The success message shown on successful import has been updated to include the number of 'deleted' and 'skipped' rows.
 See `this PR <https://github.com/django-import-export/django-import-export/issues/1691>`_.
 
+Import error messages
+---------------------
+
+The default error message for import errors has been modified to simplify the format.
+Error messages now contain the error message only by default.  The row and traceback are not presented.
+
+The original format can be restored by setting :attr:`~import_export.admin.ImportMixin.import_error_display` on the
+Admin class definition.  For example::
+
+  class BookAdmin(ImportExportModelAdmin):
+    import_error_display = ("message", "row", "traceback")
+
+
+See `this issue <https://github.com/django-import-export/django-import-export/issues/1724>`_.
+
 API changes
 ===========
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -83,6 +83,10 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     confirm_form_class = ConfirmImportForm
     #: import data encoding
     from_encoding = "utf-8-sig"
+    #: control which UI elements appear when import errors are displayed.
+    #: Available options: 'message', 'row', 'traceback'
+    import_error_display = ("message", "row", "traceback")
+
     skip_admin_log = None
     # storage class for saving temporary files
     tmp_storage_class = None
@@ -535,6 +539,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             )
             for resource in resources
         ]
+        context["import_error_display"] = self.import_error_display
 
         request.current_app = self.admin_site.name
         return TemplateResponse(request, [self.import_template_name], context)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -85,7 +85,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     from_encoding = "utf-8-sig"
     #: control which UI elements appear when import errors are displayed.
     #: Available options: 'message', 'row', 'traceback'
-    import_error_display = ("message", "row", "traceback")
+    import_error_display = ("message",)
 
     skip_admin_log = None
     # storage class for saving temporary files

--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -85,15 +85,25 @@
           <div class="traceback">{{ error.traceback|linebreaks }}</div>
         </li>
         {% endfor %}
+        {% block import_error_list %}
         {% for line, errors in result.row_errors %}
           {% for error in errors %}
-            <li>
-              {% translate "Line number" %}: {{ line }} - {{ error.error }}
-              <div><code>{{ error.row.values|join:", " }}</code></div>
-              <div class="traceback">{{ error.traceback|linebreaks }}</div>
+            {% block import_error_list_item %}
+            <li class="import-error-li">
+              {% if "message" in import_error_display %}
+                <div class="import-error-display-message">{% translate "Line number" %}: {{ line }} - {{ error.error }}</div>
+              {% endif %}
+              {% if "row" in import_error_display %}
+                <div class="import-error-display-row">{{ error.row.values|join:", " }}</div>
+              {% endif %}
+              {% if "traceback" in import_error_display %}
+              <div class="import-error-display-traceback">{{ error.traceback|linebreaks }}</div>
+              {% endif %}
             </li>
+            {% endblock %}
           {% endfor %}
         {% endfor %}
+        {% endblock %}
       </ul>
     {% endblock %}
 

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -502,12 +502,12 @@ class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
         response = self.model_admin.import_action(self.request)
         response.render()
         self.assertIn("import-error-display-message", str(response.content))
-        self.assertIn("import-error-display-row", str(response.content))
-        self.assertIn("import-error-display-traceback", str(response.content))
         self.assertIn(
             "Line number: 1 - Author matching query does not exist.",
             str(response.content),
         )
+        self.assertNotIn("import-error-display-row", str(response.content))
+        self.assertNotIn("import-error-display-traceback", str(response.content))
 
     def test_result_error_display_message_only(self):
         self.model_admin.import_error_display = ("message",)

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+from io import StringIO
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +10,10 @@ from core.models import Author, Book, EBook, Parent
 from core.tests.admin_integration.mixins import AdminTestMixin
 from core.tests.utils import ignore_widget_deprecation_warning
 from django.contrib.admin.models import DELETION, LogEntry
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
 from django.http import HttpRequest
+from django.test import RequestFactory
 from django.test.testcases import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
@@ -478,6 +482,71 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
     def test_export_empty_import_formats(self):
         with self.assertRaisesRegex(ValueError, "invalid formats list"):
             self.client.get(self.book_import_url)
+
+
+class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
+    # issue 1724
+
+    def setUp(self):
+        super().setUp()
+        self.csvdata = "id,name,author\r\n" "1,Ulysses,666\r\n"
+        self.filedata = StringIO(self.csvdata)
+        self.data = {"format": "0", "import_file": self.filedata}
+        self.model_admin = BookAdmin(Book, AdminSite())
+
+        factory = RequestFactory()
+        self.request = factory.post(self.book_import_url, self.data, follow=True)
+        self.request.user = User.objects.create_user("admin1")
+
+    def test_result_error_display_default(self):
+        response = self.model_admin.import_action(self.request)
+        response.render()
+        self.assertIn("import-error-display-message", str(response.content))
+        self.assertIn("import-error-display-row", str(response.content))
+        self.assertIn("import-error-display-traceback", str(response.content))
+        self.assertIn(
+            "Line number: 1 - Author matching query does not exist.",
+            str(response.content),
+        )
+
+    def test_result_error_display_message_only(self):
+        self.model_admin.import_error_display = ("message",)
+
+        response = self.model_admin.import_action(self.request)
+        response.render()
+        self.assertIn(
+            "Line number: 1 - Author matching query does not exist.",
+            str(response.content),
+        )
+        self.assertIn("import-error-display-message", str(response.content))
+        self.assertNotIn("import-error-display-row", str(response.content))
+        self.assertNotIn("import-error-display-traceback", str(response.content))
+
+    def test_result_error_display_row_only(self):
+        self.model_admin.import_error_display = ("row",)
+
+        response = self.model_admin.import_action(self.request)
+        response.render()
+        self.assertNotIn(
+            "Line number: 1 - Author matching query does not exist.",
+            str(response.content),
+        )
+        self.assertNotIn("import-error-display-message", str(response.content))
+        self.assertIn("import-error-display-row", str(response.content))
+        self.assertNotIn("import-error-display-traceback", str(response.content))
+
+    def test_result_error_display_traceback_only(self):
+        self.model_admin.import_error_display = ("traceback",)
+
+        response = self.model_admin.import_action(self.request)
+        response.render()
+        self.assertNotIn(
+            "Line number: 1 - Author matching query does not exist.",
+            str(response.content),
+        )
+        self.assertNotIn("import-error-display-message", str(response.content))
+        self.assertNotIn("import-error-display-row", str(response.content))
+        self.assertIn("import-error-display-traceback", str(response.content))
 
 
 class ConfirmImportEncodingTest(AdminTestMixin, TestCase):

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -498,6 +498,7 @@ class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
         self.request = factory.post(self.book_import_url, self.data, follow=True)
         self.request.user = User.objects.create_user("admin1")
 
+    @ignore_widget_deprecation_warning
     def test_result_error_display_default(self):
         response = self.model_admin.import_action(self.request)
         response.render()
@@ -509,6 +510,7 @@ class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
         self.assertNotIn("import-error-display-row", str(response.content))
         self.assertNotIn("import-error-display-traceback", str(response.content))
 
+    @ignore_widget_deprecation_warning
     def test_result_error_display_message_only(self):
         self.model_admin.import_error_display = ("message",)
 
@@ -522,6 +524,7 @@ class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
         self.assertNotIn("import-error-display-row", str(response.content))
         self.assertNotIn("import-error-display-traceback", str(response.content))
 
+    @ignore_widget_deprecation_warning
     def test_result_error_display_row_only(self):
         self.model_admin.import_error_display = ("row",)
 
@@ -535,6 +538,7 @@ class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
         self.assertIn("import-error-display-row", str(response.content))
         self.assertNotIn("import-error-display-traceback", str(response.content))
 
+    @ignore_widget_deprecation_warning
     def test_result_error_display_traceback_only(self):
         self.model_admin.import_error_display = ("traceback",)
 


### PR DESCRIPTION
**Problem**

Closes #1724 

**Solution**

Added a new `ImportMixin` attribute to control which elements are displayed.  Users can override this to customize the error display.

**Acceptance Criteria**

 - Added integration tests
 - Manual testing
 - Updated docs