### PR TITLE
Improve warning for ExportViewFormMixin

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     Version 4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.1.2 (Unreleased)
+------------------
+
+- Improve deprecation warning for ``ExportViewFormMixin`` to report at point of class definition (`1900 <https://github.com/django-import-export/django-import-export/pull/1900>`_).
+
 4.1.1 (2024-07-08)
 ------------------
 

--- a/import_export/mixins.py
+++ b/import_export/mixins.py
@@ -280,13 +280,16 @@ class ExportViewMixin(BaseExportMixin):
 
 
 class ExportViewFormMixin(ExportViewMixin, FormView):
-    def form_valid(self, form):
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
         warn(
             "ExportViewFormMixin is deprecated and will be removed "
-            "in a future release",
+            "in a future release.",
             DeprecationWarning,
             stacklevel=2,
         )
+
+    def form_valid(self, form):
         formats = self.get_export_formats()
         file_format = formats[int(form.cleaned_data["format"])]()
         if hasattr(self, "get_filterset"):

--- a/tests/core/tests/test_mixins.py
+++ b/tests/core/tests/test_mixins.py
@@ -46,22 +46,23 @@ class ExportViewMixinTest(TestCase):
         """
         content_type = "text/csv"
 
-        class TestMixin(mixins.ExportViewFormMixin):
-            def __init__(self):
-                self.model = MagicMock()
-                self.request = MagicMock(spec=HttpRequest)
-                self.model.__name__ = "mockModel"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
 
-            def get_queryset(self):
-                return MagicMock()
+            class TestMixin(mixins.ExportViewFormMixin):
+                def __init__(self):
+                    self.model = MagicMock()
+                    self.request = MagicMock(spec=HttpRequest)
+                    self.model.__name__ = "mockModel"
+
+                def get_queryset(self):
+                    return MagicMock()
 
         m = TestMixin()
         with mock.patch("import_export.mixins.HttpResponse") as mock_http_response:
             # on first instantiation, raise TypeError, on second, return mock
             mock_http_response.side_effect = [TypeError(), mock_http_response]
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                m.form_valid(self.form)
+            m.form_valid(self.form)
             self.assertEqual(
                 content_type, mock_http_response.call_args_list[0][1]["content_type"]
             )
@@ -75,27 +76,28 @@ class ExportViewMixinTest(TestCase):
         method, then this is called as required.
         """
 
-        class TestMixin(mixins.ExportViewFormMixin):
-            mock_get_filterset_call_count = 0
-            mock_get_filterset_class_call_count = 0
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
 
-            def __init__(self):
-                self.model = MagicMock()
-                self.request = MagicMock(spec=HttpRequest)
-                self.model.__name__ = "mockModel"
+            class TestMixin(mixins.ExportViewFormMixin):
+                mock_get_filterset_call_count = 0
+                mock_get_filterset_class_call_count = 0
 
-            def get_filterset(self, filterset_class):
-                self.mock_get_filterset_call_count += 1
-                return MagicMock()
+                def __init__(self):
+                    self.model = MagicMock()
+                    self.request = MagicMock(spec=HttpRequest)
+                    self.model.__name__ = "mockModel"
 
-            def get_filterset_class(self):
-                self.mock_get_filterset_class_call_count += 1
-                return MagicMock()
+                def get_filterset(self, filterset_class):
+                    self.mock_get_filterset_call_count += 1
+                    return MagicMock()
+
+                def get_filterset_class(self):
+                    self.mock_get_filterset_class_call_count += 1
+                    return MagicMock()
 
         m = TestMixin()
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            res = m.form_valid(self.form)
+        res = m.form_valid(self.form)
         self.assertEqual(200, res.status_code)
         self.assertEqual(1, m.mock_get_filterset_call_count)
         self.assertEqual(1, m.mock_get_filterset_class_call_count)

--- a/tests/core/views.py
+++ b/tests/core/views.py
@@ -1,9 +1,13 @@
+import warnings
+
 from django.views.generic.list import ListView
 
 from import_export import mixins
 
 from . import models
 
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=DeprecationWarning)
 
-class CategoryExportView(mixins.ExportViewFormMixin, ListView):
-    model = models.Category
+    class CategoryExportView(mixins.ExportViewFormMixin, ListView):
+        model = models.Category


### PR DESCRIPTION
**Problem**

The existing warning added in #1667 did not reveal which class used the deprecated mixin.

**Solution**

Transform this warning to run at class definition time using [`object.__init_subclass__`](https://docs.python.org/3.12/reference/datamodel.html#object.__init_subclass__). Then the deprecated line is shown as the point of class definition.

**Acceptance Criteria**

Tested in my own project. Modified the tests here, though none check the warning message.