### PR TITLE
Fix for incorrect header order on 'confirm' page

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 -----------------------
 
 - Add form error if source file contains invalid header (#1780)
+- Fix for incorrect header order on 'confirm' page (#1786)
 
 4.0.0-rc.1 (2024-03-15)
 -----------------------

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -579,7 +579,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         """
         Diff representation headers.
         """
-        return self.get_user_visible_headers()
+        return [force_str(field.column_name) for field in self.get_import_fields()]
 
     def before_import(self, dataset, **kwargs):
         r"""
@@ -1049,12 +1049,6 @@ class Resource(metaclass=DeclarativeMetaclass):
         if isinstance(fields, list) and fields:
             return [f for f in headers if f in fields]
 
-        return headers
-
-    def get_user_visible_headers(self):
-        headers = [
-            force_str(field.column_name) for field in self.get_user_visible_fields()
-        ]
         return headers
 
     def get_user_visible_fields(self):

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -55,6 +55,11 @@ class EBookResource(ModelResource):
 
     class Meta:
         model = EBook
+        fields = (
+            "id",
+            "author_email",
+            "name",
+        )
 
 
 class CustomBookAdmin(ImportExportModelAdmin):

--- a/tests/core/tests/admin_integration/mixins.py
+++ b/tests/core/tests/admin_integration/mixins.py
@@ -9,6 +9,7 @@ from import_export.formats.base_formats import DEFAULT_FORMATS
 class AdminTestMixin(object):
     category_change_url = "/admin/core/category/"
     book_import_url = "/admin/core/book/import/"
+    ebook_import_url = "/admin/core/ebook/import/"
     book_process_import_url = "/admin/core/book/process_import/"
     legacybook_import_url = "/admin/core/legacybook/import/"
     legacybook_process_import_url = "/admin/core/legacybook/process_import/"
@@ -24,7 +25,14 @@ class AdminTestMixin(object):
         self.client.login(username="admin", password="password")
 
     def _do_import_post(
-        self, url, filename, input_format=0, encoding=None, resource=None, follow=False
+        self,
+        url,
+        filename,
+        input_format=0,
+        encoding=None,
+        resource=None,
+        follow=False,
+        data=None,
     ):
         input_format = input_format
         filename = os.path.join(
@@ -35,10 +43,14 @@ class AdminTestMixin(object):
             filename,
         )
         with open(filename, "rb") as f:
-            data = {
-                "format": str(input_format),
-                "import_file": f,
-            }
+            if data is None:
+                data = dict()
+            data.update(
+                {
+                    "format": str(input_format),
+                    "import_file": f,
+                }
+            )
             if encoding:
                 BookAdmin.from_encoding = encoding
             if resource:

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -327,10 +327,8 @@ class FilteredExportAdminIntegrationTest(AdminTestMixin, TestCase):
             'attachment; filename="EBook-{}.csv"'.format(date_str),
         )
         self.assertEqual(
-            b"id,name,author,author_email,imported,published,"
-            b"published_time,price,added,categories\r\n"
-            b"5,The Man with the Golden Gun,5,ian@example.com,"
-            b"0,1965-04-01,21:00:00,5.00,,2\r\n",
+            b"id,author_email,name\r\n"
+            b"5,ian@example.com,The Man with the Golden Gun\r\n",
             response.content,
         )
 

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -991,6 +991,7 @@ class ConfirmImportPreviewOrderTest(AdminTestMixin, TestCase):
 
     fixtures = ["author"]
 
+    @ignore_widget_deprecation_warning
     def test_import_preview_order(self):
         author_id = Author.objects.first().id
         response = self._do_import_post(

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -1002,7 +1002,7 @@ class ConfirmImportPreviewOrderTest(AdminTestMixin, TestCase):
         # test header rendered in correct order
         target_header_re = (
             r"<thead>[\\n\s]+<tr>[\\n\s]+<th></th>[\\n\s]+<th>id</th>"
-            r"[\\n\s]+<th>name</th>[\\n\s]+<th>author_email</th>[\\n\s]+</tr>[\\n\s]+"
+            r"[\\n\s]+<th>author_email</th>[\\n\s]+<th>name</th>[\\n\s]+</tr>[\\n\s]+"
             "</thead>"
         )
         self.assertRegex(str(response.content), target_header_re)

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -1008,7 +1008,7 @@ class ConfirmImportPreviewOrderTest(AdminTestMixin, TestCase):
         self.assertRegex(str(response.content), target_header_re)
         # test row rendered in correct order
         target_row_re = (
-            r'<tr class="new">[\\n\s]+"'
+            r'<tr class="new">[\\n\s]+'
             r'<td class="import-type">[\\n\s]+New[\\n\s]+</td>[\\n\s]+'
             r'<td><ins style="background:#e6ffe6;">1</ins></td>[\\n\s]+'
             r'<td><ins style="background:#e6ffe6;">test@example.com</ins></td>[\\n\s]+'

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -984,3 +984,35 @@ class TestImportSkipConfirm(AdminTestMixin, TransactionTestCase):
             str_in_response="Import finished: 1 new, 0 updated, "
             + "0 deleted and 0 skipped books.",
         )
+
+
+class ConfirmImportPreviewOrderTest(AdminTestMixin, TestCase):
+    """Test preview order displayed correctly (issue 1784)."""
+
+    fixtures = ["author"]
+
+    def test_import_preview_order(self):
+        author_id = Author.objects.first().id
+        response = self._do_import_post(
+            self.ebook_import_url,
+            "books.csv",
+            input_format="0",
+            data={"author": author_id},
+        )
+        # test header rendered in correct order
+        target_header_re = (
+            r"<thead>[\\n\s]+<tr>[\\n\s]+<th></th>[\\n\s]+<th>id</th>"
+            r"[\\n\s]+<th>name</th>[\\n\s]+<th>author_email</th>[\\n\s]+</tr>[\\n\s]+"
+            "</thead>"
+        )
+        self.assertRegex(str(response.content), target_header_re)
+        # test row rendered in correct order
+        target_row_re = (
+            r'<tr class="new">[\\n\s]+"'
+            r'<td class="import-type">[\\n\s]+New[\\n\s]+</td>[\\n\s]+'
+            r'<td><ins style="background:#e6ffe6;">1</ins></td>[\\n\s]+'
+            r'<td><ins style="background:#e6ffe6;">test@example.com</ins></td>[\\n\s]+'
+            r'<td><ins style="background:#e6ffe6;">Some book</ins></td>[\\n\s]+'
+            "</tr>"
+        )
+        self.assertRegex(str(response.content), target_row_re)

--- a/tests/core/tests/test_resources/test_diffs.py
+++ b/tests/core/tests/test_resources/test_diffs.py
@@ -99,7 +99,7 @@ class SkipDiffTest(TestCase):
             "import_export.resources.Resource.get_import_fields"
         ) as mock_get_import_fields:
             resource.import_data(self.dataset, dry_run=True)
-            self.assertEqual(2, mock_get_import_fields.call_count)
+            self.assertEqual(3, mock_get_import_fields.call_count)
 
 
 class SkipHtmlDiffTest(TestCase):


### PR DESCRIPTION
**Problem**

Closes #1784

**Solution**

- Fix `get_diff_headers` so that it matches the field order in the Diff class.
- Remove unnecessary method `get_user_visible_headers()`

**Acceptance Criteria**

- includes test