### PR TITLE
Use literals to create lists and dicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,5 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-comprehensions==3.14.0

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -432,7 +432,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
         import_formats = self.get_import_formats()
         import_form = self.create_import_form(request)
-        resources = list()
+        resources = []
         if request.POST and import_form.is_valid():
             input_format = import_formats[int(import_form.cleaned_data["format"])]()
             if not input_format.is_binary():
@@ -556,9 +556,9 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
         """
         Create appropriate LogEntry instances for the result.
         """
-        rows = dict()
+        rows = {}
         for row in result:
-            rows.setdefault(row.import_type, list())
+            rows.setdefault(row.import_type, [])
             rows[row.import_type].append(row.instance)
 
         self._create_log_entries(request.user.pk, rows)

--- a/import_export/declarative.py
+++ b/import_export/declarative.py
@@ -78,7 +78,7 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
             # class.
             # if 'fields' property is defined, declared fields can only be included
             # if they appear in the 'fields' iterable.
-            declared_fields = dict()
+            declared_fields = {}
             for field_name, field in new_class.fields.items():
                 column_name = field.column_name
                 if (

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -120,7 +120,7 @@ class SelectableFieldsExportForm(ExportForm):
         """
         self.resources = resources
         self.is_selectable_fields_form = True
-        self.resource_fields = {resource.__name__: list() for resource in resources}
+        self.resource_fields = {resource.__name__: [] for resource in resources}
 
         for index, resource in enumerate(resources):
             boolean_fields = self._create_boolean_fields(resource, index)
@@ -130,7 +130,7 @@ class SelectableFieldsExportForm(ExportForm):
         ordered_fields = [
             "resource",
             # flatten resource fields lists
-            *chain(*[fields for fields in self.resource_fields.values()]),
+            *chain(*self.resource_fields.values()),
         ]
         self.order_fields(ordered_fields)
 
@@ -262,9 +262,9 @@ class SelectableFieldsExportForm(ExportForm):
         """
         Validate if any field for resource was selected in form data
         """
-        resource_fields = [field for field in resource().get_export_order()]
+        resource_fields = list(resource().get_export_order())
 
-        if not any([v for k, v in self.cleaned_data.items() if k in resource_fields]):
+        if not any(v for k, v in self.cleaned_data.items() if k in resource_fields):
             raise forms.ValidationError(
                 _("""Select at least 1 field for "%(resource_name)s" to export"""),
                 code="invalid",

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -89,9 +89,9 @@ class Resource(metaclass=DeclarativeMetaclass):
         self.fields = deepcopy(self.fields)
 
         # lists to hold model instances in memory when bulk operations are enabled
-        self.create_instances = list()
-        self.update_instances = list()
-        self.delete_instances = list()
+        self.create_instances = []
+        self.update_instances = []
+        self.delete_instances = []
 
     @classmethod
     def get_result_class(self):
@@ -578,9 +578,7 @@ class Resource(metaclass=DeclarativeMetaclass):
                 # have not been written to the 'instance' at this point
                 instance_values = list(field.clean(row))
                 original_values = (
-                    list()
-                    if original.pk is None
-                    else list(field.get_value(original).all())
+                    [] if original.pk is None else list(field.get_value(original).all())
                 )
                 if len(instance_values) != len(original_values):
                     return False
@@ -1123,7 +1121,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         # get any defined fields
         defined_fields = order_fields + tuple(getattr(self._meta, "fields") or ())
 
-        order = list()
+        order = []
         [order.append(f) for f in defined_fields if f not in order]
         declared_fields = []
         for field_name, field in self.fields.items():
@@ -1145,9 +1143,9 @@ class Resource(metaclass=DeclarativeMetaclass):
         There are conditions, such as 'dynamic fields' where this does not apply.
         See issue 1834 for more information.
         """
-        import_id_fields = list()
-        missing_fields = list()
-        missing_headers = list()
+        import_id_fields = []
+        missing_fields = []
+        missing_headers = []
 
         if self.get_import_id_fields() == ["id"]:
             # this is the default case, so ok if not present

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -201,7 +201,7 @@ class Result:
         self.base_errors.append(error)
 
     def add_dataset_headers(self, headers):
-        headers = list() if not headers else headers
+        headers = [] if not headers else headers
         self.failed_dataset.headers = headers + ["Error"]
 
     def append_failed_row(self, row, error):

--- a/tests/core/tests/admin_integration/mixins.py
+++ b/tests/core/tests/admin_integration/mixins.py
@@ -50,7 +50,7 @@ class AdminTestMixin(object):
         )
         with open(filename, "rb") as f:
             if data is None:
