### PR TITLE
removed outdated formatting of date strings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Changelog
 - fix issue with widget assignment for custom ``ForeignKey`` subclasses (`1826 <https://github.com/django-import-export/django-import-export/pull/1826>`_)
 - performance: select of valid pks for export restricted to action exports (`1827 <https://github.com/django-import-export/django-import-export/pull/1827>`_)
 - fix crash on export with custom column name (`1828 <https://github.com/django-import-export/django-import-export/pull/1828>`_)
-- remove outdated datetime formatting logic (`1828 <https://github.com/django-import-export/django-import-export/pull/1828>`_)
+- remove outdated datetime formatting logic (`1830 <https://github.com/django-import-export/django-import-export/pull/1830>`_)
 
 4.0.1 (2024-05-08)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
 - fix issue with widget assignment for custom ``ForeignKey`` subclasses (`1826 <https://github.com/django-import-export/django-import-export/pull/1826>`_)
 - performance: select of valid pks for export restricted to action exports (`1827 <https://github.com/django-import-export/django-import-export/pull/1827>`_)
 - fix crash on export with custom column name (`1828 <https://github.com/django-import-export/django-import-export/pull/1828>`_)
+- remove outdated datetime formatting logic (`1828 <https://github.com/django-import-export/django-import-export/pull/1828>`_)
 
 4.0.1 (2024-05-08)
 ------------------

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -20,13 +20,10 @@ logger = logging.getLogger(__name__)
 
 
 def format_datetime(value, datetime_format):
-    # conditional logic to handle correct formatting of dates
+    # handle correct formatting of dates
     # see https://code.djangoproject.com/ticket/32738
-    if django.VERSION[0] >= 4:
-        format = django.utils.formats.sanitize_strftime_format(datetime_format)
-        return value.strftime(format)
-    else:
-        return django.utils.datetime_safe.new_datetime(value).strftime(datetime_format)
+    format_ = django.utils.formats.sanitize_strftime_format(datetime_format)
+    return value.strftime(format_)
 
 
 class Widget:


### PR DESCRIPTION
**Problem**

widget module no longer needs to check for code pre django 3.* as it is now no longer supported.

**Solution**

- Removed outdated logic

**Acceptance Criteria**

- Test suite