### PR TITLE
Export from admin: display both field name and column_name (if available)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 4.0.7 (unreleased)
 ------------------
 
-- Export from admin: display both field name and column_name (if available)
+- Admin UI: display both field name and column_name on export (`1857 <https://github.com/django-import-export/django-import-export/pull/1857>`_)
 
 4.0.6 (2024-05-27)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.7 (unreleased)
+------------------
+
+- Export from admin: display both field name and column_name (if available)
+
 4.0.6 (2024-05-27)
 ------------------
 

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -134,6 +134,13 @@ class SelectableFieldsExportForm(ExportForm):
         ]
         self.order_fields(ordered_fields)
 
+    def _get_field_label(self, resource: ModelResource, field_name: str) -> str:
+        title = field_name.replace("_", " ").title()
+        field = resource.fields.get(field_name)
+        if field and field.column_name != field_name:
+            title = f"{title} ({field.column_name})"
+        return title
+
     def _create_boolean_fields(self, resource: ModelResource, index: int) -> None:
         # Initiate resource to get ordered export fields
         fields = resource().get_export_order()
@@ -143,7 +150,7 @@ class SelectableFieldsExportForm(ExportForm):
         for field in fields:
             field_name = self.create_boolean_field_name(resource, field)
             boolean_field = forms.BooleanField(
-                label=field.replace("_", " ").title(),
+                label=self._get_field_label(resource, field),
                 initial=True,
                 required=False,
             )

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -317,7 +317,7 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertContains(
             response,
             '<label for="id_ebookresource_published">'
-            'Published (published_date):</label>',
+            "Published (published_date):</label>",
             html=True,
         )
         self.assertContains(

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -308,6 +308,25 @@ class ExportAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "UUIDCategoryResource")
 
+    def test_export_get(self):
+        """
+        Test export view get method.
+        Test that field checkboxes are displayied with names as discussed under #1846
+        """
+        response = self.client.get(self.ebook_export_url)
+        self.assertContains(
+            response,
+            '<label for="id_ebookresource_published">'
+            'Published (published_date):</label>',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            '<input type="checkbox" name="ebookresource_published" resource-id="0" '
+            'id="id_ebookresource_published" checked="">',
+            html=True,
+        )
+
     def test_export_with_custom_field(self):
         # issue 1808
         a = Author.objects.create(id=11, name="Ian Fleming")

--- a/tests/core/tests/test_forms.py
+++ b/tests/core/tests/test_forms.py
@@ -180,6 +180,21 @@ class SelectableFieldsExportFormTest(TestCase):
             django.forms.ValidationError, self.form.get_selected_resource_export_fields
         )
 
+    def test_get_field_label(self):
+        """ test SelectableFieldsExportForm._get_field_label """
+        form = forms.SelectableFieldsExportForm(
+            formats=(CSV,), resources=(BookResource,)
+        )
+        resource = BookResource()
+        self.assertEqual(
+            form._get_field_label(resource, "bookresource_id"),
+            "Bookresource Id",
+        )
+        self.assertEqual(
+            form._get_field_label(resource, "published"),
+            "Published (published_date)"
+        )
+
     def test_get_selected_resrource_fields(self) -> None:
         data = {"resource": "0", "format": "0"}
         form = forms.SelectableFieldsExportForm(

--- a/tests/core/tests/test_forms.py
+++ b/tests/core/tests/test_forms.py
@@ -181,7 +181,7 @@ class SelectableFieldsExportFormTest(TestCase):
         )
 
     def test_get_field_label(self):
-        """ test SelectableFieldsExportForm._get_field_label """
+        """test SelectableFieldsExportForm._get_field_label"""
         form = forms.SelectableFieldsExportForm(
             formats=(CSV,), resources=(BookResource,)
         )
@@ -191,8 +191,7 @@ class SelectableFieldsExportFormTest(TestCase):
             "Bookresource Id",
         )
         self.assertEqual(
-            form._get_field_label(resource, "published"),
-            "Published (published_date)"
+            form._get_field_label(resource, "published"), "Published (published_date)"
         )
 
     def test_get_selected_resrource_fields(self) -> None:


### PR DESCRIPTION
**Problem**

See @matthewhegarty under #1846 

**Solution**

I added both filed name and column name into the output:
![Snímek obrazovky_2024-05-28_15-35-57](https://github.com/django-import-export/django-import-export/assets/156755/ef0c4d58-7d26-4ed0-94e4-8a90b7805c44)

**Acceptance Criteria**

I didn't wrote any tests, but I can if they would help.