### PR TITLE
Handle django FieldError raised during export

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Changelog
   (#1735)
 - Updated Admin integration documentation to clarify how to save custom form values (#1746)
 - Updated test coverage to include error row when ``collect_failed_rows`` is ``True`` (#1753)
+- Fixed handling of django ``FieldError`` during Admin export (#1756)
 
 4.0.0-beta.2 (2023-12-09)
 -------------------------


### PR DESCRIPTION
**Problem**

Closes #1723

**Solution**

Added except block to catch field error, and return message as error message.

![Screenshot 2024-02-13 at 20 17 57](https://github.com/django-import-export/django-import-export/assets/6249838/3ddbdb76-4006-41d8-b630-ab86b0f96e84)


**Acceptance Criteria**

Added integration test