### PR TITLE
re-add `resource_class` deprecation warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean-pyc clean-build docs help
 .PHONY: lint test coverage test-codecov
 .DEFAULT_GOAL := help
-RUN_TEST_COMMAND=PYTHONPATH=".:tests:${PYTHONPATH}" django-admin test core --settings=settings
+RUN_TEST_COMMAND=PYTHONPATH=".:tests:${PYTHONPATH}" python -W error -m django test core --settings=settings
 help:
 	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | sort | awk -F ':.*?## ' 'NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 4.0.3 (unreleased)
 ------------------
 
-- re-add ``resource_class`` deprecation warning (`1821 <https://github.com/django-import-export/django-import-export/pull/1821>`_)
+- re-add ``resource_class`` deprecation warning (`1837 <https://github.com/django-import-export/django-import-export/pull/1837>`_)
 
 4.0.2 (2024-05-13)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.3 (unreleased)
+------------------
+
+- re-add ``resource_class`` deprecation warning (`1821 <https://github.com/django-import-export/django-import-export/pull/1821>`_)
+
 4.0.2 (2024-05-13)
 ------------------
 


### PR DESCRIPTION
**Problem**

Closes #1823 

Re-added the deprecation warnings from v3.

Now if you declare:

```python
class BookAdmin(ImportExportModelAdmin):
    list_display = ("name", "author", "added")
    list_filter = ["categories", "author"]
    resource_class = BookResource
    change_list_template = "core/admin/change_list.html"
```

You will see the following warning if you enable deprecation warnings, and browse to the import or export page in the UI:

```
python -X dev ./manage.py runserver

 DeprecationWarning: The 'resource_class' field has been deprecated. Please implement the new 'resource_classes' field
```

**Acceptance Criteria**

- Re-added tests