### PR TITLE
pass `get_export_resource_kwargs()` to Resource constructor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,8 @@ Changelog
 3.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Pass :meth:`~import_export.mixins.BaseExportMixin.get_export_resource_kwargs` to Resource constructor
+  :meth:`~import_export.admin.ExportMixin.export_action` (#)
 
 
 3.3.6 (2024-01-10)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - Pass :meth:`~import_export.mixins.BaseExportMixin.get_export_resource_kwargs` to Resource constructor
-  :meth:`~import_export.admin.ExportMixin.export_action` (#)
+  :meth:`~import_export.admin.ExportMixin.export_action` (#1739)
 
 
 3.3.6 (2024-01-10)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -855,7 +855,9 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
                 res.get_display_name(),
                 [
                     field.column_name
-                    for field in res(model=self.model).get_user_visible_fields()
+                    for field in res(
+                        model=self.model, **self.get_export_resource_kwargs(request)
+                    ).get_user_visible_fields()
                 ],
             )
             for res in self.get_export_resource_classes()

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -675,6 +675,16 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
             ],
         )
 
+    @mock.patch("core.admin.BookAdmin.get_export_resource_kwargs")
+    def test_export_passes_export_resource_kwargs(
+        self, mock_get_export_resource_kwargs
+    ):
+        # issue 1738
+        mock_get_export_resource_kwargs.return_value = {"a": 1}
+        response = self.client.get("/admin/core/book/export/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(2, mock_get_export_resource_kwargs.call_count)
+
     def test_export(self):
         response = self.client.get("/admin/core/book/export/")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
**Problem**

Closes #1738 

**Solution**

Pass `get_export_resource_kwargs()` to Resource constructor to code block added in #1685.

**Acceptance Criteria**

- Added test
- Manual testing