### PR TITLE
Remove django version check for custom storages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.0.10 (2024-06-25)
+------------------
+
+- remove django version check for custom storages (`1889 <https://github.com/django-import-export/django-import-export/pull/1889>`_)
+
 4.0.9 (2024-06-18)
 ------------------
 

--- a/import_export/tmp_storages.py
+++ b/import_export/tmp_storages.py
@@ -2,8 +2,6 @@ import os
 import tempfile
 from uuid import uuid4
 
-import django
-from django.conf import settings
 from django.core.cache import cache
 from django.core.files.base import ContentFile
 
@@ -73,11 +71,7 @@ class MediaStorage(BaseStorage):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if django.VERSION[:2] > (4, 2):
-            self._configure_storage()
-        else:
-            self._configure_storage_legacy()
-
+        self._configure_storage()
         self.MEDIA_FOLDER = kwargs.get("MEDIA_FOLDER", "django-import-export")
 
         # issue 1589 - Ensure that for MediaStorage, we read in binary mode
@@ -91,12 +85,6 @@ class MediaStorage(BaseStorage):
         self._storage = (
             sh["import_export"] if "import_export" in sh.backends else sh["default"]
         )
-
-    def _configure_storage_legacy(self):
-        from django.core.files.storage import default_storage
-
-        storage_class = getattr(settings, "IMPORT_EXPORT_DEFAULT_FILE_STORAGE", None)
-        self._storage = storage_class() if storage_class else default_storage
 
     def save(self, data):
         if not self.name:

--- a/tests/core/tests/test_tmp_storages.py
+++ b/tests/core/tests/test_tmp_storages.py
@@ -1,9 +1,7 @@
 import io
 import os
-from unittest import skipUnless
 from unittest.mock import mock_open, patch
 
-import django
 from django.core.cache import cache
 from django.core.files.storage import FileSystemStorage, default_storage
 from django.test import TestCase
@@ -136,21 +134,7 @@ class CustomizedStorage(object):
         self.delete_count += 1
 
 
-@skipUnless(django.VERSION <= (4, 2), "Django 4.2")
-class CustomizedMediaStorageTestDjango42(TestCase):
-    @override_settings(IMPORT_EXPORT_DEFAULT_FILE_STORAGE=CustomizedStorage)
-    def test_MediaStorage_uses_custom_storage_implementation(self):
-        tmp_storage = TestMediaStorage()
-        tmp_storage.save(b"a")
-        self.assertEqual(1, tmp_storage._storage.save_count)
-        tmp_storage.read()
-        self.assertEqual(1, tmp_storage._storage.open_count)
-        tmp_storage.remove()
-        self.assertEqual(1, tmp_storage._storage.delete_count)
-
-
-@skipUnless(django.VERSION >= (5, 0), "Django 5.0")
-class CustomizedMediaStorageTestDjango50(TestCase):
+class CustomizedMediaStorageTestDjango(TestCase):
     @override_settings(
         STORAGES={
             "import_export": {


### PR DESCRIPTION
**Problem**

Closes #1888 

**Solution**

Remove the version check and associated tests.

**Acceptance Criteria**

All tests pass.