-                data = dict()
+                data = {}
             data.update(
                 {
                     "format": str(input_format),

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -418,7 +418,7 @@ class TestExportEncoding(TestCase):
             return dataset
 
         def get_export_queryset(self, request):
-            return list()
+            return []
 
         def get_export_filename(self, request, queryset, file_format):
             return "f"
@@ -430,7 +430,7 @@ class TestExportEncoding(TestCase):
     def test_to_encoding_not_set_default_encoding_is_utf8(self):
         self.export_mixin = self.TestMixin(test_str="teststr")
         data = self.export_mixin.get_export_data(
-            self.file_format, self.mock_request, list()
+            self.file_format, self.mock_request, []
         )
         csv_dataset = tablib.import_set(data)
         self.assertEqual("teststr", csv_dataset.dict[0]["name"])
@@ -438,7 +438,7 @@ class TestExportEncoding(TestCase):
     def test_to_encoding_set(self):
         self.export_mixin = self.TestMixin(test_str="ハローワールド")
         data = self.export_mixin.get_export_data(
-            self.file_format, self.mock_request, list(), encoding="shift-jis"
+            self.file_format, self.mock_request, [], encoding="shift-jis"
         )
         encoding = chardet.detect(bytes(data))["encoding"]
         self.assertEqual("SHIFT_JIS", encoding)
@@ -449,7 +449,7 @@ class TestExportEncoding(TestCase):
             self.export_mixin.get_export_data(
                 self.file_format,
                 self.mock_request,
-                list(),
+                [],
                 encoding="bad-encoding",
             )
 
@@ -460,7 +460,7 @@ class TestExportEncoding(TestCase):
         data = self.export_mixin.get_export_data(
             self.file_format,
             self.mock_request,
-            list(),
+            [],
         )
         binary_dataset = tablib.import_set(data)
         self.assertEqual("teststr", binary_dataset.dict[0]["name"])
@@ -485,7 +485,7 @@ class TestExportEncoding(TestCase):
         with mock.patch(
             "import_export.admin.ExportMixin.get_export_data"
         ) as mock_get_export_data:
-            self.export_mixin.export_admin_action(self.mock_request, list())
+            self.export_mixin.export_admin_action(self.mock_request, [])
             encoding_kwarg = mock_get_export_data.call_args_list[0][1]["encoding"]
             self.assertEqual("utf-8", encoding_kwarg)
 

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -493,7 +493,7 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
 
     def test_get_context_data_returns_empty_dict(self):
         m = ExportMixin()
-        self.assertEqual(dict(), m.get_context_data())
+        self.assertEqual({}, m.get_context_data())
 
     @patch("import_export.admin.logger")
     def test_issue_1521_change_list_template_as_property(self, mock_logger):

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -13,7 +13,7 @@ from import_export.resources import modelresource_factory
 
 class ExportViewMixinTest(TestCase):
     class TestExportForm(forms.ExportForm):
-        cleaned_data = dict()
+        cleaned_data = {}
 
     def setUp(self):
         self.url = reverse("export-category")

--- a/tests/core/tests/test_resources/test_import_export.py
+++ b/tests/core/tests/test_resources/test_import_export.py
@@ -44,7 +44,7 @@ class AfterImportComparisonTest(TestCase):
 class ImportExportFieldOrderTest(TestCase):
     class BaseBookResource(resources.ModelResource):
         def __init__(self):
-            self.field_names = list()
+            self.field_names = []
 
         def get_queryset(self):
             return Book.objects.all().order_by("id")

--- a/tests/core/tests/test_resources/test_modelresource/test_export.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_export.py
@@ -79,7 +79,7 @@ class ExportFunctionalityTest(TestCase):
         # when queryset is supplied, it should be passed to before_export()
         self.resource.export(queryset=Book.objects.all(), **{"a": 1})
         self.assertEqual(Book.objects.count(), len(self.resource.qs))
-        self.assertEqual(dict(a=1), self.resource.kwargs_)
+        self.assertEqual({"a": 1}, self.resource.kwargs_)
 
     def test_export_declared_field(self):
         # test that declared fields with no attribute return empty value

--- a/tests/core/tests/test_resources/test_modelresource/test_resource.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_resource.py
@@ -106,7 +106,7 @@ class ResourceTestCase(TestCase):
         book = Book()
         self.my_resource._meta.clean_model_instances = True
         self.my_resource.validate_instance(book)
-        target = dict()
+        target = {}
         full_clean_mock.assert_called_once_with(
             exclude=target.keys(), validate_unique=True
         )

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -680,7 +680,7 @@ class JSONWidgetTest(TestCase, RowDeprecationTestMixin):
 
     def test_render_none(self):
         self.assertEqual(self.widget.render(None), None)
-        self.assertEqual(self.widget.render(dict()), None)
+        self.assertEqual(self.widget.render({}), None)
         self.assertEqual(self.widget.render({"value": None}), '{"value": null}')
 
 


### PR DESCRIPTION
They’re clearer and a little bit faster, per [rule C408 in flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions?tab=readme-ov-file#c408-unnecessary-dictlisttuple-call---rewrite-as-a-literal) (which I’d be happy to add to the setup, if you want).
