### PR TITLE
Remove unneeded format method overrides

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -153,9 +153,6 @@ class TSV(TextFormat):
     TABLIB_MODULE = "tablib.formats._tsv"
     CONTENT_TYPE = "text/tab-separated-values"
 
-    def create_dataset(self, in_stream, **kwargs):
-        return super().create_dataset(in_stream, **kwargs)
-
 
 class ODS(TextFormat):
     TABLIB_MODULE = "tablib.formats._ods"

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -163,9 +163,6 @@ class HTML(TextFormat):
     TABLIB_MODULE = "tablib.formats._html"
     CONTENT_TYPE = "text/html"
 
-    def export_data(self, dataset, **kwargs):
-        return super().export_data(dataset, **kwargs)
-
 
 class XLS(TablibFormat):
     TABLIB_MODULE = "tablib.formats._xls"


### PR DESCRIPTION
It used to be overridden for Python 2 compat