### PR TITLE
Improve Error class

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1,7 +1,6 @@
 import functools
 import inspect
 import logging
-import traceback
 from collections import OrderedDict
 from copy import deepcopy
 from html import escape
@@ -680,10 +679,7 @@ class Resource(metaclass=DeclarativeMetaclass):
     def handle_import_error(self, result, error, raise_errors=False):
         logger.debug(error, exc_info=error)
         if result:
-            tb_info = traceback.format_exc()
-            result.append_base_error(
-                self.get_error_result_class()(error, traceback=tb_info)
-            )
+            result.append_base_error(self.get_error_result_class()(error))
         if raise_errors:
             raise exceptions.ImportError(error)
 
@@ -785,11 +781,8 @@ class Resource(metaclass=DeclarativeMetaclass):
             # when only the original error is likely to be relevant
             if not isinstance(e, TransactionManagementError):
                 logger.debug(e, exc_info=e)
-            tb_info = traceback.format_exc()
             row_result.errors.append(
-                self.get_error_result_class()(
-                    e, traceback=tb_info, row=row, number=kwargs["row_number"]
-                )
+                self.get_error_result_class()(e, row=row, number=kwargs["row_number"])
             )
 
         return row_result

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -608,7 +608,7 @@ class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
         self.assertNotIn("import-error-display-message", content)
         self.assertNotIn("import-error-display-row", content)
         self.assertIn("import-error-display-traceback", content)
-        self.assertIn("Traceback (most recent call last)", content))
+        self.assertIn("Traceback (most recent call last)", content)
 
 
 class ConfirmImportEncodingTest(AdminTestMixin, TestCase):

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -603,6 +603,7 @@ class TestImportErrorMessageFormat(AdminTestMixin, TestCase):
         self.assertNotIn("import-error-display-message", str(response.content))
         self.assertNotIn("import-error-display-row", str(response.content))
         self.assertIn("import-error-display-traceback", str(response.content))
+        self.assertIn("Traceback (most recent call last)", str(response.content))
 
 
 class ConfirmImportEncodingTest(AdminTestMixin, TestCase):

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -2,13 +2,48 @@ from unittest.mock import patch
 
 from core.models import Book
 from django.core.exceptions import ValidationError
-from django.test.testcases import TestCase
+from django.test import SimpleTestCase
 from tablib import Dataset
 
 from import_export.results import Error, Result, RowResult
 
 
-class ResultTest(TestCase):
+class ErrorTest(SimpleTestCase):
+    def test_repr_no_details(self):
+        try:
+            1 / 0
+        except Exception as exc:
+            error = Error(exc)
+
+        self.assertEqual(repr(error), "<Error: ZeroDivisionError('division by zero')>")
+
+    def test_repr_all_details(self):
+        try:
+            1 / 0
+        except Exception as exc:
+            error = Error(exc, row=1, number=2)
+
+        self.assertEqual(
+            repr(error),
+            "<Error: ZeroDivisionError('division by zero') at row 1 at number 2>",
+        )
+
+    def test_traceback(self):
+        try:
+            1 / 0
+        except Exception as exc:
+            error = Error(exc)
+
+        self.assertTrue(
+            error.traceback.startswith("Traceback (most recent call last):\n")
+        )
+        self.assertIn(
+            "ZeroDivisionError: division by zero\n",
+            error.traceback,
+        )
+
+
+class ResultTest(SimpleTestCase):
     def setUp(self):
         self.result = Result()
         headers = ["id", "book_name"]


### PR DESCRIPTION
1. Lazily compute the traceback string, using `traceback.format_exception()`. It’s only used in the rare case that `"traceback"` is in the `import_error_display` attribute, so we can save that work and memory in the usual case.
2. Add a nice `__repr__`, to help debug test failures that make assertions on `Error` objects. I had a few cases where tests failed with inscrutable messages from pytest like `Left contains one more item: <import_export.results.Error object at 0x3173c8690>`, and I needed to rerun the test with the debugger to inspect the inner exception.