### PR TITLE
fix issue with widget assignment for custom ForeignKey subclasses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.1 (unreleased)
+------------------
+
+- fix issue with widget assignment for custom ``ForeignKey`` subclasses (`<https://github.com/django-import-export/django-import-export/pull/>`_)
+
 4.0.1 (2024-05-08)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- fix issue with widget assignment for custom ``ForeignKey`` subclasses (`<https://github.com/django-import-export/django-import-export/pull/>`_)
+- fix issue with widget assignment for custom ``ForeignKey`` subclasses (`1826 <https://github.com/django-import-export/django-import-export/pull/1826>`_)
 
 4.0.1 (2024-05-08)
 ------------------

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1248,6 +1248,8 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
             for base_class in inspect.getmro(f.__class__):
                 if base_class.__name__ in cls.WIDGETS_MAP:
                     result = cls.WIDGETS_MAP[base_class.__name__]
+                    if isinstance(result, str):
+                        result = getattr(cls, result)(f)
                     break
 
             try:


### PR DESCRIPTION
**Problem**

Closes #1817 

If a project contains a custom FK field implementation, then this can crash on startup.

**Solution**

Added a missing code block to call the `get_fk_widget()` method.

**Acceptance Criteria**

- Added test