### PR TITLE
Upgrade Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.10.1
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.4.2
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/isort

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -59,9 +59,9 @@ class ImportExportMixinBase:
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
-        extra_context[
-            "ie_base_change_list_template"
-        ] = self.ie_base_change_list_template
+        extra_context["ie_base_change_list_template"] = (
+            self.ie_base_change_list_template
+        )
         return super().changelist_view(request, extra_context)
 
 

--- a/tests/scripts/bulk_import.py
+++ b/tests/scripts/bulk_import.py
@@ -3,6 +3,7 @@ Helper module for testing bulk imports.
 
 See testing.rst
 """
+
 import time
 from functools import wraps
 


### PR DESCRIPTION
Upgrade Black to this year’s major version, 24, which comes with [some style changes](https://black.readthedocs.io/en/stable/change_log.html#id18). Also, change to the mirror repo, a new option recommended by the [pre-commit integration docs](https://black.readthedocs.io/en/stable/integrations/source_version_control.html) for speed.