### PR TITLE
bump tablib to 3.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,10 @@ CLASSIFIERS = [
     "Topic :: Software Development",
 ]
 
-# tablib temporarily pinned to 3.5.0 - see issue #1602
 install_requires = [
     "diff-match-patch",
     "Django>=3.2",
-    "tablib[html,ods,xls,xlsx,yaml]==3.5.0",
+    "tablib[html,ods,xls,xlsx,yaml]==3.6.0",
 ]
 
 


### PR DESCRIPTION
**Problem**

New version of tablib is available, here a simple update to use tablib==3.6.0
