### PR TITLE
Respect color scheme override

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 3.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix issue with highlight when using 'light' color scheme (#1728)
 
 
 3.3.5 (2023-12-19)

--- a/import_export/static/import_export/import.css
+++ b/import_export/static/import_export/import.css
@@ -50,6 +50,10 @@ table.import-preview td ins, html[data-theme="light"] table.import-preview td in
   background-color: #e6ffe6 !important;
 }
 
+html[data-theme="light"] table.import-preview td del {
+  background-color: #ffe6e6 !important;
+}
+
 .import-preview td:hover .validation-error-count {
   z-index: 3;
 }


### PR DESCRIPTION
Fixes cases not covered by https://github.com/django-import-export/django-import-export/pull/1720.

**Problem**

<img width="1416" alt="image" src="https://github.com/django-import-export/django-import-export/assets/44979059/14fdd57a-0c13-40ad-b441-7ec4fa16f9dd">
We can see that the background color is overridden by the rule below despite the fact that the chosen color theme is `light`.

```css
@media (prefers-color-scheme: dark) {
  table.import-preview td del {
    background-color: #001919 !important;
  }
}
```

**Solution**

How did you solve the problem?

<img width="1194" alt="image" src="https://github.com/django-import-export/django-import-export/assets/44979059/832101ea-02a5-495d-ba88-c112ab43e7e5">

I add the rule below to override this CSS rule which we can see fixes the issue.

```css
html[data-theme="light"] table.import-preview td del {
  background-color: #ffe6e6 !important;
}
```

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 