### PR TITLE
Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,11 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.1.0
     hooks:
       - id: flake8
         additional_dependencies:


### PR DESCRIPTION
Ran `pre-commit autoupdate` to upgrade tools.

I recommend setting up [pre-commit.ci](https://pre-commit.ci/) on the repo. This will run hooks on every PR, like the deprecated `pre-commit/action` currently in use, and will make autoupdate PRs.