### PR TITLE
added fix to `add_instance_info()` for unserializable instances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.0-rc.1 (unreleased)
+
+- added try / catch to :meth:`~import_export.results.RowResult.add_instance_info` to handle unserializable instances (#1767)
+
 4.0.0-rc.0 (2024-02-14)
 -----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
 4.0.0-rc.1 (unreleased)
+-----------------------
 
 - added try / catch to :meth:`~import_export.results.RowResult.add_instance_info` to handle unserializable instances (#1767)
 

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -1,8 +1,12 @@
+import logging
 from collections import OrderedDict
 
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.utils.encoding import force_str
+from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
+
+logger = logging.getLogger(__name__)
 
 
 class Error:
@@ -110,7 +114,10 @@ class RowResult:
         if instance is not None:
             # Add object info to RowResult (e.g. for LogEntry)
             self.object_id = getattr(instance, "pk", None)
-            self.object_repr = force_str(instance)
+            try:
+                self.object_repr = force_str(instance)
+            except Exception as e:
+                logger.debug(_("call to force_str() on instance failed: %s" % str(e)))
 
 
 class InvalidRow:

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from core.models import Book
 from django.core.exceptions import ValidationError
 from django.test.testcases import TestCase
@@ -60,6 +62,22 @@ class ResultTest(TestCase):
         row_result.add_instance_info(Book(pk=1, name="some book"))
         self.assertEqual(1, row_result.object_id)
         self.assertEqual("some book", row_result.object_repr)
+
+    @patch("import_export.results.logger")
+    def test_add_instance_info_instance_unserializable(self, mock_logger):
+        # issue 1763
+        class UnserializableBook(object):
+            # will raise TypeError
+            def __str__(self):
+                return None
+
+        row_result = RowResult()
+        row_result.add_instance_info(UnserializableBook())
+        mock_logger.debug.assert_called_with(
+            "call to force_str() on instance failed: "
+            "__str__ returned non-string (type NoneType)"
+        )
+        self.assertEqual(None, row_result.object_repr)
 
     def test_is_new(self):
         row_result = RowResult()


### PR DESCRIPTION
**Problem**

Closes #1763 

**Solution**

Add try / catch block to catch and log any exception which arises from trying to call `force_str()` on an object which is not serializable via a call to `__str__()`

**Acceptance Criteria**

- Includes test