### PR TITLE
Fix crash on export from action when instance has custom PK

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.6 (unreleased)
+------------------
+
+- fix crash on export from action when instance has custom PK (`1854 <https://github.com/django-import-export/django-import-export/pull/1854>`_)
+
 4.0.5 (2024-05-23)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
-4.0.6 (unreleased)
+4.0.6 (2024-05-24)
 ------------------
 
 - fix crash on export from action when instance has custom PK (`1854 <https://github.com/django-import-export/django-import-export/pull/1854>`_)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -853,7 +853,7 @@ class ExportActionMixin(ExportMixin):
         # called if the export is triggered from the instance detail page.
         if "_export-item" in request.POST:
             return self.export_admin_action(
-                request, self.model.objects.filter(id=obj.id)
+                request, self.model.objects.filter(pk=obj.pk)
             )
         return super().response_change(request, obj)
 

--- a/tests/core/tests/admin_integration/test_action_export.py
+++ b/tests/core/tests/admin_integration/test_action_export.py
@@ -192,6 +192,27 @@ class TestExportButtonOnChangeForm(AdminTestMixin, TestCase):
         )
         self.assertIn("Export 1 selected item", str(response.content))
 
+    def test_export_button_on_change_form_for_custom_pk(self):
+        self.cat1 = UUIDCategory.objects.create(name="Cat 1")
+        self.change_url = reverse(
+            "%s:%s_%s_change"
+            % (
+                "admin",
+                "core",
+                "uuidcategory",
+            ),
+            args=[self.cat1.pk],
+        )
+        response = self.client.get(self.change_url)
+        self.assertIn(
+            self.target_str,
+            str(response.content),
+        )
+        response = self.client.post(
+            self.change_url, data={"_export-item": "Export", "name": self.cat1.name}
+        )
+        self.assertIn("Export 1 selected item", str(response.content))
+
     def test_save_button_on_change_form(self):
         # test default behavior is retained when saving an instance ChangeForm
         response = self.client.post(


### PR DESCRIPTION
**Problem**

If an model has a custom pk (e.g. `UUIDCategory`) then an export via the instance page would cause a crash.

**Solution**

replaced reference to `obj.id` with `obj.pk`

**Acceptance Criteria**

- Added test