### PR TITLE
Revert setting `attribute` for declared fields with no attribute declared

### DIFF
--- a/docs/admin_integration.rst
+++ b/docs/admin_integration.rst
@@ -338,6 +338,8 @@ The parameters can then be read from ``Resource`` methods, such as:
     :doc:`/api_admin`
         available mixins and options.
 
+.. _customize_admin_export_forms:
+
 Customize admin export forms
 ----------------------------
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -109,7 +109,9 @@ column name (i.e. row header)::
         class Meta:
             model = Book
 
-The ``attribute`` parameter is optional and if not supplied then the field will be skipped during import.
+The ``attribute`` parameter is optional and if not supplied then the field will be skipped during import and export.
+It is possible to enable export for the field by declaring a :ref:`dehydrate<advanced_data_manipulation_on_export>`
+method.
 
 .. seealso::
 
@@ -489,7 +491,7 @@ Then if the import was being called from another module, we would pass the ``pub
     >>> resource = BookResource(publisher_id=1)
 
 If you need to pass dynamic values to the Resource from an `Admin integration`_, refer to
-:ref:`advanced_usage:How to dynamically set resource values`.
+See :ref:`dynamically_set_resource_values`.
 
 Django Natural Keys
 -------------------
@@ -718,7 +720,7 @@ You can define your resource to take the associated instance as a param, and the
         class Meta:
             model = Book
 
-See also :ref:`advanced_usage:How to dynamically set resource values`.
+See :ref:`dynamically_set_resource_values`.
 
 .. _advanced_data_manipulation_on_export:
 
@@ -758,7 +760,7 @@ Filtering querysets during export
 =================================
 
 You can use :meth:`~import_export.resources.Resource.filter_export` to filter querysets
-during export.  See also `Customize admin export forms`_.
+during export.  See also :ref:`customize_admin_export_forms`.
 
 Signals
 =======

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -109,8 +109,7 @@ column name (i.e. row header)::
         class Meta:
             model = Book
 
-The ``attribute`` kwarg is optional and if it is not declared, the value is taken to be the name of the field
-(e.g. 'published').
+The ``attribute`` parameter is optional and if not supplied then the field will be skipped during import.
 
 .. seealso::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,13 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
-4.0.8 (unreleased)
+4.0.9 (2024-06-18)
+------------------
+
+- fix default ``Field`` returns empty string instead of *'None'*  (`1872 <https://github.com/django-import-export/django-import-export/pull/1872>`_)
+- revert setting default value for ``attribute`` (`1875 <https://github.com/django-import-export/django-import-export/pull/1875>`_)
+
+4.0.8 (2024-06-13)
 ------------------
 
 - docs: clarify widget configuration (`1865 <https://github.com/django-import-export/django-import-export/pull/1865>`_)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -87,7 +87,6 @@ Your signal receiver can then include conditional logic to handle this flag::
 Further discussion `here <https://github.com/django-import-export/django-import-export/issues/1078/>`_
 and `here <https://stackoverflow.com/a/71625152/39296/>`_.
 
-
 How to dynamically set resource values
 --------------------------------------
 

--- a/import_export/declarative.py
+++ b/import_export/declarative.py
@@ -51,8 +51,6 @@ class DeclarativeMetaclass(type):
                 field = attrs.pop(field_name)
                 if not field.column_name:
                     field.column_name = field_name
-                # if not field.attribute:
-                #     field.attribute = field_name
                 declared_fields.append((field_name, field))
 
         attrs["fields"] = OrderedDict(declared_fields)

--- a/import_export/declarative.py
+++ b/import_export/declarative.py
@@ -51,8 +51,8 @@ class DeclarativeMetaclass(type):
                 field = attrs.pop(field_name)
                 if not field.column_name:
                     field.column_name = field_name
-                if not field.attribute:
-                    field.attribute = field_name
+                # if not field.attribute:
+                #     field.attribute = field_name
                 declared_fields.append((field_name, field))
 
         attrs["fields"] = OrderedDict(declared_fields)

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -100,7 +100,7 @@ class Field:
         Returns the value of the instance's attribute.
         """
         if self.attribute is None:
-            raise AttributeError("Field attribute cannot be null")
+            return None
 
         attrs = self.attribute.split("__")
         value = instance

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -419,6 +419,9 @@ class Resource(metaclass=DeclarativeMetaclass):
         :param \**kwargs:
             See :meth:`import_row`
         """
