### PR TITLE
Update widgets.py

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -329,6 +329,7 @@ class SimpleArrayWidget(Widget):
 
     :param separator: Defaults to ``','``
     """
+
     def ArrayToString(value):
         if type(value) == list:
             if len(value) != 0:
@@ -338,9 +339,9 @@ class SimpleArrayWidget(Widget):
                     value = ",".join(value)
         else:
             pass
-            
+
         return value
-    
+
     def __init__(self, separator=None):
         if separator is None:
             separator = ","

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -329,7 +329,18 @@ class SimpleArrayWidget(Widget):
 
     :param separator: Defaults to ``','``
     """
-
+    def ArrayToString(value):
+        if type(value) == list:
+            if len(value) != 0:
+                if type(value[0]) == int:
+                    value = ",".join(str(num) for num in value)
+                else:
+                    value = ",".join(value)
+        else:
+            pass
+            
+        return value
+    
     def __init__(self, separator=None):
         if separator is None:
             separator = ","
@@ -337,6 +348,7 @@ class SimpleArrayWidget(Widget):
         super().__init__()
 
     def clean(self, value, row=None, **kwargs):
+        value = ArrayToString(value)
         return value.split(self.separator) if value else []
 
     def render(self, value, obj=None):


### PR DESCRIPTION
**Problem**

previously in django when using arrayfield model from postgresql we could not import an array directly into arrayfield it would always give some error so i modified it so that the arrayflied will store the entire array as intended the error was due to the fact that in the simplearraywidget class it was expecting a string rather than an array

**Solution**

i made changes in clean function giving it the desired string instead of an array

**Acceptance Criteria**

i made a project using this and i was able to import successfully an array but it was a long time ago and i dont have any screenshots of that now. as for test cases imported around 130k arrays into my project without any issues