### PR TITLE
Update Django version in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 # tablib temporarily using master before v4
 dependencies = [
     "diff-match-patch",
-    "Django>=3.2",
+    "Django>=4.2",
     "tablib==3.5.0"
 ]
 


### PR DESCRIPTION
Update the minimum version in `dependencies` to 4.2, which is the minimum tested version. I believe this was missed in #1790, which removed Django 3.2 support.