### PR TITLE
Support Django 5.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,7 @@ Changelog
 - Hide the "Resource" form when it only has one option (`1908 <https://github.com/django-import-export/django-import-export/issues/1908>`_)
 - Update date, time and datetime widget render method to handle derived instance (`1918 <https://github.com/django-import-export/django-import-export/issues/1918>`_)
 - Upgraded tablib version (`1627 <https://github.com/django-import-export/django-import-export/issues/1627>`_)
-- Add support for Django 5.1
+- Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Changelog
 - Hide the "Resource" form when it only has one option (`1908 <https://github.com/django-import-export/django-import-export/issues/1908>`_)
 - Update date, time and datetime widget render method to handle derived instance (`1918 <https://github.com/django-import-export/django-import-export/issues/1918>`_)
 - Upgraded tablib version (`1627 <https://github.com/django-import-export/django-import-export/issues/1627>`_)
+- Add support for Django 5.1
 
 4.1.1 (2024-07-08)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.0
 envlist =
        {py38,py39}-{django42}
-       {py310,py311,py312}-{django42,django50,djangomain}
+       {py310,py311,py312}-{django42,django50,django51,djangomain}
        # tablib dev temporarily removed - see issue #1602
        # py311-djangomain-tablibdev
 
@@ -26,7 +26,8 @@ commands =
 deps =
     tablibdev: -egit+https://github.com/jazzband/tablib.git@master\#egg=tablib
     django42: Django>=4.2,<5.0
-    django50: Django>=5.0,<6.0
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1rc1,<5.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
     -rrequirements/test.txt
 


### PR DESCRIPTION
Django 5.1 is in release candidate as of last week: https://www.djangoproject.com/weblog/2024/jul/24/django-51-rc1/

This PR adds it to the test matrix and corrects the tox configuration for 5.0, which would accidentally have started testing 5.1 upon its release.