### PR TITLE
Remove setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
PR #1630 refactored the build process to use `pyproject.toml`. Keeping `setup.py` was necessary in the past to continue to support editable installs, but this has not been the case [since pip 21.3](https://pip.pypa.io/en/latest/news/#v21-3) (“Support editable installs for projects that have a pyproject.toml and use a build backend that supports PEP 660.”).

This PR removes `setup.py`. FYI, I removed `setup.py` files from my projects in 2022, for example: https://github.com/adamchainz/apig-wsgi/commit/d4222e04f7cbe44cf39cce54c9537617c874a94c .