### PR TITLE
Return `kwargs` by default from `get_resource_kwargs`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Pass :meth:`~import_export.mixins.BaseExportMixin.get_export_resource_kwargs` to Resource constructor
   :meth:`~import_export.admin.ExportMixin.export_action` (#1739)
 - Fix issue with model class passed to Resource constructor crashing on export (#1745)
+- Return ``kwargs``` by default from :meth:`~import_export.mixins.BaseImportExportMixin.get_resource_kwargs` (#1748)
 
 3.3.6 (2024-01-10)
 ------------------

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -63,7 +63,7 @@ class BaseImportExportMixin:
         return [self.resource_class]
 
     def get_resource_kwargs(self, request, *args, **kwargs):
-        return {}
+        return kwargs
 
     def get_resource_index(self, form):
         resource_index = 0

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 
 
 class BaseImportExportMixin:
+    """
+    Base mixin for functionality related to importing and exporting via the Admin
+    interface.
+    """
+
     resource_class = None
     resource_classes = []
 
@@ -63,9 +68,24 @@ class BaseImportExportMixin:
         return [self.resource_class]
 
     def get_resource_kwargs(self, request, *args, **kwargs):
+        """
+        Return the kwargs which are to be passed to the Resource constructor.
+        Can be overridden to provide additional kwarg params.
+
+        :param request: The request object.
+        :param args: Positional arguments.
+        :param kwargs: Keyword arguments.
+        :returns: The Resource kwargs (by default, is the kwargs passed).
+        """
         return kwargs
 
     def get_resource_index(self, form):
+        """
+        Return the index of the resource class defined in the form.
+
+        :param form: The form object.
+        :returns: The index of the resource as an int.
+        """
         resource_index = 0
         if form and "resource" in form.cleaned_data:
             try:

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -179,15 +179,19 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
     def test_import_passes_correct_kwargs_to_constructor(
         self, mock_choose_import_resource_class
     ):
+        # issue 1716
         class TestResource(ModelResource):
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)
-                self.kwargs = kwargs
+
+                # the form is passed as a kwarg to the Resource constructor
+                # if not present, then it means that the original kwargs were lost
                 if "form" not in kwargs:
                     raise Exception("No form")
 
+        # mock the returned resource class so that we can inspect constructor params
         mock_choose_import_resource_class.return_value = TestResource
-        # issue 1716
+
         response = self._do_import_post(self.book_import_url, "books.csv")
         self.assertEqual(response.status_code, 200)
 

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -179,7 +179,7 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
     def test_import_passes_correct_kwargs_to_constructor(
         self, mock_choose_import_resource_class
     ):
-        # issue 1716
+        # issue 1741
         class TestResource(ModelResource):
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)

--- a/tests/core/tests/test_admin_integration.py
+++ b/tests/core/tests/test_admin_integration.py
@@ -38,6 +38,7 @@ from import_export.admin import (
 )
 from import_export.formats import base_formats
 from import_export.formats.base_formats import DEFAULT_FORMATS
+from import_export.resources import ModelResource
 from import_export.tmp_storages import TempFolderStorage
 
 
@@ -173,6 +174,22 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
             count=1,
             html=True,
         )
+
+    @patch("import_export.admin.ImportMixin.choose_import_resource_class")
+    def test_import_passes_correct_kwargs_to_constructor(
+        self, mock_choose_import_resource_class
+    ):
+        class TestResource(ModelResource):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.kwargs = kwargs
+                if "form" not in kwargs:
+                    raise Exception("No form")
+
+        mock_choose_import_resource_class.return_value = TestResource
+        # issue 1716
+        response = self._do_import_post(self.book_import_url, "books.csv")
+        self.assertEqual(response.status_code, 200)
 
     @override_settings(DEBUG=False)
     def test_correct_scripts_declared_when_debug_is_false(self):


### PR DESCRIPTION
**Problem**

Closes #1741 

**Solution**

Returned kwargs 

**Acceptance Criteria**

- Added tests