### PR TITLE
Fix regression: allow import when `import_id_fields` is 'id'

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1126,7 +1126,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                 import_id_fields.append(self.fields[field_name])
 
         if missing_fields:
-            raise exceptions.FieldError(
+            logger.debug(
                 _(
                     "The following fields are declared in 'import_id_fields' but "
                     "are not present in the resource fields: %s"
@@ -1141,7 +1141,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                 missing_headers.append(col)
 
         if missing_headers:
-            raise exceptions.FieldError(
+            logger.debug(
                 _(
                     "The following fields are declared in 'import_id_fields' but "
                     "are not present in the file headers: %s"

--- a/tests/core/tests/test_resources/test_import_export.py
+++ b/tests/core/tests/test_resources/test_import_export.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import tablib
 from core.models import Author, Book, Category
-from core.tests.resources import BookResource
+from core.tests.resources import AuthorResource, BookResource
 from django.test import TestCase
 
 from import_export import exceptions, fields, resources, widgets
@@ -364,3 +364,11 @@ class ImportWithMissingFields(TestCase):
             "- column name 'author_email' is not present in row"
         )
         self.assertEqual(2, mock_field_save.call_count)
+
+    def test_import_row_with_no_defined_id_field(self):
+        """Ensure a row with no id field can be imported (issue 1812)."""
+        self.assertEqual(0, Author.objects.count())
+        dataset = tablib.Dataset(*[("J. R. R. Tolkien",)], headers=["name"])
+        self.resource = AuthorResource()
+        self.resource.import_data(dataset)
+        self.assertEqual(1, Author.objects.count())

--- a/tests/core/tests/test_resources/test_modelresource/test_error_handling.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_error_handling.py
@@ -48,7 +48,8 @@ class ErrorHandlingTest(TestCase):
 
     def test_import_data_raises_field_specific_validation_errors(self):
         resource = AuthorResource()
-        dataset = tablib.Dataset(headers=["id", "name", "birthday"])
+        resource._meta.import_id_fields = ["pk"]
+        dataset = tablib.Dataset(headers=["pk", "name", "birthday"])
         dataset.append(["", "A.A.Milne", "1882test-01-18"])
 
         result = resource.import_data(dataset, raise_errors=False)
@@ -61,11 +62,12 @@ class ErrorHandlingTest(TestCase):
         self,
     ):
         resource = AuthorResource()
+        resource._meta.import_id_fields = ["pk"]
         resource._meta.skip_unchanged = True
 
         author = Author.objects.create(name="Some author")
 
-        dataset = tablib.Dataset(headers=["id", "birthday"])
+        dataset = tablib.Dataset(headers=["pk", "birthday"])
         dataset.append([author.id, "1882test-01-18"])
 
         result = resource.import_data(dataset, raise_errors=False)
@@ -76,13 +78,14 @@ class ErrorHandlingTest(TestCase):
 
     def test_import_data_empty_dataset_with_collect_failed_rows(self):
         resource = AuthorResource()
+        resource._meta.import_id_fields = ["pk"]
         with self.assertRaises(exceptions.ImportError) as e:
             resource.import_data(
                 tablib.Dataset(), collect_failed_rows=True, raise_errors=True
             )
         self.assertEqual(
             "The following fields are declared in 'import_id_fields' "
-            "but are not present in the file headers: id",
+            "but are not present in the resource fields: pk",
             str(e.exception),
         )
 


### PR DESCRIPTION
**Problem**

Closes #1812 

**Solution**

Re-added checks from v3 which permit imports when 'id' field is not specified.

**Acceptance Criteria**

- Added test