### PR TITLE
Re-add removed methods with deprecations for backwards compatibility

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,9 @@
 Changelog
 =========
 
-Please refer to :doc:`release notes<release_notes>`.
+.. warning::
+
+    Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
 4.0.0-beta.3 (unreleased)
 -------------------------
@@ -19,7 +21,7 @@ Please refer to :doc:`release notes<release_notes>`.
 - Support export from model change form (#1687)
 - Updated Admin UI to track deleted and skipped Imports (#1691)
 - Import form defaults to read-only field if only one format defined (#1690)
-- Refactored :module:`~import_export.resources` into separate modules for ``declarative`` and ``options`` (#1695)
+- Refactored :mod:`~import_export.resources` into separate modules for ``declarative`` and ``options`` (#1695)
 - fix multiple inheritance not setting options (#1696)
 - Refactored tests to remove dependencies between tests (#1703)
 - Handle python3.12 datetime deprecations (#1705)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -70,6 +70,8 @@ Deprecations
 
 * Use of ``ExportViewFormMixin`` is deprecated.  See `this issue <https://github.com/django-import-export/django-import-export/issues/1666>`_.
 
+* See :ref:`renamed_methods`.
+
 Admin UI
 ========
 
@@ -120,6 +122,8 @@ method calls, and to allow easier extensibility.
 
 :class:`import_export.resources.Resource`
 -----------------------------------------
+
+.. _renamed_methods:
 
 Renamed methods
 ^^^^^^^^^^^^^^^
@@ -185,41 +189,41 @@ This section describes methods in which the parameters have changed.
 
    * - ``save_m2m(self, obj, data, using_transactions, dry_run)``
      - ``save_m2m(self, instance, row, **kwargs)``
-     - * ``dry_run`` param now in ``kwargs``
-       * ``using_transactions`` param now in ``kwargs``
-       * ``row`` added as mandatory arg
+     - * ``row`` added as mandatory arg
        * ``obj`` renamed to ``instance``
        * ``data`` renamed to ``row``
+       * ``dry_run`` param now in ``kwargs``
+       * ``using_transactions`` param now in ``kwargs``
 
    * - ``before_save_instance(self, instance, using_transactions, dry_run)``
      - ``before_save_instance(self, instance, row, **kwargs)``
-     - * ``dry_run`` param now in ``kwargs``
+     - * ``row`` added as mandatory arg
+       * ``dry_run`` param now in ``kwargs``
        * ``using_transactions`` param now in ``kwargs``
-       * ``row`` added as mandatory arg
 
    * - ``after_save_instance(self, instance, using_transactions, dry_run)``
      - ``after_save_instance(self, instance, row, **kwargs)``
-     - * ``dry_run`` param now in ``kwargs``
+     - * ``row`` added as mandatory arg
+       * ``dry_run`` param now in ``kwargs``
        * ``using_transactions`` param now in ``kwargs``
-       * ``row`` added as mandatory arg
 
    * - ``delete_instance(self, instance, using_transactions=True, dry_run=False)``
      - ``delete_instance(self, instance, row, **kwargs)``
-     - * ``dry_run`` param now in ``kwargs``
+     - * ``row`` added as mandatory arg
+       * ``dry_run`` param now in ``kwargs``
        * ``using_transactions`` param now in ``kwargs``
-       * ``row`` added as mandatory arg
 
    * - ``before_delete_instance(self, instance, dry_run)``
      - ``before_delete_instance(self, instance, row, **kwargs)``
-     - * ``dry_run`` param now in ``kwargs``
+     - * ``row`` added as mandatory arg
+       * ``dry_run`` param now in ``kwargs``
        * ``using_transactions`` param now in ``kwargs``
-       * ``row`` added as mandatory arg
 
    * - ``after_delete_instance(self, instance, dry_run)``
      - ``after_delete_instance(self, instance, row, **kwargs)``
-     - * ``dry_run`` param now in ``kwargs``
+     - * ``row`` added as mandatory arg
+       * ``dry_run`` param now in ``kwargs``
        * ``using_transactions`` param now in ``kwargs``
-       * ``row`` added as mandatory arg
 
    * - ``before_export(self, queryset, *args, **kwargs)``
      - ``before_export(self, queryset, **kwargs)``

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -4,6 +4,7 @@ import traceback
 from collections import OrderedDict
 from copy import deepcopy
 from html import escape
+from warnings import warn
 
 import tablib
 from diff_match_patch import diff_match_patch
@@ -423,6 +424,18 @@ class Resource(metaclass=DeclarativeMetaclass):
     def get_import_fields(self):
         return [self.fields[f] for f in self.get_import_order()]
 
+    def import_obj(self, obj, data, dry_run, **kwargs):
+        warn(
+            "The 'import_obj' method is deprecated and will be replaced "
+            "with 'import_instance(self, instance, row, **kwargs)' "
+            "in a future release",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if dry_run is True:
+            kwargs.update({"dry_run": dry_run})
+        self.import_instance(obj, data, **kwargs)
+
     def import_instance(self, instance, row, **kwargs):
         r"""
         Traverses every field in this Resource and calls
@@ -614,6 +627,18 @@ class Resource(metaclass=DeclarativeMetaclass):
             See :meth:`import_row`
         """
         pass
+
+    def after_import_instance(self, instance, new, row_number=None, **kwargs):
+        warn(
+            "The 'after_import_instance' method is deprecated and will be replaced "
+            "with 'after_init_instance(self, instance, new, row, **kwargs)' "
+            "in a future release",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if row_number is not None:
+            kwargs.update({"row_number": row_number})
+        self.after_init_instance(instance, new, None, **kwargs)
 
     def after_init_instance(self, instance, new, row, **kwargs):
         r"""

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -428,7 +428,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         warn(
             "The 'import_obj' method is deprecated and will be replaced "
             "with 'import_instance(self, instance, row, **kwargs)' "
-            "in a future release",
+            "in a future release.  Refer to Release Notes for details.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -632,7 +632,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         warn(
             "The 'after_import_instance' method is deprecated and will be replaced "
             "with 'after_init_instance(self, instance, new, row, **kwargs)' "
-            "in a future release",
+            "in a future release.  Refer to Release Notes for details.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/core/tests/test_resources/test_resources.py
+++ b/tests/core/tests/test_resources/test_resources.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import warnings
 from collections import OrderedDict
 from datetime import date
 from decimal import Decimal, InvalidOperation
@@ -1886,3 +1887,59 @@ class BookResourceWithStringModelTest(TestCase):
 
     def test_resource_gets_correct_model_from_string(self):
         self.assertEqual(self.resource._meta.model, Book)
+
+
+class DeprecatedMethodTest(TestCase):
+    """
+    These tests relate to renamed methods in v4.
+    The tests can be removed when the deprecated methods are removed.
+    """
+
+    def setUp(self):
+        rows = [
+            ["1", "Ulysses"],
+        ]
+        self.dataset = tablib.Dataset(*rows, headers=["id", "name"])
+        self.obj = Book.objects.create(id=1, name="Ulysses")
+
+    def test_import_obj_renamed(self):
+        resource = BookResource()
+        with self.assertWarns(
+            DeprecationWarning,
+        ):
+            resource.import_obj(self.obj, self.dataset, dry_run=True)
+
+    def test_import_obj_passes_params(self):
+        class MyBookResource(resources.ModelResource):
+            def import_instance(self, instance, row, **kwargs):
+                self.kwargs = kwargs
+
+            class Meta:
+                model = Book
+
+        resource = MyBookResource()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            resource.import_obj(self.obj, self.dataset, True)
+        self.assertTrue(resource.kwargs["dry_run"])
+
+    def test_after_import_instance_renamed(self):
+        resource = BookResource()
+        with self.assertWarns(
+            DeprecationWarning,
+        ):
+            resource.after_import_instance(self.obj, True, row_number=1)
+
+    def test_after_import_instance_passes_params(self):
+        class MyBookResource(resources.ModelResource):
+            def after_init_instance(self, instance, new, row, **kwargs):
+                self.kwargs = kwargs
+
+            class Meta:
+                model = Book
+
+        resource = MyBookResource()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            resource.after_import_instance(self.obj, True, row_number=1)
+        self.assertEqual(1, resource.kwargs["row_number"])


### PR DESCRIPTION
**Problem**

Closes #1731 

Renamed methods were re-added with deprecation warnings to ease upgrades for users with direct method calls in their implementations.

**Solution**

Re-added original method names with call to new (and DeprecationWarning)

**Acceptance Criteria**

- Added integration tests
- Updated Release Notes