+        if not field.attribute:
+            logger.debug(f"skipping field '{field}' - field attribute is not defined")
+            return
         if field.column_name not in row:
             logger.debug(
                 f"skipping field '{field}' "

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -95,7 +95,7 @@ class Widget:
         :return: By default, this value will be a string, with ``None`` values returned
           as empty strings.
         """
-        return force_str(value)
+        return force_str(value) if value is not None else ""
 
     def _obj_deprecation_warning(self, obj):
         if obj is not None:

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -971,7 +971,7 @@ class ConfirmImportPreviewOrderTest(AdminTestMixin, TestCase):
             r'<td><ins style="background:#e6ffe6;">1</ins></td>[\\n\s]+'
             r'<td><ins style="background:#e6ffe6;">test@example.com</ins></td>[\\n\s]+'
             r'<td><ins style="background:#e6ffe6;">Some book</ins></td>[\\n\s]+'
-            r"<td><span>None</span></td>[\\n\s]+"
+            r"<td></td>[\\n\s]+"
             "</tr>"
         )
         self.assertRegex(str(response.content), target_row_re)
@@ -1018,7 +1018,7 @@ class CustomColumnNameImportTest(AdminTestMixin, TestCase):
             r'<td><ins style="background:#e6ffe6;">1</ins></td>[\\n\s]+'
             r'<td><ins style="background:#e6ffe6;">test@example.com</ins></td>[\\n\s]+'
             r'<td><ins style="background:#e6ffe6;">Some book</ins></td>[\\n\s]+'
-            r"<td><span>None</span></td>[\\n\s]+"
+            r"<td></td>[\\n\s]+"
             "</tr>"
         )
         self.assertRegex(str(response.content), target_row_re)

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -36,6 +36,7 @@ class FieldTest(TestCase):
         self.assertEqual(self.field.export(self.obj), self.row["name"])
 
     def test_export_none(self):
+        # 1872
         instance = Obj(name=None)
         self.assertEqual("", self.field.export(instance))
 

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -154,6 +154,4 @@ class FieldTest(TestCase):
 
     def test_get_value_with_no_attribute(self):
         self.field.attribute = None
-        with self.assertRaises(AttributeError) as e:
-            self.field.get_value(self.obj)
-        self.assertEqual("Field attribute cannot be null", str(e.exception))
+        self.assertIsNone(self.field.get_value(self.obj))

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -35,6 +35,10 @@ class FieldTest(TestCase):
     def test_export(self):
         self.assertEqual(self.field.export(self.obj), self.row["name"])
 
+    def test_export_none(self):
+        instance = Obj(name=None)
+        self.assertEqual("", self.field.export(instance))
+
     def test_save(self):
         self.row["name"] = "foo"
         self.field.save(self.obj, self.row)

--- a/tests/core/tests/test_resources/test_modelresource/test_export.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_export.py
@@ -83,6 +83,7 @@ class ExportFunctionalityTest(TestCase):
 
     def test_export_declared_field(self):
         # test that declared fields with no attribute return empty value
+        # see 1874
         class EBookResource(ModelResource):
             published = Field(column_name="published")
 

--- a/tests/core/tests/test_resources/test_modelresource/test_export.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_export.py
@@ -82,8 +82,7 @@ class ExportFunctionalityTest(TestCase):
         self.assertEqual(dict(a=1), self.resource.kwargs_)
 
     def test_export_declared_field(self):
-        # test that declared fields have the correct widget set
-        # #1860
+        # test that declared fields with no attribute return empty value
         class EBookResource(ModelResource):
             published = Field(column_name="published")
 
@@ -96,4 +95,4 @@ class ExportFunctionalityTest(TestCase):
         self.book.published = date(1955, 4, 5)
         self.book.save()
         dataset = resource.export()
-        self.assertEqual("1955-04-05", dataset.dict[0]["published"])
+        self.assertEqual("", dataset.dict[0]["published"])


### PR DESCRIPTION
**Problem**

Closes #1874 #1872 

If a Resource has declared fields with no attribute declaration, then there should be no attempt to set attributes on the resource.  This is the v3 behaviour.

**Solution**

Reverted changes from #1861 which set attribute if not defined.

**Acceptance Criteria**

Added tests and documentation to confirm the behaviour.