### PR TITLE
Speed up tests 10x

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -107,3 +107,7 @@ if django.VERSION >= (4, 1):
     FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
 if django.VERSION >= (5, 0):
     FORM_RENDERER = "django.forms.renderers.DjangoTemplates"
+
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]


### PR DESCRIPTION
Take the tests from ~40s to ~4s on my machine, by using a weaker password hasher, per the Django documentation recommendation: https://docs.djangoproject.com/en/5.0/topics/testing/overview/#speeding-up-the-tests .