### PR TITLE
Add check for type to widget render

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,7 @@ Changelog
   (#1735)
 - Updated Admin integration documentation to clarify how to save custom form values (#1746)
 - Updated test coverage to include error row when ``collect_failed_rows`` is ``True`` (#1753)
-- Add check for type to :meth:`~import_export.widgets.Widget.render` (#)
+- Add check for type to :meth:`~import_export.widgets.Widget.render` (#1757)
 
 4.0.0-beta.2 (2023-12-09)
 -------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Changelog
 - Fix slow export with ForeignKey id (#1717)
 - Added customization of Admin UI import error messages (#1727)
 - Improve output of error messages (#1729)
-- Refactor `test_resources.py` into smaller modules (#1733)
+- Refactor ``test_resources.py`` into smaller modules (#1733)
 - Added specific check for declared :attr:`~import_export.options.ResourceOptions.import_id_fields` not in dataset
   (#1735)
 - Updated Admin integration documentation to clarify how to save custom form values (#1746)
@@ -26,7 +26,7 @@ Changelog
 -------------------------
 
 - Fix declaring existing model field(s) in ModelResource altering export order (#1663)
-- Updated `docker-compose` command with latest version syntax in `runtests.sh` (#1686)
+- Updated ``docker-compose`` command with latest version syntax in ``runtests.sh`` (#1686)
 - Support export from model change form (#1687)
 - Updated Admin UI to track deleted and skipped Imports (#1691)
 - Import form defaults to read-only field if only one format defined (#1690)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Changelog
   (#1735)
 - Updated Admin integration documentation to clarify how to save custom form values (#1746)
 - Updated test coverage to include error row when ``collect_failed_rows`` is ``True`` (#1753)
+- Add check for type to :meth:`~import_export.widgets.Widget.render` (#)
 
 4.0.0-beta.2 (2023-12-09)
 -------------------------

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from datetime import date, datetime, time
+import numbers
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from warnings import warn
 
@@ -86,6 +87,8 @@ class NumberWidget(Widget):
 
     def render(self, value, obj=None):
         self._obj_deprecation_warning(obj)
+        if not isinstance(value, numbers.Number):
+            return ""
         if self.coerce_to_string:
             return "" if value is None else number_format(value)
         return value
@@ -204,7 +207,7 @@ class BooleanWidget(Widget):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string is False:
             return value
-        if value in self.NULL_VALUES:
+        if value in self.NULL_VALUES or not type(value) is bool:
             return ""
         return self.TRUE_VALUES[0] if value else self.FALSE_VALUES[0]
 
@@ -248,7 +251,7 @@ class DateWidget(Widget):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string is False:
             return value
-        if not value:
+        if not value or not type(value) is date:
             return ""
         return format_datetime(value, self.formats[0])
 
@@ -298,7 +301,7 @@ class DateTimeWidget(Widget):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string is False:
             return value
-        if not value:
+        if not value or not type(value) is datetime:
             return ""
         if settings.USE_TZ:
             value = timezone.localtime(value)
@@ -344,7 +347,7 @@ class TimeWidget(Widget):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string is False:
             return value
-        if not value:
+        if not value or not type(value) is time:
             return ""
         return value.strftime(self.formats[0])
 
@@ -372,7 +375,7 @@ class DurationWidget(Widget):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string is False:
             return value
-        if value is None:
+        if value is None or not type(value) is timedelta:
             return ""
         return str(value)
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -87,10 +87,12 @@ class NumberWidget(Widget):
 
     def render(self, value, obj=None):
         self._obj_deprecation_warning(obj)
-        if not isinstance(value, numbers.Number):
-            return ""
         if self.coerce_to_string:
-            return "" if value is None else number_format(value)
+            return (
+                ""
+                if value is None or not isinstance(value, numbers.Number)
+                else number_format(value)
+            )
         return value
 
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -93,6 +93,9 @@ class BooleanWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertFalse(self.widget.render(False))
         self.assertIsNone(self.widget.render(None))
 
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render("a"), "")
+
 
 class FormatDatetimeTest(TestCase):
     date = date(10, 8, 2)
@@ -126,6 +129,9 @@ class DateWidgetTest(TestCase, RowDeprecationTestMixin):
 
     def test_render_none(self):
         self.assertEqual(self.widget.render(None), "")
+
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render(int(1)), "")
 
     def test_render_coerce_to_string_is_False(self):
         self.widget = widgets.DateWidget(coerce_to_string=False)
@@ -177,6 +183,9 @@ class DateTimeWidgetTest(TestCase, RowDeprecationTestMixin):
 
     def test_render_none(self):
         self.assertEqual(self.widget.render(None), "")
+
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render(int(1)), "")
 
     def test_render_coerce_to_string_is_False(self):
         self.widget = widgets.DateTimeWidget(coerce_to_string=False)
@@ -279,6 +288,9 @@ class TimeWidgetTest(TestCase, RowDeprecationTestMixin):
     def test_render_none(self):
         self.assertEqual(self.widget.render(None), "")
 
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render(int(1)), "")
+
     def test_render_coerce_to_string_is_False(self):
         self.widget = widgets.TimeWidget(coerce_to_string=False)
         self.assertEqual(self.time, self.widget.render(self.time))
@@ -324,6 +336,9 @@ class DurationWidgetTest(TestCase, RowDeprecationTestMixin):
         self.widget = widgets.DurationWidget(coerce_to_string=False)
         self.assertEqual(self.duration, self.widget.render(self.duration))
 
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render(int(1)), "")
+
     def test_clean(self):
         self.assertEqual(self.widget.clean("1:57:00"), self.duration)
 
@@ -365,6 +380,9 @@ class NumberWidgetTest(TestCase, RowDeprecationTestMixin):
     def test_render_None_coerce_to_string_False(self):
         self.assertEqual("", self.widget.render(None))
 
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render("a"), "")
+
     @skipUnless(
         django.VERSION[0] < 4, f"skipping django {django.VERSION} version specific test"
     )
@@ -395,6 +413,9 @@ class FloatWidgetTest(TestCase, RowDeprecationTestMixin):
 
     def test_render(self):
         self.assertEqual(self.widget.render(self.value), "11.111")
+
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render("a"), "")
 
     def test_clean_string_zero(self):
         self.assertEqual(self.widget.clean("0"), 0.0)
@@ -436,6 +457,9 @@ class DecimalWidgetTest(TestCase, RowDeprecationTestMixin):
 
     def test_render(self):
         self.assertEqual(self.widget.render(self.value), "11.111")
+
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render("1"), "")
 
     def test_clean_string_zero(self):
         self.assertEqual(self.widget.clean("0"), Decimal("0"))
@@ -483,6 +507,9 @@ class IntegerWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertEqual(self.widget.clean(""), None)
         self.assertEqual(self.widget.clean(" "), None)
         self.assertEqual(self.widget.clean("\n\t\r"), None)
+
+    def test_render_invalid_type(self):
+        self.assertEqual(self.widget.render("a"), "")
 
     @skipUnless(
         django.VERSION[0] < 4, f"skipping django {django.VERSION} version specific test"


### PR DESCRIPTION
**Problem**

Closes #1736 



**Solution**

Add a check to widget render() before attempting to render a value.  This prevents a crash due to unknown type such as Now().

**Acceptance Criteria**

- Added unit tests
- Manual test using steps defined in original issue

Screen shots show different error when fix is in place:

![Screenshot 2024-02-13 at 21 39 35](https://github.com/django-import-export/django-import-export/assets/6249838/716cc8fd-34de-4767-8de3-37e59a08727b)

![Screenshot 2024-02-13 at 21 39 55](https://github.com/django-import-export/django-import-export/assets/6249838/c7228584-cb10-49c2-ab74-0c57c20cf6e6)
