### PR TITLE
Added overridable method to restrict pks when exporting

### DIFF
--- a/docs/admin_integration.rst
+++ b/docs/admin_integration.rst
@@ -200,7 +200,12 @@ this to refer to your own model instances.  In the example application, the 'Cat
 
 When 'Go' is clicked for the selected items, the user will be directed to the
 :ref:`export 'confirm' page<export_confirm>`.  It is possible to disable this extra step by setting the
-:ref:`import_export_skip_admin_action_export_ui` flag
+:ref:`import_export_skip_admin_action_export_ui` flag.
+
+.. note::
+
+    If deploying to a multi-tenant environment, you may need to use the to ensure that one set of users cannot export
+    data belonging to another set.  See :meth:`~import_export.admin.ExportMixin.get_valid_export_item_pks`.
 
 Export from model instance change form
 --------------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
-- performance: select of valid pks for export restricted to action exports (`1802 <https://github.com/django-import-export/django-import-export/pull/1802>`_)
+- performance: select of valid pks for export restricted to action exports (`1827 <https://github.com/django-import-export/django-import-export/pull/1827>`_)
 
 4.0.1 (2024-05-08)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.2 (unreleased)
+------------------
+
+- performance: select of valid pks for export restricted to action exports (`1802 <https://github.com/django-import-export/django-import-export/pull/1802>`_)
+
 4.0.1 (2024-05-08)
 ------------------
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -730,11 +730,14 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             self.get_export_resource_classes(request),
             data=request.POST or None,
         )
-        form.fields["export_items"] = MultipleChoiceField(
-            widget=MultipleHiddenInput,
-            required=False,
-            choices=[(pk, pk) for pk in self.get_valid_export_item_pks(request)],
-        )
+        if request.POST and "export_items" in request.POST:
+            # this field is instantiated if the export is POSTed from the
+            # 'action' drop down
+            form.fields["export_items"] = MultipleChoiceField(
+                widget=MultipleHiddenInput,
+                required=False,
+                choices=[(pk, pk) for pk in self.get_valid_export_item_pks(request)],
+            )
         if form.is_valid():
             file_format = formats[int(form.cleaned_data["format"])]()
 
@@ -772,6 +775,15 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
         return TemplateResponse(request, [self.export_template_name], context=context)
 
     def get_valid_export_item_pks(self, request):
+        """
+        Returns a list of valid pks for export.
+        This is used to validate which objects can be exported when exports are
+        triggered from the Admin UI 'action' dropdown.
+        This can be overridden to filter returned pks for performance and/or security
+        reasons.
+        :param request: The request object.
+        :returns: a list of valid pks (by default is all pks in table).
+        """
         return self.model.objects.all().values_list("pk", flat=True)
 
     def changelist_view(self, request, extra_context=None):
@@ -847,6 +859,7 @@ class ExportActionMixin(ExportMixin):
         )
 
     def response_change(self, request, obj):
