### PR TITLE
fix 1846 and add tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.7 (unreleased)
+------------------
+
+- Fix for #1846 - exporting fields with changed column_name doesn't work in v4
+
 4.0.6 (2024-05-27)
 ------------------
 

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1064,29 +1064,26 @@ class Resource(metaclass=DeclarativeMetaclass):
                     continue
         return export_fields
 
-    def export_resource(self, instance, fields=None):
+    def get_enabled_export_fields(self, fields):
         export_fields = self.get_export_fields()
 
         if isinstance(fields, list) and fields:
             return [
-                self.export_field(field, instance)
+                field
                 for field in export_fields
-                if field.attribute in fields or field.column_name in fields or
-                field.original_name in fields
+                if field.attribute in fields
+                or field.column_name in fields
+                or field.original_name in fields
             ]
 
+        return export_fields
+
+    def export_resource(self, instance, fields=None):
+        export_fields = self.get_enabled_export_fields(fields)
         return [self.export_field(field, instance) for field in export_fields]
 
     def get_export_headers(self, fields=None):
-        export_fields = self.get_export_fields()
-        if isinstance(fields, list) and fields:
-            return [
-                f.column_name
-                for f in export_fields
-                if f.attribute in fields or f.column_name in fields or
-                f.original_name in fields
-            ]
-
+        export_fields = self.get_enabled_export_fields(fields)
         return [force_str(field.column_name) for field in export_fields]
 
     def get_user_visible_fields(self):

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1051,12 +1051,15 @@ class Resource(metaclass=DeclarativeMetaclass):
         export_fields = []
         for field_name in self.get_export_order():
             if field_name in self.fields:
-                export_fields.append(self.fields[field_name])
+                field = self.fields[field_name]
+                field.original_name = field_name
+                export_fields.append(field)
                 continue
             # issue 1828
             # allow for fields to be referenced by column_name in `fields` list
             for field in self.fields.values():
                 if field.column_name == field_name:
+                    field.original_name = field_name
                     export_fields.append(field)
                     continue
         return export_fields
@@ -1068,7 +1071,8 @@ class Resource(metaclass=DeclarativeMetaclass):
             return [
                 self.export_field(field, instance)
                 for field in export_fields
-                if field.attribute in fields or field.column_name in fields
+                if field.attribute in fields or field.column_name in fields or
+                field.original_name in fields
             ]
 
         return [self.export_field(field, instance) for field in export_fields]
@@ -1079,7 +1083,8 @@ class Resource(metaclass=DeclarativeMetaclass):
             return [
                 f.column_name
                 for f in export_fields
-                if f.attribute in fields or f.column_name in fields
+                if f.attribute in fields or f.column_name in fields or
+                f.original_name in fields
             ]
 
         return [force_str(field.column_name) for field in export_fields]

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -61,6 +61,7 @@ class UUIDBookResource(ModelResource):
 
 class EBookResource(ModelResource):
     published = Field(attribute="published", column_name="published_date")
+    author_email = Field(attribute="author_email", column_name="Email of the author")
 
     def __init__(self, **kwargs):
         super().__init__()

--- a/tests/core/exports/ebooks.csv
+++ b/tests/core/exports/ebooks.csv
@@ -1,0 +1,2 @@
+id,name,Email of the author
+1,Some book,test@example.com

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -329,7 +329,9 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
             response["Content-Disposition"],
             'attachment; filename="EBook-{}.csv"'.format(date_str),
         )
-        self.assertEqual(b"id,author_email,name,published_date\r\n", response.content)
+        self.assertEqual(
+            b"id,Email of the author,name,published_date\r\n", response.content
+        )
 
 
 class FilteredExportAdminIntegrationTest(AdminTestMixin, TestCase):
@@ -357,7 +359,7 @@ class FilteredExportAdminIntegrationTest(AdminTestMixin, TestCase):
             'attachment; filename="EBook-{}.csv"'.format(date_str),
         )
         self.assertEqual(
-            b"id,author_email,name,published_date\r\n"
+            b"id,Email of the author,name,published_date\r\n"
             b"5,ian@example.com,The Man with the Golden Gun,1965-04-01\r\n",
             response.content,
         )
