### PR TITLE
Added warning log for declared fields excluded from fields whitelist

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,7 +17,7 @@ Changelog
 - Update date, time and datetime widget render method to handle derived instance (`1918 <https://github.com/django-import-export/django-import-export/issues/1918>`_)
 - Upgraded tablib version (`1627 <https://github.com/django-import-export/django-import-export/issues/1627>`_)
 - Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
-- Added warning log for declared fields excluded from fields whitelist ()
+- Added warning log for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Changelog
 - Update date, time and datetime widget render method to handle derived instance (`1918 <https://github.com/django-import-export/django-import-export/issues/1918>`_)
 - Upgraded tablib version (`1627 <https://github.com/django-import-export/django-import-export/issues/1627>`_)
 - Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
+- Added warning log for declared fields excluded from fields whitelist ()
 
 4.1.1 (2024-07-08)
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -268,6 +268,7 @@ You can adjust the log level to see output as required.
 This is an example configuration to be placed in your application settings::
 
     LOGGING = {
+        "version" 1,
         "handlers": {
             "console": {"level": "DEBUG", "class": "logging.StreamHandler"},
         },

--- a/import_export/declarative.py
+++ b/import_export/declarative.py
@@ -86,6 +86,10 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                     and field_name not in opts.fields
                     and column_name not in opts.fields
                 ):
+                    logger.warning(
+                        f"ignoring field '{field_name}' because not declared "
+                        "in 'fields' whitelist"
+                    )
                     continue
                 declared_fields[field_name] = field
 


### PR DESCRIPTION
**Problem**

Closes #1902 

**Solution**

Added a log warning if a field is excluded.

**Acceptance Criteria**

- Manual testing
- Enable [logging](https://django-import-export.readthedocs.io/en/latest/installation.html#configure-logging), run the test suite, and you will see the warning message.