### PR TITLE
fixed issue with `natural_foreign_keys` and `key_is_id`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.2 (unreleased)
+------------------
+
+- fix clash between ``key_is_id`` and ``use_natural_foreign_keys`` (`1816 <https://github.com/django-import-export/django-import-export/pull/1816>`_)
+
 4.0.1 (2024-05-08)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
-- fix clash between ``key_is_id`` and ``use_natural_foreign_keys`` (`1816 <https://github.com/django-import-export/django-import-export/pull/1816>`_)
+- fix clash between ``key_is_id`` and ``use_natural_foreign_keys`` (`1824 <https://github.com/django-import-export/django-import-export/pull/1824>`_)
 
 4.0.1 (2024-05-08)
 ------------------

--- a/import_export/exceptions.py
+++ b/import_export/exceptions.py
@@ -10,6 +10,12 @@ class FieldError(ImportExportError):
     pass
 
 
+class WidgetError(ImportExportError):
+    """Raised when there is a misconfiguration with a Widget."""
+
+    pass
+
+
 class ImportError(ImportExportError):
     def __init__(self, error, number=None, row=None):
         """A wrapper for errors thrown from the import process.

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1290,7 +1290,11 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         attribute = field_name
         column_name = field_name
         # To solve #974
-        if isinstance(django_field, ForeignKey) and "__" not in column_name:
+        if (
+            isinstance(django_field, ForeignKey)
+            and "__" not in column_name
+            and not cls._meta.use_natural_foreign_keys
+        ):
             attribute += "_id"
             widget_kwargs["key_is_id"] = True
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -14,6 +14,8 @@ from django.utils.encoding import force_str, smart_str
 from django.utils.formats import number_format
 from django.utils.translation import gettext_lazy as _
 
+from import_export.exceptions import WidgetError
+
 logger = logging.getLogger(__name__)
 
 
@@ -497,6 +499,10 @@ class ForeignKeyWidget(Widget):
         self.field = field
         self.key_is_id = key_is_id
         self.use_natural_foreign_keys = use_natural_foreign_keys
+        if use_natural_foreign_keys is True and key_is_id is True:
+            raise WidgetError(
+                _("use_natural_foreign_keys and key_is_id cannot both be True")
+            )
         super().__init__(**kwargs)
 
     def get_queryset(self, value, row, *args, **kwargs):

--- a/tests/core/tests/test_resources/test_natural_foreign_key.py
+++ b/tests/core/tests/test_resources/test_natural_foreign_key.py
@@ -1,0 +1,66 @@
+import tablib
+from core.models import Author, Book
+from django.test import TestCase
+
+from import_export import fields, resources, widgets
+
+
+class BookUsingNaturalKeys(resources.ModelResource):
+    class Meta:
+        model = Book
+        fields = ["name", "author"]
+        use_natural_foreign_keys = True
+
+
+class BookUsingAuthorNaturalKey(resources.ModelResource):
+    class Meta:
+        model = Book
+        fields = ["name", "author"]
+
+    author = fields.Field(
+        attribute="author",
+        column_name="author",
+        widget=widgets.ForeignKeyWidget(
+            Author,
+            use_natural_foreign_keys=True,
+        ),
+    )
+
+
+class TestNaturalKeys(TestCase):
+    """Tests for issue 1816."""
+
+    def setUp(self) -> None:
+        author = Author.objects.create(name="J. R. R. Tolkien")
+        Book.objects.create(author=author, name="The Hobbit")
+        self.expected_dataset = tablib.Dataset(headers=["name", "author"])
+        row = ["The Hobbit", '["J. R. R. Tolkien"]']
+        self.expected_dataset.append(row)
+
+    def test_resource_use_natural_keys(self):
+        """
+        test with ModelResource.Meta.use_natural_foreign_keys=True
+        Reproduces this problem
+        """
+        resource = BookUsingNaturalKeys()
+        exported_dataset = resource.export(Book.objects.all())
+        self.assertDatasetEqual(self.expected_dataset, exported_dataset)
+
+    def test_field_use_natural_keys(self):
+        """
+        test with ModelResource.field.widget.use_natural_foreign_keys=True
+        Example of correct behaviour
+        """
+        resource = BookUsingAuthorNaturalKey()
+        exported_dataset = resource.export(Book.objects.all())
+        self.assertDatasetEqual(self.expected_dataset, exported_dataset)
+
+    def assertDatasetEqual(self, expected_dataset, actual_dataset, message=None):
+        """
+        Util for comparing datasets
+        """
+        self.assertEqual(len(expected_dataset), len(actual_dataset), message)
+        for expected_row, actual_row in zip(
+            expected_dataset, actual_dataset, strict=True
+        ):
+            self.assertEqual(expected_row, actual_row, message)

--- a/tests/core/tests/test_resources/test_natural_foreign_key.py
+++ b/tests/core/tests/test_resources/test_natural_foreign_key.py
@@ -60,7 +60,5 @@ class TestNaturalKeys(TestCase):
         Util for comparing datasets
         """
         self.assertEqual(len(expected_dataset), len(actual_dataset), message)
-        for expected_row, actual_row in zip(
-            expected_dataset, actual_dataset, strict=True
-        ):
+        for expected_row, actual_row in zip(expected_dataset, actual_dataset):
             self.assertEqual(expected_row, actual_row, message)

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -12,6 +12,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 
 from import_export import widgets
+from import_export.exceptions import WidgetError
 
 
 class WidgetTest(TestCase):
@@ -580,6 +581,16 @@ class ForeignKeyWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertEqual(
             self.natural_key_book_widget.render(self.book),
             json.dumps(self.book.natural_key()),
+        )
+
+    def test_natural_foreign_key_with_key_is_id(self):
+        with self.assertRaises(WidgetError) as e:
+            widgets.ForeignKeyWidget(
+                Author, use_natural_foreign_keys=True, key_is_id=True
+            )
+        self.assertEqual(
+            "use_natural_foreign_keys and key_is_id " "cannot both be True",
+            str(e.exception),
         )
 
 


### PR DESCRIPTION
**Problem**

Closes #1816 

`key_is_id` which fixes #974 clashes with `use_natural_foreign_keys`.

**Solution**

Only apply the `key_is_id` widget kwarg is `use_natural_foreign_keys` is False.

**Acceptance Criteria**

Added tests (thanks to @mishka251)