### PR TITLE
Fix regression of `form` not being passed to `get_import_resource_kwargs()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.0-rc.3 (unreleased)
+-----------------------
+
+- fix form not being passed to ``get_import_resource_kwargs()`` (#)
+
 4.0.0-rc.2 (2024-04-08)
 -----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 4.0.0-rc.3 (unreleased)
 -----------------------
 
-- fix form not being passed to ``get_import_resource_kwargs()`` (#)
+- fix form not being passed to ``get_import_resource_kwargs()`` (#1789)
 
 4.0.0-rc.2 (2024-04-08)
 -----------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -186,7 +186,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         request,
         **kwargs,
     ):
-        res_kwargs = self.get_import_resource_kwargs(request, **kwargs)
+        res_kwargs = self.get_import_resource_kwargs(request, form=form, **kwargs)
         resource = self.choose_import_resource_class(form, request)(**res_kwargs)
         imp_kwargs = self.get_import_data_kwargs(request=request, form=form, **kwargs)
         imp_kwargs["retain_instance_in_row_result"] = True

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -82,6 +82,9 @@ class CustomBookAdmin(ImportExportModelAdmin):
         # update resource kwargs so that the Resource is passed the authenticated user
         # This is included as an example of how dynamic values
         # can be passed to resources
+        if "form" not in kwargs:
+            # test for #1789
+            raise ValueError("'form' param was expected in kwargs")
         kwargs = super().get_resource_kwargs(request, **kwargs)
         kwargs.update({"user": request.user})
         return kwargs


### PR DESCRIPTION
**Problem**

- `form` param not passed to `get_import_resource_kwargs()` as it was previously

**Solution**

Passed the param.

**Acceptance Criteria**

Tested manually