### PR TITLE
Avoid thousand separators in NumberWidget.render()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Changelog
 - Update date, time and datetime widget render method to handle derived instance (`1918 <https://github.com/django-import-export/django-import-export/issues/1918>`_)
 - Upgraded tablib version (`1627 <https://github.com/django-import-export/django-import-export/issues/1627>`_)
 - Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
+- Avoid using thousand separators in :meth:`~import_export.widgets.NumberWidget.render` (`1928 <https://github.com/django-import-export/django-import-export/issues/1928>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -8,10 +8,11 @@ from warnings import warn
 import django
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import timezone
+from django.utils import numberformat, timezone
 from django.utils.dateparse import parse_duration
 from django.utils.encoding import force_str, smart_str
-from django.utils.formats import number_format
+from django.utils.formats import get_format
+from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 
 from import_export.exceptions import WidgetError
@@ -121,10 +122,18 @@ class NumberWidget(Widget):
     def render(self, value, obj=None):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string:
-            return (
-                ""
-                if value is None or not isinstance(value, numbers.Number)
-                else "" + number_format(value)
+            if value is None or not isinstance(value, numbers.Number):
+                return ""
+            # Format the number avoiding the thousand separator
+            lang = get_language()
+            # The `"" +` casts SafeString to str
+            return "" + numberformat.format(
+                value,
+                get_format("DECIMAL_SEPARATOR", lang, use_l10n=True),
+                None,
+                get_format("NUMBER_GROUPING", lang, use_l10n=True),
+                "",
+                use_l10n=True,
             )
         return value
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -404,8 +404,15 @@ class NumberWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertEqual(self.widget.render("a"), "")
 
     @override_settings(LANGUAGE_CODE="fr-fr")
-    def test_locale_render_coerce_to_string_gte4(self):
+    def test_locale_render_coerce_to_string(self):
         self.assertEqual("11,111", self.widget_coerce_to_string.render(self.value))
+
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_locale_render_coerce_to_string_no_thousand_separator(self):
+        self.assertEqual(
+            self.widget_coerce_to_string.render(1234),
+            "1234",
+        )
 
     def test_coerce_to_string_value_is_None(self):
         self.assertEqual("", self.widget_coerce_to_string.render(None))
@@ -436,8 +443,12 @@ class FloatWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertEqual(self.widget.clean("\r\n\t"), None)
 
     @override_settings(LANGUAGE_CODE="fr-fr")
-    def test_locale_render_coerce_to_string_gte4(self):
+    def test_locale_render_coerce_to_string(self):
         self.assertEqual(self.widget_coerce_to_string.render(self.value), "11,111")
+
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_locale_render_coerce_to_string_no_thousand_separator(self):
+        self.assertEqual(self.widget_coerce_to_string.render(1234), "1234")
 
 
 class DecimalWidgetTest(TestCase, RowDeprecationTestMixin):
@@ -469,8 +480,12 @@ class DecimalWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertEqual(self.widget.clean("\r\n\t"), None)
 
     @override_settings(LANGUAGE_CODE="fr-fr")
-    def test_locale_render_coerce_to_string_gte4(self):
+    def test_locale_render_coerce_to_string(self):
         self.assertEqual(self.widget.render(self.value), "11,111")
+
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_locale_render_coerce_to_string_no_thousand_separator(self):
+        self.assertEqual(self.widget.render(1234), "1234")
 
 
 class IntegerWidgetTest(TestCase, RowDeprecationTestMixin):
@@ -499,8 +514,12 @@ class IntegerWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertEqual(self.widget.render("a"), "")
 
     @override_settings(LANGUAGE_CODE="fr-fr")
-    def test_locale_render_gte_django4(self):
+    def test_locale_render(self):
         self.assertEqual(self.widget_coerce_to_string.render(self.value), "0")
+
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_locale_render_no_thousand_separator(self):
+        self.assertEqual(self.widget_coerce_to_string.render(1234), "1234")
 
 
 class ForeignKeyWidgetTest(TestCase, RowDeprecationTestMixin):


### PR DESCRIPTION
**Problem**

Fixes #1927.

**Solution**

Switch from calling `number_format` to the underlying `numberformat.format()`, always passing `""` as the thousand separator.

**Acceptance Criteria**

Updated the widget unit tests.

Ran the manual test per issue: successfully exported and imported a book with a four-digit price.