### PR TITLE
Support widgets with CSS and JS media in ImportForm

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -151,3 +151,4 @@ The following is a list of much appreciated contributors:
 * RobTilton (Robert Tilton)
 * ulliholtgrave
 * mishka251 (Mikhail Belov)
+* jhthompson (Jeremy Thompson)

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -70,14 +70,22 @@ class ImportForm(ImportExportFormBase):
 
     @property
     def media(self):
+        """Media required to render this form and all widgets within it."""
+        # Media required to render this form.
         extra = "" if settings.DEBUG else ".min"
-        return forms.Media(
+        media = forms.Media(
             js=(
                 f"admin/js/vendor/jquery/jquery{extra}.js",
                 "admin/js/jquery.init.js",
                 "import_export/guess_format.js",
             )
         )
+
+        # All other media required to render the widgets on this form.
+        for field in self.fields.values():
+            media += field.widget.media
+
+        return media
 
 
 class ConfirmImportForm(forms.Form):

--- a/tests/core/tests/test_forms.py
+++ b/tests/core/tests/test_forms.py
@@ -70,11 +70,7 @@ class ImportFormMediaTest(TestCase):
                 widget=TestMediaWidget,
             )
 
-        class ResourceWithWidgetWithMedia(resources.ModelResource):
-            class Meta:
-                model = Author
-
-        form = CustomImportForm([CSV], [ResourceWithWidgetWithMedia])
+        form = CustomImportForm([CSV], [MyResource])
         media = form.media
         self.assertEqual(
             media._css,

--- a/tests/core/tests/test_forms.py
+++ b/tests/core/tests/test_forms.py
@@ -1,4 +1,5 @@
 import django.forms
+from core.models import Author
 from django.test import TestCase
 
 from import_export import forms, resources
@@ -30,6 +31,63 @@ class FormTest(TestCase):
         self.assertEqual(
             form.fields["resource"].choices,
             [(0, "ModelResource"), (1, "My super resource")],
+        )
+
+
+class ImportFormMediaTest(TestCase):
+    def test_import_form_media(self):
+        form = forms.ImportForm([CSV], [MyResource])
+        media = form.media
+        self.assertEqual(
+            media._css,
+            {},
+        )
+        self.assertEqual(
+            media._js,
+            [
+                "admin/js/vendor/jquery/jquery.min.js",
+                "admin/js/jquery.init.js",
+                "import_export/guess_format.js",
+            ],
+        )
+
+    def test_import_form_and_custom_widget_media(self):
+        class TestMediaWidget(django.forms.TextInput):
+            """Dummy test widget with associated CSS and JS media."""
+
+            class Media:
+                css = {
+                    "all": ["test.css"],
+                }
+                js = ["test.js"]
+
+        class CustomImportForm(forms.ImportForm):
+            """Dummy custom import form with a custom widget."""
+
+            author = django.forms.ModelChoiceField(
+                queryset=Author.objects.none(),
+                required=True,
+                widget=TestMediaWidget,
+            )
+
+        class ResourceWithWidgetWithMedia(resources.ModelResource):
+            class Meta:
+                model = Author
+
+        form = CustomImportForm([CSV], [ResourceWithWidgetWithMedia])
+        media = form.media
+        self.assertEqual(
+            media._css,
+            {"all": ["test.css"]},
+        )
+        self.assertEqual(
+            media._js,
+            [
+                "admin/js/vendor/jquery/jquery.min.js",
+                "test.js",
+                "admin/js/jquery.init.js",
+                "import_export/guess_format.js",
+            ],
         )
 
 


### PR DESCRIPTION
Fixes #1809 

I noticed this when trying to use [django-autocomplete-light](https://github.com/yourlabs/django-autocomplete-light) as a widget in a `ModelChoiceField` in a custom `ImportForm`. The autocomplete was fully broken on the import page, and I eventually tracked it down to the required JS files not being included on the page.

**Problem**

- the `ImportForm` class was not including any media from any of the widgets in its fields

**Solution**

- same approach as how [Django handles media for widgets within forms](https://github.com/jhthompson/django/blob/de4884b114534f43c49cf8c5b7f10181e737f4e9/django/forms/forms.py#L381)
  - add any required media from its own fields

**Acceptance Criteria**

Have you written tests? ✅
 Have you included screenshots of your changes if applicable? **N/A**
Did you document your changes? **not sure if any documentation or changelog edits required**