### PR TITLE
Added fix for crash when `CharField` subclass is present

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+4.0.1 ()
+-----------------------
+
+- fix Widget crash when django Field subclass is used (#)
+
 4.0.0 (2024-04-27)
 -----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 4.0.1 ()
 -----------------------
 
-- fix Widget crash when django Field subclass is used (#)
+- fix Widget crash when django Field subclass is used (#1805)
 
 4.0.0 (2024-04-27)
 -----------------------

--- a/tests/core/tests/test_model_resource_fields_generate_widgets.py
+++ b/tests/core/tests/test_model_resource_fields_generate_widgets.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 import django
+from core.models import WithPositiveIntegerFields
 from django.contrib.contenttypes import fields as contenttype_fields
 from django.contrib.postgres import fields as postgres
 from django.contrib.postgres import search as postgres_search
@@ -10,8 +11,6 @@ from django.db.models.fields.related import RelatedField
 
 from import_export import widgets
 from import_export.resources import ModelResource
-
-from ..models import WithPositiveIntegerFields
 
 
 class ExampleResource(ModelResource):
@@ -87,7 +86,6 @@ class TestFieldWidgetMapping(TestCase):
             models.GenericIPAddressField,
             models.ImageField,
             models.IPAddressField,
-            models.SlugField,
             models.TextField,
             models.UUIDField,
             postgres.BigIntegerRangeField,
@@ -99,12 +97,6 @@ class TestFieldWidgetMapping(TestCase):
             postgres.IntegerRangeField,
             postgres.RangeField,
         }
-        if django.VERSION < (5, 1):
-            ci_char_fields = {
-                postgres.CICharField,
-                postgres.CIEmailField,
-            }
-            expected_has_default_widget |= ci_char_fields
         return expected_has_default_widget
 
     def _get_expected_not_presented_in_test_field_subclasses(self):

--- a/tests/core/tests/test_resources/test_modelresource/test_widget.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_widget.py
@@ -1,5 +1,5 @@
 from core.tests.resources import BookResource
-from django.db.models import CharField
+from django.db.models import CharField, SlugField
 from django.test import TestCase
 
 from import_export import widgets
@@ -8,6 +8,12 @@ from import_export import widgets
 class WidgetFromDjangoFieldTest(TestCase):
     def test_widget_from_django_field_for_CharField_returns_CharWidget(self):
         f = CharField()
+        resource = BookResource()
+        w = resource.widget_from_django_field(f)
+        self.assertEqual(widgets.CharWidget, w)
+
+    def test_widget_from_django_field_for_CharField_subclass_returns_CharWidget(self):
+        f = SlugField()
         resource = BookResource()
         w = resource.widget_from_django_field(f)
         self.assertEqual(widgets.CharWidget, w)


### PR DESCRIPTION
**Problem**

Closes #1804 

**Solution**

- Added code to search base classes for `Field` to identify if there is a valid widget mapping.

**Acceptance Criteria**

- added tests