### PR TITLE
Restore return value for Resource.get_fields()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.1.1 (unreleased)
+------------------
+
+- Restore return value for deprecated method :meth:`~import_export.resources.Resource.get_fields` (`1897 <https://github.com/django-import-export/django-import-export/pull/1897>`_).
+
 4.1.0 (2024-06-25)
 ------------------
 

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -146,6 +146,7 @@ class Resource(metaclass=DeclarativeMetaclass):
             DeprecationWarning,
             stacklevel=2,
         )
+        return list(self.fields.values())
 
     def get_field_name(self, field):
         """

--- a/tests/core/tests/test_resources/test_modelresource/test_deprecated_fields.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_deprecated_fields.py
@@ -70,4 +70,19 @@ class DeprecatedMethodTest(TestCase):
             r"The 'get_fields\(\)' method is deprecated "
             "and will be removed in a future release",
         ):
-            resource.get_fields()
+            fields = resource.get_fields()
+
+        self.assertEqual(
+            {f.column_name for f in fields},
+            {
+                "added",
+                "author",
+                "author_email",
+                "categories",
+                "id",
+                "name",
+                "price",
+                "published_date",
+                "published_time",
+            },
+        )


### PR DESCRIPTION
**Problem**

PR #1886 dropped the `return` line from `get_fields()`. Consequently, I saw crashes in my project like: `'NoneType' object is not iterable` , from methods calling `get_fields()`.

When deprecating a function, it shouldn't change beyond adding the warning. That gives users time to migrate off using it.

**Solution**

Restored the removed line.

**Acceptance Criteria**

Updated the unit test.