### PR TITLE
Casting tuple onto the order_fields attribute in _get_ordered_field_names

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1119,7 +1119,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         Return a list of field names, respecting any defined ordering.
         """
         # get any declared 'order' fields
-        order_fields = getattr(self._meta, order_field) or ()
+        order_fields = tuple(getattr(self._meta, order_field) or ())
         # get any defined fields
         defined_fields = order_fields + tuple(getattr(self._meta, "fields") or ())
 

--- a/tests/core/tests/test_resources/test_import_export.py
+++ b/tests/core/tests/test_resources/test_import_export.py
@@ -62,7 +62,7 @@ class ImportExportFieldOrderTest(TestCase):
     class OrderedBookResource(BaseBookResource):
         class Meta:
             fields = ("price", "id", "name")
-            import_order = ("price", "name", "id")
+            import_order = ["price", "name", "id"]
             export_order = ("price", "name", "id")
             model = Book
 
@@ -81,6 +81,12 @@ class ImportExportFieldOrderTest(TestCase):
     class FieldsAsListBookResource(BaseBookResource):
         class Meta:
             fields = ["id", "price", "name"]
+            model = Book
+
+    class MixedIterableBookResource(BaseBookResource):
+        class Meta:
+            fields = ("price", "id", "name")
+            import_order = ["price", "name", "id"]
             model = Book
 
     class DeclaredModelFieldBookResource(BaseBookResource):
@@ -118,6 +124,12 @@ class ImportExportFieldOrderTest(TestCase):
         self.dataset = tablib.Dataset(headers=["id", "name", "price"])
         row = [self.pk, "Some book", "19.99"]
         self.dataset.append(row)
+
+    def test_mixed_iterable(self):
+        # 1878
+        self.resource = ImportExportFieldOrderTest.MixedIterableBookResource()
+        self.resource.import_data(self.dataset)
+        self.assertEqual(["price", "name", "id"], self.resource.field_names)
 
     def test_defined_import_order(self):
         self.resource = ImportExportFieldOrderTest.OrderedBookResource()


### PR DESCRIPTION
Cast tuple onto the Meta order_fields so they can concatenate with the Meta fields.

On a class inheriting `resources.ModelResource`, when fields and order_fields are defined as list in the class' Meta, tuple is cast onto the `fields `attribute but not onto the `order_fields`.

This results in the TypeError on line 1121 coming from the line `defined_fields = order_fields + tuple(getattr(self._meta, "fields") or ()`

(.../import_export/resources.py)

What problem have you solved?

![TypeError](https://github.com/Klexus1/django-import-export/assets/47198827/50089a39-4f09-4759-b2d9-1a3bf07df324)

Now both resources.ModelResource - Meta - fields and order_fields can be defined as list.

How did you solve the problem?

Casting the tuple build in function onto the order_fields too.
