### PR TITLE
Fix issue with model passed to Resource constructor crashes on export

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 3.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix issue with model class passed to Resource constructor crashing on export (#)
 
 
 3.3.6 (2024-01-10)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -853,10 +853,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         context["fields_list"] = [
             (
                 res.get_display_name(),
-                [
-                    field.column_name
-                    for field in res(model=self.model).get_user_visible_fields()
-                ],
+                [field.column_name for field in res().get_user_visible_fields()],
             )
             for res in self.get_export_resource_classes()
         ]

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -8,7 +8,13 @@ from unittest.mock import MagicMock, patch
 import chardet
 import django
 import tablib
-from core.admin import AuthorAdmin, BookAdmin, CustomBookAdmin, ImportMixin
+from core.admin import (
+    AuthorAdmin,
+    BookAdmin,
+    BookResource,
+    CustomBookAdmin,
+    ImportMixin,
+)
 from core.models import Author, Book, Category, EBook, Parent
 from django.contrib.admin.models import DELETION, LogEntry
 from django.contrib.admin.sites import AdminSite
@@ -674,6 +680,18 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
                 ("Export/Import only book names", ["id", "name"]),
             ],
         )
+
+    def book_resource_init(self):
+        # stub call to the resource constructor
+        pass
+
+    @mock.patch.object(BookResource, "__init__", book_resource_init)
+    def test_export_passes_no_resource_constructor_params(self):
+        # issue 1716
+        # assert that the export call with a no-arg constructor
+        # does not crash
+        response = self.client.get("/admin/core/book/export/")
+        self.assertEqual(response.status_code, 200)
 
     def test_export(self):
         response = self.client.get("/admin/core/book/export/")


### PR DESCRIPTION

**Problem**

Closes #1716

**Solution**

Passing the model class to the constructor is redundant.

**Acceptance Criteria**

- Added a test which proves the crash occurs if the fix is not in place.