### PR TITLE
Handle invalid confirm_form while importing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -155,3 +155,4 @@ The following is a list of much appreciated contributors:
 * thisisumurzakov (Akbarbek Umurzakov)
 * roharvey (Rob Harvey)
 * RenDelaCruz (Ren de la Cruz)
+* AyushDharDubey

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -178,12 +178,14 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             return self.process_result(result, request)
         else:
             context = self.admin_site.each_context(request)
-            context.update({
-                'title': _('Import'),
-                'confirm_form': confirm_form,
-                'opts': self.model._meta,
-                'errors': confirm_form.errors,
-            })
+            context.update(
+                {
+                    "title": _("Import"),
+                    "confirm_form": confirm_form,
+                    "opts": self.model._meta,
+                    "errors": confirm_form.errors,
+                }
+            )
             return TemplateResponse(request, [self.import_template_name], context)
 
     def process_dataset(

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -176,6 +176,15 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             tmp_storage.remove()
 
             return self.process_result(result, request)
+        else:
+            context = self.admin_site.each_context(request)
+            context.update({
+                'title': _('Import'),
+                'confirm_form': confirm_form,
+                'opts': self.model._meta,
+                'errors': confirm_form.errors,
+            })
+            return TemplateResponse(request, [self.import_template_name], context)
 
     def process_dataset(
         self,

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -426,7 +426,7 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
             "/admin/core/ebook/process_import/", data, follow=True
         )
         # check if error is captured gracefully
-        self.assertEquals(
+        self.assertEqual(
             response.context["errors"], {"author": ["This field is required."]}
         )
         # restore the correct data and resubmit

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -421,14 +421,16 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
         data = confirm_form.initial
         self.assertEqual(data["original_file_name"], "books.csv")
         # manipulate data to make the payload invalid
-        data['author'] = ''
+        data["author"] = ""
         response = self.client.post(
             "/admin/core/ebook/process_import/", data, follow=True
         )
         # check if error is captured gracefully
-        self.assertEquals(response.context['errors'], {'author': ['This field is required.']})
+        self.assertEquals(
+            response.context["errors"], {"author": ["This field is required."]}
+        )
         # restore the correct data and resubmit
-        data['author'] = 11
+        data["author"] = 11
         response = self.client.post(
             "/admin/core/ebook/process_import/", data, follow=True
         )

--- a/tests/core/tests/admin_integration/test_import.py
+++ b/tests/core/tests/admin_integration/test_import.py
@@ -420,6 +420,15 @@ class ImportAdminIntegrationTest(AdminTestMixin, TestCase):
 
         data = confirm_form.initial
         self.assertEqual(data["original_file_name"], "books.csv")
+        # manipulate data to make the payload invalid
+        data['author'] = ''
+        response = self.client.post(
+            "/admin/core/ebook/process_import/", data, follow=True
+        )
+        # check if error is captured gracefully
+        self.assertEquals(response.context['errors'], {'author': ['This field is required.']})
+        # restore the correct data and resubmit
+        data['author'] = 11
         response = self.client.post(
             "/admin/core/ebook/process_import/", data, follow=True
         )


### PR DESCRIPTION
**Problem**

#1901

**Solution**

When the confirm_form is invalid, the user will now be redirected back to the confirm page, with confirm_form errors passed as context, ensuring that appropriate validation errors are presented to the user .

**Acceptance Criteria**

Added tests.
Ran existing test suite.