@@ -502,7 +504,7 @@ class CustomColumnNameExportTest(AdminTestMixin, TestCase):
             'attachment; filename="EBook-{}.csv"'.format(date_str),
         )
         s = (
-            "id,author_email,name,published_date\r\n"
+            "id,Email of the author,name,published_date\r\n"
             f"{book.id},,Moonraker,1955-04-05\r\n"
         )
         self.assertEqual(str.encode(s), response.content)

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -932,7 +932,7 @@ class ConfirmImportPreviewOrderTest(AdminTestMixin, TestCase):
         author_id = Author.objects.first().id
         response = self._do_import_post(
             self.ebook_import_url,
-            "books.csv",
+            "ebooks.csv",
             input_format="0",
             data={"author": author_id},
         )
@@ -942,7 +942,7 @@ class ConfirmImportPreviewOrderTest(AdminTestMixin, TestCase):
             r"<tr>[\\n\s]+"
             r"<th></th>[\\n\s]+"
             r"<th>id</th>[\\n\s]+"
-            r"<th>author_email</th>[\\n\s]+"
+            r"<th>Email of the author</th>[\\n\s]+"
             r"<th>name</th>[\\n\s]+"
             r"<th>published_date</th>[\\n\s]+"
             r"</tr>[\\n\s]+"
@@ -979,7 +979,7 @@ class CustomColumnNameImportTest(AdminTestMixin, TestCase):
         author_id = Author.objects.first().id
         response = self._do_import_post(
             self.ebook_import_url,
-            "books.csv",
+            "ebooks.csv",
             input_format="0",
             data={"author": author_id},
         )
@@ -989,7 +989,7 @@ class CustomColumnNameImportTest(AdminTestMixin, TestCase):
             r"<tr>[\\n\s]+"
             r"<th></th>[\\n\s]+"
             r"<th>id</th>[\\n\s]+"
-            r"<th>author_email</th>[\\n\s]+"
+            r"<th>Email of the author</th>[\\n\s]+"
             r"<th>name</th>[\\n\s]+"
             r"<th>published_date</th>[\\n\s]+"
             r"</tr>[\\n\s]+"
@@ -1021,7 +1021,7 @@ class DefaultFieldsImportOrderTest(AdminTestMixin, TestCase):
         # test display rendered in correct order
         target_re = (
             r"This importer will import the following fields:[\\n\s]+"
-            r"<code>id, author_email, name, published_date</code>[\\n\s]+"
+            r"<code>id, Email of the author, name, published_date</code>[\\n\s]+"
         )
         self.assertRegex(str(response.content), target_re)
 
@@ -1046,6 +1046,6 @@ class DeclaredImportOrderTest(AdminTestMixin, TestCase):
         # test display rendered in correct order
         target_re = (
             r"This importer will import the following fields:[\\n\s]+"
-            r"<code>id, name, published_date, author_email</code>[\\n\s]+"
+            r"<code>id, name, published_date, Email of the author</code>[\\n\s]+"
         )
         self.assertRegex(str(response.content), target_re)


### PR DESCRIPTION
**Problem**

Issue #1846 
The fields in `SelectableFieldsExportForm` are identified by their name (as defined in `ModelResource`, but they are selected by `column_name` in `Resource.get_export_headers()/export_resource()`.

**Solution**

I changed output of `Resource.get_export_fields()` to dict containing `field_name` and added matching also by that identifier.

**Acceptance Criteria**

I have written new test for the issue #1846 and also changed `EBookResource` to contain field with custom `column_name` which would result into the field missing in `tests/admin_integration/test_export.py` tests if the problem was not fixed.

I an not sure if changing output of `Resource.get_export_fields()` would not result in backward incompatibility, so I am leaving this as a draft for further discussion.