### PR TITLE
Handle `FieldError` during import via Admin UI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 - Added specific check for declared :attr:`~import_export.options.ResourceOptions.import_id_fields` not in dataset
   (#1735)
 - Updated Admin integration documentation to clarify how to save custom form values (#1746)
+- Fixed handling of :attr:`~import_export.exceptions.FieldError` during Admin import (#17)
 
 4.0.0-beta.2 (2023-12-09)
 -------------------------


### PR DESCRIPTION
**Problem**

Closes #1722 

**Solution**

Catch the `FieldError` exception and send the response as a message to the UI

![Screenshot 2024-02-13 at 19 48 37](https://github.com/django-import-export/django-import-export/assets/6249838/d8163290-8c07-4d3d-a088-126beaa95a31)


**Acceptance Criteria**

Added integration test.