### PR TITLE
Support dynamic selection of Resource class based on request property

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ Changelog
 - Add form error if source file contains invalid header (#1780)
 - Fix for incorrect header order on 'confirm' page (#1786)
 - Remove unneeded format method overrides (#1785)
-- Support dynamic selection of Resource class based on request property ()
+- Support dynamic selection of Resource class based on request property (#1787)
 
 4.0.0-rc.1 (2024-03-15)
 -----------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Changelog
 -----------------------
 
 - Add form error if source file contains invalid header (#1780)
+- Remove unneeded format method overrides (#1785)
+- Support dynamic selection of Resource class based on request property ()
 
 4.0.0-rc.1 (2024-03-15)
 -----------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -135,23 +135,21 @@ See `this issue <https://github.com/django-import-export/django-import-export/is
 API changes
 ===========
 
-v4 of import-export contains a number of minor changes to the API.
+v4 of import-export contains a number of changes to the API.  These changes are summarized in the table below.
+Refer to
+`this PR <https://github.com/django-import-export/django-import-export/pull/1641/>`_ for detailed information.
 
-If you have customized import-export by overriding methods, then you will have to
-modify your installation before working with v4.  If you have not overridden any
-methods then you should not be affected by these changes and no changes to your code
+If you have customized import-export by overriding methods, then you may have to modify your installation before
+working with v4.
+
+If you have not overridden any methods then you should not be affected by these changes and no changes to your code
 should be necessary.
 
-The API changes include changes to method arguments, although some method names have
-changed.
-
-Refer to
-`this PR <https://github.com/django-import-export/django-import-export/pull/1641/>`_
-for more information.
+The API changes include changes to method arguments, although some method names have changed.
 
 Methods which process row data have been updated so that method args are standardized.
-This has been done to resolve inconsistency issues where the parameters differed between
-method calls, and to allow easier extensibility.
+This has been done to resolve inconsistency issues where the parameters differed between method calls, and to allow
+easier extensibility.
 
 :class:`import_export.resources.Resource`
 -----------------------------------------
@@ -258,6 +256,11 @@ This section describes methods in which the parameters have changed.
        * ``dry_run`` param now in ``kwargs``
        * ``using_transactions`` param now in ``kwargs``
 
+   * - ``import_field(self, field, obj, data, is_m2m=False, **kwargs)``
+     - ``import_field(self, field, instance, row, is_m2m=False, **kwargs):``
+     - * ``obj`` renamed to ``instance``
+       * ``data`` renamed to ``row``
+
    * - ``before_export(self, queryset, *args, **kwargs)``
      - ``before_export(self, queryset, **kwargs)``
      - * unused ``*args`` list removed
@@ -275,9 +278,18 @@ This section describes methods in which the parameters have changed.
      - ``export_field(self, field, instance)``
      - * ``obj`` renamed to ``instance``
 
+   * - ``export_resource(self, obj)``
+     - ``export_resource(self, instance, fields=None)``
+     - * ``obj`` renamed to ``instance``
+       * ``fields`` passed as kwarg
+
    * - ``export(self, *args, queryset=None, **kwargs)``
      - ``export(self, queryset=None, **kwargs)``
      - * unused ``*args`` list removed
+
+   * - ``get_export_headers(self)``
+     - ``get_export_headers(self, fields=None)``
+     - * ``fields`` passed as kwarg
 
 
 :class:`import_export.mixins.BaseImportExportMixin`
@@ -294,13 +306,12 @@ Parameter changes
      - Summary
 
    * - ``get_resource_classes(self)``
-     - ``get_resource_classes(self, **kwargs)``
-     -  * ``request`` param now in ``kwargs``
+     - ``get_resource_classes(self, request)``
+     -  * Added ``request`` param
 
    * - ``get_resource_kwargs(self, request, *args, **kwargs)``
-     - ``get_resource_kwargs(self, **kwargs)``
-     -  * ``request`` param now in ``kwargs``
-        * unused ``*args`` list removed
+     - ``get_resource_kwargs(self, request, **kwargs)``
+     -  * unused ``*args`` list removed
 
 :class:`import_export.mixins.BaseImportMixin`
 ---------------------------------------------
@@ -316,17 +327,16 @@ Parameter changes
      - Summary
 
    * - ``get_import_resource_kwargs(self, request, *args, **kwargs)``
-     - ``get_import_resource_kwargs(self, **kwargs)``
-     -  * ``request`` param now in ``kwargs``
-        * unused ``*args`` list removed
+     - ``get_import_resource_kwargs(self, request, **kwargs)``
+     -  * unused ``*args`` list removed
 
    * - ``get_import_resource_classes(self)``
-     - ``get_import_resource_classes(self, **kwargs)``
-     -  * ``request`` param now in ``kwargs``
+     - ``get_import_resource_classes(self, request)``
+     -  * Added ``request`` param
 
-   * - ``choose_import_resource_class(self, form)``
+   * - ``choose_import_resource_class(self, form, request)``
      - ``choose_import_resource_class(self, **kwargs)``
-     -  * ``form`` param now in ``kwargs``
+     -  * Added ``request`` param
 
 :class:`import_export.mixins.BaseExportMixin`
 ---------------------------------------------
@@ -342,22 +352,20 @@ Parameter changes
      - Summary
 
    * - ``get_export_resource_classes(self)``
-     - ``get_export_resource_classes(self, **kwargs)``
-     - ``kwargs`` added
+     - ``get_export_resource_classes(self, request)``
+     -  * Added ``request`` param
 
    * - ``get_export_resource_kwargs(self, request, *args, **kwargs)``
-     - ``get_export_resource_kwargs(self, **kwargs)``
+     - ``get_export_resource_kwargs(self, request, **kwargs)``
      -  * unused ``*args`` list removed
-        * ``request`` param now in ``kwargs``
 
    * - ``get_data_for_export(self, request, queryset, *args, **kwargs)``
-     - ``get_data_for_export(self, queryset, **kwargs)``
+     - ``get_data_for_export(self, request, queryset, **kwargs)``
      -  * unused ``*args`` list removed
-        * ``request`` param now in ``kwargs``
 
    * - ``choose_export_resource_class(self, form)``
-     - ``choose_export_resource_class(self, **kwargs)``
-     -  * ``form`` param now in ``kwargs``
+     - ``choose_export_resource_class(self, form, request)``
+     -  * Added ``request`` param
 
 
 :class:`import_export.fields.Field`
@@ -417,3 +425,4 @@ Parameter changes
      - ``__init__(self, formats, resources, **kwargs)``
      - * ``formats`` added as a mandatory arg
        * ``resources`` added as a mandatory arg
+       * unused ``*args`` list removed

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -279,6 +279,29 @@ This section describes methods in which the parameters have changed.
      - ``export(self, queryset=None, **kwargs)``
      - * unused ``*args`` list removed
 
+
+:class:`import_export.mixins.BaseImportExportMixin`
+---------------------------------------------
+
+Parameter changes
+^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Previous
+     - New
+     - Summary
+
+   * - ``get_resource_classes(self)``
+     - ``get_resource_classes(self, **kwargs)``
+     -  * ``request`` param now in ``kwargs``
+
+   * - ``get_resource_kwargs(self, request, *args, **kwargs)``
+     - ``get_resource_kwargs(self, **kwargs)``
+     -  * ``request`` param now in ``kwargs``
+        * unused ``*args`` list removed
+
 :class:`import_export.mixins.BaseImportMixin`
 ---------------------------------------------
 
@@ -293,11 +316,17 @@ Parameter changes
      - Summary
 
    * - ``get_import_resource_kwargs(self, request, *args, **kwargs)``
-     - ``get_import_resource_kwargs(self, request, **kwargs)``
-     -  * ``using_transactions`` param now in ``kwargs``
-        * ``dry_run`` param now in ``kwargs``
+     - ``get_import_resource_kwargs(self, **kwargs)``
+     -  * ``request`` param now in ``kwargs``
         * unused ``*args`` list removed
 
+   * - ``get_import_resource_classes(self)``
+     - ``get_import_resource_classes(self, **kwargs)``
+     -  * ``request`` param now in ``kwargs``
+
+   * - ``choose_import_resource_class(self, form)``
+     - ``choose_import_resource_class(self, **kwargs)``
+     -  * ``form`` param now in ``kwargs``
 
 :class:`import_export.mixins.BaseExportMixin`
 ---------------------------------------------
@@ -312,17 +341,23 @@ Parameter changes
      - New
      - Summary
 
-   * - ``get_export_resource_kwargs(self, request, *args, **kwargs)``
-     - ``get_export_resource_kwargs(self, request, **kwargs)``
-     -  * unused ``*args`` list removed
+   * - ``get_export_resource_classes(self)``
+     - ``get_export_resource_classes(self, **kwargs)``
+     - ``kwargs`` added
 
    * - ``get_export_resource_kwargs(self, request, *args, **kwargs)``
-     - ``get_export_resource_kwargs(self, request, **kwargs)``
+     - ``get_export_resource_kwargs(self, **kwargs)``
      -  * unused ``*args`` list removed
+        * ``request`` param now in ``kwargs``
 
-   * - ``get_data_for_export(self, request, *args, **kwargs)``
-     - ``get_data_for_export(self, request, queryset, **kwargs)``
+   * - ``get_data_for_export(self, request, queryset, *args, **kwargs)``
+     - ``get_data_for_export(self, queryset, **kwargs)``
      -  * unused ``*args`` list removed
+        * ``request`` param now in ``kwargs``
+
+   * - ``choose_export_resource_class(self, form)``
+     - ``choose_export_resource_class(self, **kwargs)``
+     -  * ``form`` param now in ``kwargs``
 
 
 :class:`import_export.fields.Field`
@@ -379,6 +414,6 @@ Parameter changes
      - Summary
 
    * - ``__init__(self, *args, resources=None, **kwargs)``
-     - ``__init__(self, formats, resources, *args, **kwargs)``
+     - ``__init__(self, formats, resources, **kwargs)``
      - * ``formats`` added as a mandatory arg
        * ``resources`` added as a mandatory arg

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -192,7 +192,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         res_kwargs = self.get_import_resource_kwargs(
             request, form=confirm_form, **kwargs
         )
-        resource = self.choose_import_resource_class(confirm_form)(**res_kwargs)
+        resource = self.choose_import_resource_class(request, confirm_form)(
+            **res_kwargs
+        )
         imp_kwargs = self.get_import_data_kwargs(request, form=confirm_form, **kwargs)
         imp_kwargs["retain_instance_in_row_result"] = True
 
@@ -286,7 +288,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         form_class = self.get_import_form_class(request)
         kwargs = self.get_import_form_kwargs(request)
 
-        return form_class(formats, self.get_import_resource_classes(), **kwargs)
+        return form_class(
+            formats, self.get_import_resource_classes(request, **kwargs), **kwargs
+        )
 
     def get_import_form_class(self, request):
         """
@@ -504,7 +508,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     res_kwargs = self.get_import_resource_kwargs(
                         request, form=import_form, **kwargs
                     )
-                    resource = self.choose_import_resource_class(import_form)(
+                    resource = self.choose_import_resource_class(request, import_form)(
                         **res_kwargs
                     )
                     resources = [resource]
@@ -538,7 +542,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             res_kwargs = self.get_import_resource_kwargs(
                 request, form=import_form, **kwargs
             )
-            resource_classes = self.get_import_resource_classes()
+            resource_classes = self.get_import_resource_classes(request, **kwargs)
             resources = [
                 resource_class(**res_kwargs) for resource_class in resource_classes
             ]
@@ -735,7 +739,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         formats = self.get_export_formats()
         form = form_type(
             formats,
-            self.get_export_resource_classes(),
+            self.get_export_resource_classes(request=request),
             data=request.POST or None,
         )
         form.fields["export_items"] = MultipleChoiceField(
@@ -804,7 +808,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
                     ).get_user_visible_fields()
                 ],
             )
-            for res in self.get_export_resource_classes()
+            for res in self.get_export_resource_classes(request=request)
         ]
         return context
 
@@ -883,7 +887,7 @@ class ExportActionMixin(ExportMixin):
         formats = self.get_export_formats()
         form = form_type(
             formats=formats,
-            resources=self.get_export_resource_classes(),
+            resources=self.get_export_resource_classes(request),
             initial={"export_items": list(queryset.values_list("id", flat=True))},
         )
         # selected items are to be stored as a hidden input on the form

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -188,7 +188,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     ):
         res_kwargs = self.get_import_resource_kwargs(request, **kwargs)
         resource = self.choose_import_resource_class(form, request)(**res_kwargs)
-        imp_kwargs = self.get_import_data_kwargs(**kwargs)
+        imp_kwargs = self.get_import_data_kwargs(request=request, form=form, **kwargs)
         imp_kwargs["retain_instance_in_row_result"] = True
 
         return resource.import_data(
@@ -730,7 +730,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         formats = self.get_export_formats()
         form = form_type(
             formats,
-            self.get_export_resource_classes(request=request),
+            self.get_export_resource_classes(request),
             data=request.POST or None,
         )
         form.fields["export_items"] = MultipleChoiceField(
@@ -795,11 +795,11 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
                 [
                     field.column_name
                     for field in res(
-                        **self.get_export_resource_kwargs(request=request)
+                        **self.get_export_resource_kwargs(request)
                     ).get_user_visible_fields()
                 ],
             )
-            for res in self.get_export_resource_classes(request=request)
+            for res in self.get_export_resource_classes(request)
         ]
         return context
 
@@ -878,7 +878,7 @@ class ExportActionMixin(ExportMixin):
         formats = self.get_export_formats()
         form = form_type(
             formats=formats,
-            resources=self.get_export_resource_classes(request=request),
+            resources=self.get_export_resource_classes(request),
             initial={"export_items": list(queryset.values_list("id", flat=True))},
         )
         # selected items are to be stored as a hidden input on the form

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -173,7 +173,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
             data = tmp_storage.read()
             dataset = input_format.create_dataset(data)
-            result = self.process_dataset(dataset, confirm_form, request, **kwargs)
+            result = self.process_dataset(
+                dataset, form=confirm_form, request=request, **kwargs
+            )
 
             tmp_storage.remove()
 
@@ -182,20 +184,19 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     def process_dataset(
         self,
         dataset,
-        confirm_form,
-        request,
         **kwargs,
     ):
-        kwargs.update(request=request, form=confirm_form)
         res_kwargs = self.get_import_resource_kwargs(**kwargs)
         resource = self.choose_import_resource_class(**kwargs)(**res_kwargs)
         imp_kwargs = self.get_import_data_kwargs(**kwargs)
         imp_kwargs["retain_instance_in_row_result"] = True
 
+        request = kwargs["request"]
+        form = kwargs["form"]
         return resource.import_data(
             dataset,
             dry_run=False,
-            file_name=confirm_form.cleaned_data.get("original_file_name"),
+            file_name=form.cleaned_data.get("original_file_name"),
             user=request.user,
             **imp_kwargs,
         )
@@ -459,8 +460,8 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                 if not import_form.errors:
                     result = self.process_dataset(
                         dataset,
-                        import_form,
-                        request,
+                        form=import_form,
+                        request=request,
                         raise_errors=False,
                         rollback_on_validation_errors=True,
                         **kwargs,

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -496,11 +496,11 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                 if not import_form.errors:
                     # prepare kwargs for import data, if needed
                     res_kwargs = self.get_import_resource_kwargs(
-                        request=request, form=import_form, **kwargs
+                        request, form=import_form, **kwargs
                     )
-                    resource = self.choose_import_resource_class(
-                        request=request, form=import_form
-                    )(**res_kwargs)
+                    resource = self.choose_import_resource_class(import_form, request)(
+                        **res_kwargs
+                    )
                     resources = [resource]
 
                     # prepare additional kwargs for import_data, if needed
@@ -532,9 +532,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             res_kwargs = self.get_import_resource_kwargs(
                 request=request, form=import_form, **kwargs
             )
-            resource_classes = self.get_import_resource_classes(
-                request=request, **kwargs
-            )
+            resource_classes = self.get_import_resource_classes(request)
             resources = [
                 resource_class(**res_kwargs) for resource_class in resource_classes
             ]

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -21,8 +21,8 @@ class ImportExportFormBase(forms.Form):
         choices=(),
     )
 
-    def __init__(self, formats, resources, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, formats, resources, **kwargs):
+        super().__init__(**kwargs)
         self._init_resources(resources)
         self._init_formats(formats)
 
@@ -62,8 +62,8 @@ class ImportForm(ImportExportFormBase):
     # so that the 'guess_format' js logic makes sense
     field_order = ["resource", "import_file", "format"]
 
-    def __init__(self, formats, resources, *args, **kwargs):
-        super().__init__(formats, resources, *args, **kwargs)
+    def __init__(self, formats, resources, **kwargs):
+        super().__init__(formats, resources, **kwargs)
         if len(formats) > 1:
             self.fields["import_file"].widget.attrs["class"] = "guess_format"
             self.fields["format"].widget.attrs["class"] = "guess_format"
@@ -99,8 +99,8 @@ class ExportForm(ImportExportFormBase):
 
 
 class SelectableFieldsExportForm(ExportForm):
-    def __init__(self, formats, resources, *args, **kwargs):
-        super().__init__(formats, resources, *args, **kwargs)
+    def __init__(self, formats, resources, **kwargs):
+        super().__init__(formats, resources, **kwargs)
         self._init_selectable_fields(resources)
 
     @property

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -42,13 +42,18 @@ class BaseImportExportMixin:
                 "subscriptable (list, tuple, ...)"
             )
 
-    def get_resource_classes(self):
-        """Return subscriptable type (list, tuple, ...) containing resource classes"""
+    def get_resource_classes(self, request=None, **kwargs):
+        """
+        Return subscriptable type (list, tuple, ...) containing resource classes
+        :param request: The request object.
+        :param kwargs: Keyword arguments.
+        :returns: The Resource classes.
+        """
         if not self.resource_classes:
             return [modelresource_factory(self.model)]
         return self.resource_classes
 
-    def get_resource_kwargs(self, request, *args, **kwargs):
+    def get_resource_kwargs(self, request=None, **kwargs):
         """
         Return the kwargs which are to be passed to the Resource constructor.
         Can be overridden to provide additional kwarg params.
@@ -77,11 +82,11 @@ class BaseImportExportMixin:
 
 
 class BaseImportMixin(BaseImportExportMixin):
-    def get_import_resource_classes(self):
+    def get_import_resource_classes(self, request=None, **kwargs):
         """
         Returns ResourceClass subscriptable (list, tuple, ...) to use for import.
         """
-        resource_classes = self.get_resource_classes()
+        resource_classes = self.get_resource_classes(request, **kwargs)
         self.check_resource_classes(resource_classes)
         return resource_classes
 
@@ -91,12 +96,18 @@ class BaseImportMixin(BaseImportExportMixin):
         """
         return [f for f in self.import_formats if f().can_import()]
 
-    def get_import_resource_kwargs(self, request, **kwargs):
+    def get_import_resource_kwargs(self, request=None, **kwargs):
+        """
+        Returns kwargs which will be passed to the Resource constructor.
+        :param request: The request object.
+        :param kwargs: Keyword arguments.
+        :returns: The kwargs (dict)
+        """
         return self.get_resource_kwargs(request, **kwargs)
 
-    def choose_import_resource_class(self, form):
+    def choose_import_resource_class(self, request, form):
         resource_index = self.get_resource_index(form)
-        return self.get_import_resource_classes()[resource_index]
+        return self.get_import_resource_classes(request)[resource_index]
 
 
 class BaseExportMixin(BaseImportExportMixin):
@@ -108,11 +119,14 @@ class BaseExportMixin(BaseImportExportMixin):
         """
         return [f for f in self.export_formats if f().can_export()]
 
-    def get_export_resource_classes(self):
+    def get_export_resource_classes(self, request=None, **kwargs):
         """
         Returns ResourceClass subscriptable (list, tuple, ...) to use for export.
+        :param request: The request object.
+        :param kwargs: Keyword arguments.
+        :returns: The Resource classes.
         """
-        resource_classes = self.get_resource_classes()
+        resource_classes = self.get_resource_classes(request=request, **kwargs)
         self.check_resource_classes(resource_classes)
         return resource_classes
 
@@ -121,6 +135,12 @@ class BaseExportMixin(BaseImportExportMixin):
         return self.get_export_resource_classes()[resource_index]
 
     def get_export_resource_kwargs(self, request, **kwargs):
+        """
+        Returns kwargs which will be passed to the Resource constructor.
+        :param request: The request object.
+        :param kwargs: Keyword arguments.
+        :returns: The kwargs (dict)
+        """
         return self.get_resource_kwargs(request, **kwargs)
 
     def get_export_resource_fields_from_form(self, form):

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -41,21 +41,22 @@ class BaseImportExportMixin:
                 "subscriptable (list, tuple, ...)"
             )
 
-    def get_resource_classes(self, **kwargs):
+    def get_resource_classes(self, request):
         """
         Return subscriptable type (list, tuple, ...) containing resource classes
-        :param kwargs: Keyword arguments.
+        :param request: The request object.
         :returns: The Resource classes.
         """
         if not self.resource_classes:
             return [modelresource_factory(self.model)]
         return self.resource_classes
 
-    def get_resource_kwargs(self, **kwargs):
+    def get_resource_kwargs(self, request, **kwargs):
         """
         Return the kwargs which are to be passed to the Resource constructor.
         Can be overridden to provide additional kwarg params.
 
+        :param request: The request object.
         :param kwargs: Keyword arguments.
         :returns: The Resource kwargs (by default, is the kwargs passed).
         """
@@ -78,11 +79,12 @@ class BaseImportExportMixin:
 
 
 class BaseImportMixin(BaseImportExportMixin):
-    def get_import_resource_classes(self, **kwargs):
+    def get_import_resource_classes(self, request):
         """
+        :param request: The request object.
         Returns ResourceClass subscriptable (list, tuple, ...) to use for import.
         """
-        resource_classes = self.get_resource_classes(**kwargs)
+        resource_classes = self.get_resource_classes(request)
         self.check_resource_classes(resource_classes)
         return resource_classes
 
@@ -92,17 +94,24 @@ class BaseImportMixin(BaseImportExportMixin):
         """
         return [f for f in self.import_formats if f().can_import()]
 
-    def get_import_resource_kwargs(self, **kwargs):
+    def get_import_resource_kwargs(self, request, **kwargs):
         """
         Returns kwargs which will be passed to the Resource constructor.
+        :param request: The request object.
         :param kwargs: Keyword arguments.
         :returns: The kwargs (dict)
         """
-        return self.get_resource_kwargs(**kwargs)
+        return self.get_resource_kwargs(request, **kwargs)
 
-    def choose_import_resource_class(self, **kwargs):
-        resource_index = self.get_resource_index(kwargs["form"])
-        return self.get_import_resource_classes(**kwargs)[resource_index]
+    def choose_import_resource_class(self, form, request):
+        """
+        Identify which class should be used for import
+        :param form: The form object.
+        :param request: The request object.
+        :returns: The export Resource class.
+        """
+        resource_index = self.get_resource_index(form)
+        return self.get_import_resource_classes(request)[resource_index]
 
 
 class BaseExportMixin(BaseImportExportMixin):
@@ -114,27 +123,34 @@ class BaseExportMixin(BaseImportExportMixin):
         """
         return [f for f in self.export_formats if f().can_export()]
 
-    def get_export_resource_classes(self, **kwargs):
+    def get_export_resource_classes(self, request):
         """
         Returns ResourceClass subscriptable (list, tuple, ...) to use for export.
-        :param kwargs: Keyword arguments.
+        :param request: The request object.
         :returns: The Resource classes.
         """
-        resource_classes = self.get_resource_classes(**kwargs)
+        resource_classes = self.get_resource_classes(request)
         self.check_resource_classes(resource_classes)
         return resource_classes
 
-    def choose_export_resource_class(self, **kwargs):
-        resource_index = self.get_resource_index(kwargs["form"])
-        return self.get_export_resource_classes()[resource_index]
+    def choose_export_resource_class(self, form, request):
+        """
+        Identify which class should be used for export
+        :param request: The request object.
+        :param form: The form object.
+        :returns: The export Resource class.
+        """
+        resource_index = self.get_resource_index(form)
+        return self.get_export_resource_classes(request)[resource_index]
 
-    def get_export_resource_kwargs(self, **kwargs):
+    def get_export_resource_kwargs(self, request, **kwargs):
         """
         Returns kwargs which will be passed to the Resource constructor.
+        :param request: The request object.
         :param kwargs: Keyword arguments.
         :returns: The kwargs (dict)
         """
-        return self.get_resource_kwargs(**kwargs)
+        return self.get_resource_kwargs(request, **kwargs)
 
     def get_export_resource_fields_from_form(self, form):
         if isinstance(form, SelectableFieldsExportForm):
@@ -144,10 +160,10 @@ class BaseExportMixin(BaseImportExportMixin):
 
         return
 
-    def get_data_for_export(self, queryset, **kwargs):
+    def get_data_for_export(self, request, queryset, **kwargs):
         export_form = kwargs.get("export_form")
-        export_class = self.choose_export_resource_class(form=export_form, **kwargs)
-        export_resource_kwargs = self.get_export_resource_kwargs(**kwargs)
+        export_class = self.choose_export_resource_class(export_form, request)
+        export_resource_kwargs = self.get_export_resource_kwargs(request, **kwargs)
         export_fields = self.get_export_resource_fields_from_form(export_form)
         cls = export_class(**export_resource_kwargs)
         export_data = cls.export(
@@ -172,7 +188,7 @@ class ExportViewMixin(BaseExportMixin):
         """
         Returns file_format representation for given queryset.
         """
-        data = self.get_data_for_export(queryset, **kwargs)
+        data = self.get_data_for_export(self.request, queryset, **kwargs)
         export_data = file_format.export_data(data)
         return export_data
 
@@ -183,7 +199,7 @@ class ExportViewMixin(BaseExportMixin):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["formats"] = self.get_export_formats()
-        kwargs["resources"] = self.get_export_resource_classes()
+        kwargs["resources"] = self.get_export_resource_classes(self.request)
         return kwargs
 
 

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -124,8 +124,8 @@ class BaseExportMixin(BaseImportExportMixin):
         self.check_resource_classes(resource_classes)
         return resource_classes
 
-    def choose_export_resource_class(self, form):
-        resource_index = self.get_resource_index(form)
+    def choose_export_resource_class(self, **kwargs):
+        resource_index = self.get_resource_index(kwargs["form"])
         return self.get_export_resource_classes()[resource_index]
 
     def get_export_resource_kwargs(self, **kwargs):
@@ -146,7 +146,7 @@ class BaseExportMixin(BaseImportExportMixin):
 
     def get_data_for_export(self, queryset, **kwargs):
         export_form = kwargs.get("export_form")
-        export_class = self.choose_export_resource_class(export_form)
+        export_class = self.choose_export_resource_class(form=export_form, **kwargs)
         export_resource_kwargs = self.get_export_resource_kwargs(**kwargs)
         export_fields = self.get_export_resource_fields_from_form(export_form)
         cls = export_class(**export_resource_kwargs)

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -20,7 +20,6 @@ class BaseImportExportMixin:
     interface.
     """
 
-    resource_class = None
     resource_classes = []
 
     @property
@@ -42,10 +41,9 @@ class BaseImportExportMixin:
                 "subscriptable (list, tuple, ...)"
             )
 
-    def get_resource_classes(self, request=None, **kwargs):
+    def get_resource_classes(self, **kwargs):
         """
         Return subscriptable type (list, tuple, ...) containing resource classes
-        :param request: The request object.
         :param kwargs: Keyword arguments.
         :returns: The Resource classes.
         """
@@ -53,13 +51,11 @@ class BaseImportExportMixin:
             return [modelresource_factory(self.model)]
         return self.resource_classes
 
-    def get_resource_kwargs(self, request=None, **kwargs):
+    def get_resource_kwargs(self, **kwargs):
         """
         Return the kwargs which are to be passed to the Resource constructor.
         Can be overridden to provide additional kwarg params.
 
-        :param request: The request object.
-        :param args: Positional arguments.
         :param kwargs: Keyword arguments.
         :returns: The Resource kwargs (by default, is the kwargs passed).
         """
@@ -82,11 +78,11 @@ class BaseImportExportMixin:
 
 
 class BaseImportMixin(BaseImportExportMixin):
-    def get_import_resource_classes(self, request=None, **kwargs):
+    def get_import_resource_classes(self, **kwargs):
         """
         Returns ResourceClass subscriptable (list, tuple, ...) to use for import.
         """
-        resource_classes = self.get_resource_classes(request, **kwargs)
+        resource_classes = self.get_resource_classes(**kwargs)
         self.check_resource_classes(resource_classes)
         return resource_classes
 
@@ -96,18 +92,17 @@ class BaseImportMixin(BaseImportExportMixin):
         """
         return [f for f in self.import_formats if f().can_import()]
 
-    def get_import_resource_kwargs(self, request=None, **kwargs):
+    def get_import_resource_kwargs(self, **kwargs):
         """
         Returns kwargs which will be passed to the Resource constructor.
-        :param request: The request object.
         :param kwargs: Keyword arguments.
         :returns: The kwargs (dict)
         """
-        return self.get_resource_kwargs(request, **kwargs)
+        return self.get_resource_kwargs(**kwargs)
 
-    def choose_import_resource_class(self, request, form):
-        resource_index = self.get_resource_index(form)
-        return self.get_import_resource_classes(request)[resource_index]
+    def choose_import_resource_class(self, **kwargs):
+        resource_index = self.get_resource_index(kwargs["form"])
+        return self.get_import_resource_classes(**kwargs)[resource_index]
 
 
 class BaseExportMixin(BaseImportExportMixin):
@@ -119,14 +114,13 @@ class BaseExportMixin(BaseImportExportMixin):
         """
         return [f for f in self.export_formats if f().can_export()]
 
-    def get_export_resource_classes(self, request=None, **kwargs):
+    def get_export_resource_classes(self, **kwargs):
         """
         Returns ResourceClass subscriptable (list, tuple, ...) to use for export.
-        :param request: The request object.
         :param kwargs: Keyword arguments.
         :returns: The Resource classes.
         """
-        resource_classes = self.get_resource_classes(request=request, **kwargs)
+        resource_classes = self.get_resource_classes(**kwargs)
         self.check_resource_classes(resource_classes)
         return resource_classes
 
@@ -134,14 +128,13 @@ class BaseExportMixin(BaseImportExportMixin):
         resource_index = self.get_resource_index(form)
         return self.get_export_resource_classes()[resource_index]
 
-    def get_export_resource_kwargs(self, request, **kwargs):
+    def get_export_resource_kwargs(self, **kwargs):
         """
         Returns kwargs which will be passed to the Resource constructor.
-        :param request: The request object.
         :param kwargs: Keyword arguments.
         :returns: The kwargs (dict)
         """
-        return self.get_resource_kwargs(request, **kwargs)
+        return self.get_resource_kwargs(**kwargs)
 
     def get_export_resource_fields_from_form(self, form):
         if isinstance(form, SelectableFieldsExportForm):
@@ -151,10 +144,10 @@ class BaseExportMixin(BaseImportExportMixin):
 
         return
 
-    def get_data_for_export(self, request, queryset, **kwargs):
+    def get_data_for_export(self, queryset, **kwargs):
         export_form = kwargs.get("export_form")
         export_class = self.choose_export_resource_class(export_form)
-        export_resource_kwargs = self.get_export_resource_kwargs(request, **kwargs)
+        export_resource_kwargs = self.get_export_resource_kwargs(**kwargs)
         export_fields = self.get_export_resource_fields_from_form(export_form)
         cls = export_class(**export_resource_kwargs)
         export_data = cls.export(
@@ -175,11 +168,11 @@ class BaseExportMixin(BaseImportExportMixin):
 class ExportViewMixin(BaseExportMixin):
     form_class = SelectableFieldsExportForm
 
-    def get_export_data(self, file_format, queryset, *args, **kwargs):
+    def get_export_data(self, file_format, queryset, **kwargs):
         """
         Returns file_format representation for given queryset.
         """
-        data = self.get_data_for_export(self.request, queryset, *args, **kwargs)
+        data = self.get_data_for_export(queryset, **kwargs)
         export_data = file_format.export_data(data)
         return export_data
 

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -78,16 +78,15 @@ class CustomBookAdmin(ImportExportModelAdmin):
             initial["author"] = import_form.cleaned_data["author"].id
         return initial
 
-    def get_import_resource_kwargs(self, **kwargs):
+    def get_import_resource_kwargs(self, request, **kwargs):
         # update resource kwargs so that the Resource is passed the authenticated user
         # This is included as an example of how dynamic values
         # can be passed to resources
-        request = kwargs["request"]
-        kwargs = super().get_resource_kwargs(**kwargs)
+        kwargs = super().get_resource_kwargs(request, **kwargs)
         kwargs.update({"user": request.user})
         return kwargs
 
-    def get_export_resource_kwargs(self, **kwargs):
+    def get_export_resource_kwargs(self, request, **kwargs):
         # this is overridden to demonstrate that custom form fields can be used
         # to override the export query.
         # The dict returned here will be passed as kwargs to EBookResource

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -78,15 +78,16 @@ class CustomBookAdmin(ImportExportModelAdmin):
             initial["author"] = import_form.cleaned_data["author"].id
         return initial
 
-    def get_import_resource_kwargs(self, request, **kwargs):
+    def get_import_resource_kwargs(self, **kwargs):
         # update resource kwargs so that the Resource is passed the authenticated user
         # This is included as an example of how dynamic values
         # can be passed to resources
-        kwargs = super().get_resource_kwargs(request, **kwargs)
+        request = kwargs["request"]
+        kwargs = super().get_resource_kwargs(**kwargs)
         kwargs.update({"user": request.user})
         return kwargs
 
-    def get_export_resource_kwargs(self, request, **kwargs):
+    def get_export_resource_kwargs(self, **kwargs):
         # this is overridden to demonstrate that custom form fields can be used
         # to override the export query.
         # The dict returned here will be passed as kwargs to EBookResource

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -50,7 +50,7 @@ class EBookResource(ModelResource):
         super().__init__()
         self.author_id = kwargs.get("author_id")
 
-    def filter_export(self, queryset, *args, **kwargs):
+    def filter_export(self, queryset, **kwargs):
         return queryset.filter(author_id=self.author_id)
 
     class Meta:

--- a/tests/core/tests/admin_integration/test_action.py
+++ b/tests/core/tests/admin_integration/test_action.py
@@ -130,7 +130,7 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
 
         m = TestMixin()
         with self.assertRaises(PermissionDenied):
-            m.get_export_data("0", Book.objects.none(), request=request)
+            m.get_export_data("0", request, Book.objects.none())
 
 
 class TestExportButtonOnChangeForm(AdminTestMixin, TestCase):

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -343,7 +343,7 @@ class TestExportEncoding(TestCase):
         def __init__(self, test_str=None):
             self.test_str = test_str
 
-        def get_data_for_export(self, queryset, **kwargs):
+        def get_data_for_export(self, request, queryset, **kwargs):
             dataset = Dataset(headers=["id", "name"])
             dataset.append([1, self.test_str])
             return dataset
@@ -361,7 +361,7 @@ class TestExportEncoding(TestCase):
     def test_to_encoding_not_set_default_encoding_is_utf8(self):
         self.export_mixin = self.TestMixin(test_str="teststr")
         data = self.export_mixin.get_export_data(
-            self.file_format, list(), request=self.mock_request
+            self.file_format, self.mock_request, list()
         )
         csv_dataset = tablib.import_set(data)
         self.assertEqual("teststr", csv_dataset.dict[0]["name"])
@@ -369,7 +369,7 @@ class TestExportEncoding(TestCase):
     def test_to_encoding_set(self):
         self.export_mixin = self.TestMixin(test_str="ハローワールド")
         data = self.export_mixin.get_export_data(
-            self.file_format, list(), request=self.mock_request, encoding="shift-jis"
+            self.file_format, self.mock_request, list(), encoding="shift-jis"
         )
         encoding = chardet.detect(bytes(data))["encoding"]
         self.assertEqual("SHIFT_JIS", encoding)
@@ -379,8 +379,8 @@ class TestExportEncoding(TestCase):
         with self.assertRaises(LookupError):
             self.export_mixin.get_export_data(
                 self.file_format,
+                self.mock_request,
                 list(),
-                request=self.mock_request,
                 encoding="bad-encoding",
             )
 
@@ -389,7 +389,9 @@ class TestExportEncoding(TestCase):
         self.export_mixin = self.TestMixin(test_str="teststr")
         self.file_format = formats.base_formats.XLSX()
         data = self.export_mixin.get_export_data(
-            self.file_format, list(), request=self.mock_request
+            self.file_format,
+            self.mock_request,
+            list(),
         )
         binary_dataset = tablib.import_set(data)
         self.assertEqual("teststr", binary_dataset.dict[0]["name"])

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -72,7 +72,7 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(2, mock_get_export_resource_kwargs.call_count)
 
-    def book_resource_init(self):
+    def book_resource_init(self, **kwargs):
         # stub call to the resource constructor
         pass
 
@@ -343,7 +343,7 @@ class TestExportEncoding(TestCase):
         def __init__(self, test_str=None):
             self.test_str = test_str
 
-        def get_data_for_export(self, request, queryset, *args, **kwargs):
+        def get_data_for_export(self, queryset, **kwargs):
             dataset = Dataset(headers=["id", "name"])
             dataset.append([1, self.test_str])
             return dataset

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -487,7 +487,7 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
         target = {"a": 1}
         self.assertEqual(target, m.get_import_data_kwargs(**kw))
 
-    def test_get_import_data_kwargs_with_no_form_kwarg_returns_empty_dict(self):
+    def test_get_import_data_kwargs_with_no_form_kwarg_returns_kwarg_dict(self):
         """
         Test that if the method is called with no 'form' kwarg,
         then an empty dict is returned
@@ -496,7 +496,7 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
         kw = {
             "a": 1,
         }
-        target = {}
+        target = {"a": 1}
         self.assertEqual(target, m.get_import_data_kwargs(**kw))
 
     def test_get_context_data_returns_empty_dict(self):

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -2,7 +2,7 @@ import os
 import warnings
 from io import StringIO
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import django
 from core.admin import AuthorAdmin, BookAdmin, CustomBookAdmin, ImportMixin
@@ -12,7 +12,6 @@ from core.tests.utils import ignore_widget_deprecation_warning
 from django.contrib.admin.models import DELETION, LogEntry
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
-from django.http import HttpRequest
 from django.test import RequestFactory
 from django.test.testcases import TestCase, TransactionTestCase
 from django.test.utils import override_settings
@@ -480,27 +479,25 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
 
     def test_get_import_data_kwargs_with_form_kwarg(self):
         """
-        Test that if a the method is called with a 'form' kwarg,
+        Test that if the method is called with a 'form' kwarg,
         then it is removed and the updated dict is returned
         """
-        request = MagicMock(spec=HttpRequest)
         m = ImportMixin()
         kw = {"a": 1, "form": "some_form"}
         target = {"a": 1}
-        self.assertEqual(target, m.get_import_data_kwargs(request, **kw))
+        self.assertEqual(target, m.get_import_data_kwargs(**kw))
 
     def test_get_import_data_kwargs_with_no_form_kwarg_returns_empty_dict(self):
         """
         Test that if the method is called with no 'form' kwarg,
         then an empty dict is returned
         """
-        request = MagicMock(spec=HttpRequest)
         m = ImportMixin()
         kw = {
             "a": 1,
         }
         target = {}
-        self.assertEqual(target, m.get_import_data_kwargs(request, **kw))
+        self.assertEqual(target, m.get_import_data_kwargs(**kw))
 
     def test_get_context_data_returns_empty_dict(self):
         m = ExportMixin()

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -44,10 +44,10 @@ class BookResourceWithStoreInstance(resources.ModelResource):
 
 
 class BookResourceWithLineNumberLogger(BookResource):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.before_lines = []
         self.after_lines = []
-        return super().__init__(*args, **kwargs)
+        return super().__init__(**kwargs)
 
     def before_import_row(self, row, **kwargs):
         row_number = kwargs.pop("row_number")

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -172,7 +172,7 @@ class MixinModelAdminTest(TestCase):
 
     def test_get_import_resource_kwargs_calls_self_get_resource_kwargs(self):
         admin = self.BaseImportModelAdminTest()
-        admin.get_import_resource_kwargs(self.request)
+        admin.get_import_resource_kwargs(request=self.request)
         self.assertEqual(1, admin.call_count)
 
     def test_get_export_resource_class_calls_self_get_resource_class(self):
@@ -223,18 +223,21 @@ class MixinModelAdminTest(TestCase):
         admin = self.BaseModelImportChooseTest()
         request = MagicMock(spec=HttpRequest)
         self.assertEqual(
-            admin.choose_import_resource_class(request, form), resources.Resource
+            admin.choose_import_resource_class(request=request, form=form),
+            resources.Resource,
         )
 
         form.cleaned_data = {"resource": 1}
-        self.assertEqual(admin.choose_import_resource_class(request, form), FooResource)
+        self.assertEqual(
+            admin.choose_import_resource_class(request=request, form=form), FooResource
+        )
 
 
 class BaseExportMixinTest(TestCase):
     class TestBaseExportMixin(mixins.BaseExportMixin):
-        def get_export_resource_kwargs(self, request, **kwargs):
+        def get_export_resource_kwargs(self, **kwargs):
             self.kwargs = kwargs
-            return super().get_resource_kwargs(request, **kwargs)
+            return super().get_resource_kwargs(**kwargs)
 
     def test_get_data_for_export_sets_kwargs(self):
         """
@@ -244,8 +247,8 @@ class BaseExportMixinTest(TestCase):
         request = MagicMock(spec=HttpRequest)
         m = self.TestBaseExportMixin()
         m.model = Book
-        target_kwargs = {"a": 1}
-        m.get_data_for_export(request, Book.objects.none(), **target_kwargs)
+        target_kwargs = {"a": 1, "request": request}
+        m.get_data_for_export(Book.objects.none(), **target_kwargs)
         self.assertEqual(m.kwargs, target_kwargs)
 
     def test_get_export_formats(self):
@@ -305,6 +308,6 @@ class BaseExportImportMixinTest(TestCase):
         mixin_instance = self.TestMixin()
         test_kwargs = {"key1": "value1", "key2": "value2"}
 
-        result = mixin_instance.get_resource_kwargs(HttpRequest, **test_kwargs)
+        result = mixin_instance.get_resource_kwargs(**test_kwargs)
 
         self.assertEqual(result, test_kwargs)

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -150,19 +150,19 @@ class MixinModelAdminTest(TestCase):
     class BaseImportModelAdminTest(mixins.BaseImportMixin):
         call_count = 0
 
-        def get_resource_classes(self, request=None, **kwargs):
+        def get_resource_classes(self, **kwargs):
             self.call_count += 1
 
-        def get_resource_kwargs(self, request=None, **kwargs):
+        def get_resource_kwargs(self, **kwargs):
             self.call_count += 1
 
     class BaseExportModelAdminTest(mixins.BaseExportMixin):
         call_count = 0
 
-        def get_resource_classes(self, request=None, **kwargs):
+        def get_resource_classes(self, **kwargs):
             self.call_count += 1
 
-        def get_export_resource_kwargs(self, request, **kwargs):
+        def get_export_resource_kwargs(self, **kwargs):
             self.call_count += 1
 
     def test_get_import_resource_class_calls_self_get_resource_class(self):
@@ -182,7 +182,7 @@ class MixinModelAdminTest(TestCase):
 
     def test_get_export_resource_kwargs_calls_self_get_resource_kwargs(self):
         admin = self.BaseExportModelAdminTest()
-        admin.get_export_resource_kwargs(self.request)
+        admin.get_export_resource_kwargs(request=self.request)
         self.assertEqual(1, admin.call_count)
 
     class BaseModelAdminFaultyResourceClassesTest(mixins.BaseExportMixin):
@@ -209,10 +209,12 @@ class MixinModelAdminTest(TestCase):
     def test_choose_export_resource_class(self, form):
         """Test choose_export_resource_class() method"""
         admin = self.BaseModelExportChooseTest()
-        self.assertEqual(admin.choose_export_resource_class(form), resources.Resource)
+        self.assertEqual(
+            admin.choose_export_resource_class(form=form), resources.Resource
+        )
 
         form.cleaned_data = {"resource": 1}
-        self.assertEqual(admin.choose_export_resource_class(form), FooResource)
+        self.assertEqual(admin.choose_export_resource_class(form=form), FooResource)
 
     class BaseModelImportChooseTest(mixins.BaseImportMixin):
         resource_classes = [resources.Resource, FooResource]

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -150,19 +150,19 @@ class MixinModelAdminTest(TestCase):
     class BaseImportModelAdminTest(mixins.BaseImportMixin):
         call_count = 0
 
-        def get_resource_classes(self):
+        def get_resource_classes(self, request=None, **kwargs):
             self.call_count += 1
 
-        def get_resource_kwargs(self, request, *args, **kwargs):
+        def get_resource_kwargs(self, request=None, **kwargs):
             self.call_count += 1
 
     class BaseExportModelAdminTest(mixins.BaseExportMixin):
         call_count = 0
 
-        def get_resource_classes(self):
+        def get_resource_classes(self, request=None, **kwargs):
             self.call_count += 1
 
-        def get_resource_kwargs(self, request, *args, **kwargs):
+        def get_export_resource_kwargs(self, request, **kwargs):
             self.call_count += 1
 
     def test_get_import_resource_class_calls_self_get_resource_class(self):
@@ -221,10 +221,13 @@ class MixinModelAdminTest(TestCase):
     def test_choose_import_resource_class(self, form):
         """Test choose_import_resource_class() method"""
         admin = self.BaseModelImportChooseTest()
-        self.assertEqual(admin.choose_import_resource_class(form), resources.Resource)
+        request = MagicMock(spec=HttpRequest)
+        self.assertEqual(
+            admin.choose_import_resource_class(request, form), resources.Resource
+        )
 
         form.cleaned_data = {"resource": 1}
-        self.assertEqual(admin.choose_import_resource_class(form), FooResource)
+        self.assertEqual(admin.choose_import_resource_class(request, form), FooResource)
 
 
 class BaseExportMixinTest(TestCase):


### PR DESCRIPTION
**Problem**

Closes #1778

- Standardise method args
- Also fixes issue where `get_import_data_kwargs()` did not return the kwargs that were passed.

**Solution**

- Standardise mixin method interface.
- Changes summarised in release_notes.rst