+        # called if the export is triggered from the instance detail page.
         if "_export-item" in request.POST:
             return self.export_admin_action(
                 request, self.model.objects.filter(id=obj.id)

--- a/import_export/templates/admin/import_export/export.html
+++ b/import_export/templates/admin/import_export/export.html
@@ -13,6 +13,9 @@
 {% endblock %}
 
 {% block content %}
+{% if form.errors %}
+  {{ form.errors }}
+{% endif %}
 <form action="{{ export_url }}" method="POST">
   {% csrf_token %}
     {# export request has originated from an Admin UI action #}

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -5,6 +5,7 @@ from import_export.admin import (
     ImportExportModelAdmin,
     ImportMixin,
 )
+from import_export.fields import Field
 from import_export.resources import ModelResource
 
 from .forms import CustomConfirmImportForm, CustomExportForm, CustomImportForm
@@ -50,6 +51,8 @@ class AuthorAdmin(ImportMixin, admin.ModelAdmin):
 
 
 class EBookResource(ModelResource):
+    published = Field(attribute="published", column_name="published_date")
+
     def __init__(self, **kwargs):
         super().__init__()
         self.author_id = kwargs.get("author_id")
@@ -59,11 +62,7 @@ class EBookResource(ModelResource):
 
     class Meta:
         model = EBook
-        fields = (
-            "id",
-            "author_email",
-            "name",
-        )
+        fields = ("id", "author_email", "name", "published")
 
 
 class CustomBookAdmin(ImportExportModelAdmin):
@@ -97,10 +96,10 @@ class CustomBookAdmin(ImportExportModelAdmin):
         # this is overridden to demonstrate that custom form fields can be used
         # to override the export query.
         # The dict returned here will be passed as kwargs to EBookResource
-        export_form = kwargs["export_form"]
+        export_form = kwargs.get("export_form")
         if export_form:
-            return dict(author_id=export_form.cleaned_data["author"].id)
-        return {}
+            kwargs.update(author_id=export_form.cleaned_data["author"].id)
+        return kwargs
 
 
 admin.site.register(Book, BookAdmin)

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -5,7 +5,6 @@ from import_export.admin import (
     ImportExportModelAdmin,
     ImportMixin,
 )
-from import_export.fields import Field
 from import_export.resources import ModelResource
 
 from .forms import CustomConfirmImportForm, CustomExportForm, CustomImportForm
@@ -51,8 +50,6 @@ class AuthorAdmin(ImportMixin, admin.ModelAdmin):
 
 
 class EBookResource(ModelResource):
-    published = Field(attribute="published", column_name="published_date")
-
     def __init__(self, **kwargs):
         super().__init__()
         self.author_id = kwargs.get("author_id")
@@ -62,7 +59,11 @@ class EBookResource(ModelResource):
 
     class Meta:
         model = EBook
-        fields = ("id", "author_email", "name", "published")
+        fields = (
+            "id",
+            "author_email",
+            "name",
+        )
 
 
 class CustomBookAdmin(ImportExportModelAdmin):
@@ -96,10 +97,10 @@ class CustomBookAdmin(ImportExportModelAdmin):
         # this is overridden to demonstrate that custom form fields can be used
         # to override the export query.
         # The dict returned here will be passed as kwargs to EBookResource
-        export_form = kwargs.get("export_form")
+        export_form = kwargs["export_form"]
         if export_form:
-            kwargs.update(author_id=export_form.cleaned_data["author"].id)
-        return kwargs
+            return dict(author_id=export_form.cleaned_data["author"].id)
+        return {}
 
 
 admin.site.register(Book, BookAdmin)

--- a/tests/core/tests/admin_integration/test_action_export.py
+++ b/tests/core/tests/admin_integration/test_action_export.py
@@ -128,6 +128,25 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
             self.assertTrue(200 <= response.status_code <= 399)
             mock_export_admin_action.assert_called()
 
+    def test_export_admin_action_with_restricted_pks(self):
+        data = {
+            "format": "0",
+            "export_items": [str(self.cat1.id)],
+            **self.resource_fields_payload,
+        }
+        # mock returning a set of pks which is not in the submitted range
+        with mock.patch(
+            "import_export.admin.ExportMixin.get_valid_export_item_pks"
+        ) as mock_valid_pks:
+            mock_valid_pks.return_value = [999]
+            response = self.client.post(self.category_export_url, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(
+                "Select a valid choice. "
+                f"{self.cat1.id} is not one of the available choices.",
+                str(response.content),
+            )
+
     def test_get_export_data_raises_PermissionDenied_when_no_export_permission_assigned(
         self,
     ):

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -327,8 +327,8 @@ class FilteredExportAdminIntegrationTest(AdminTestMixin, TestCase):
             'attachment; filename="EBook-{}.csv"'.format(date_str),
         )
         self.assertEqual(
-            b"id,author_email,name\r\n"
-            b"5,ian@example.com,The Man with the Golden Gun\r\n",
+            b"id,author_email,name,published_date\r\n"
+            b"5,ian@example.com,The Man with the Golden Gun,1965-04-01\r\n",
             response.content,
         )
 

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -45,7 +45,7 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
         data = {"format": "0", **self.bookresource_export_fields_payload}
         date_str = datetime.now().strftime("%Y-%m-%d")
         # Should not contain COUNT queries from ModelAdmin.get_results()
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.post(self.book_export_url, data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.has_header("Content-Disposition"))
@@ -327,8 +327,8 @@ class FilteredExportAdminIntegrationTest(AdminTestMixin, TestCase):
             'attachment; filename="EBook-{}.csv"'.format(date_str),
         )
         self.assertEqual(
-            b"id,author_email,name,published_date\r\n"
-            b"5,ian@example.com,The Man with the Golden Gun,1965-04-01\r\n",
+            b"id,author_email,name\r\n"
+            b"5,ian@example.com,The Man with the Golden Gun\r\n",
             response.content,
         )
 


### PR DESCRIPTION
**Problem**

Closes #1806 

A 'SELECT * FROM table' was executed on every export.  Refactored to perform this only when necessary

**Solution**

- Restrict select of valid items only to cases of export from ['action' menu](https://django-import-export.readthedocs.io/en/latest/admin_integration.html#exporting-via-admin-action).
- Return only 'pk' field
- Provide overrideable method

**Acceptance Criteria**

- Added tests