### PR TITLE
Accept locale numeric separators in imported numbers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
 - Upgraded tablib version (`1627 <https://github.com/django-import-export/django-import-export/issues/1627>`_)
 - Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
 - Added warning log for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
+- Accept numbers using the numeric separators of the current language in number widgets (:meth:`~import_export.widgets.FloatWidget`, :meth:`~import_export.widgets.IntegerWidget`, :meth:`~import_export.widgets.DecimalWidget`) (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from django.utils.dateparse import parse_duration
 from django.utils.encoding import force_str, smart_str
-from django.utils.formats import number_format
+from django.utils.formats import number_format, sanitize_separators
 from django.utils.translation import gettext_lazy as _
 
 from import_export.exceptions import WidgetError
@@ -137,7 +137,7 @@ class FloatWidget(NumberWidget):
     def clean(self, value, row=None, **kwargs):
         if self.is_empty(value):
             return None
-        return float(value)
+        return float(sanitize_separators(value))
 
 
 class IntegerWidget(NumberWidget):
@@ -148,7 +148,7 @@ class IntegerWidget(NumberWidget):
     def clean(self, value, row=None, **kwargs):
         if self.is_empty(value):
             return None
-        return int(Decimal(value))
+        return int(Decimal(sanitize_separators(value)))
 
 
 class DecimalWidget(NumberWidget):
@@ -159,7 +159,7 @@ class DecimalWidget(NumberWidget):
     def clean(self, value, row=None, **kwargs):
         if self.is_empty(value):
             return None
-        return Decimal(force_str(value))
+        return Decimal(force_str(sanitize_separators(value)))
 
 
 class CharWidget(Widget):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -420,6 +420,22 @@ class FloatWidgetTest(TestCase, RowDeprecationTestMixin):
     def test_clean(self):
         self.assertEqual(self.widget.clean(11.111), self.value)
 
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators(self):
+        self.assertEqual(self.widget.clean("1,234.5"), 1234.5)
+
+    @override_settings(LANGUAGE_CODE="ar", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_arabic(self):
+        self.assertEqual(self.widget.clean("1.234,5"), 1234.5)
+
+    @override_settings(LANGUAGE_CODE="zh-hans", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_chinese_simplified(self):
+        self.assertEqual(self.widget.clean("1234.5"), 1234.5)
+
+    @override_settings(LANGUAGE_CODE="fr", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_french(self):
+        self.assertEqual(self.widget.clean("1\xa0234,5"), 1234.5)
+
     def test_render(self):
         self.assertEqual(self.widget.render(self.value), "11.111")
 
@@ -448,6 +464,22 @@ class DecimalWidgetTest(TestCase, RowDeprecationTestMixin):
     def test_clean(self):
         self.assertEqual(self.widget.clean("11.111"), self.value)
         self.assertEqual(self.widget.clean(11.111), self.value)
+
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators(self):
+        self.assertEqual(self.widget.clean("1,234.5"), Decimal("1234.5"))
+
+    @override_settings(LANGUAGE_CODE="ar", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_arabic(self):
+        self.assertEqual(self.widget.clean("1.234,5"), Decimal("1234.5"))
+
+    @override_settings(LANGUAGE_CODE="zh-hans", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_chinese_simplified(self):
+        self.assertEqual(self.widget.clean("1234.5"), Decimal("1234.5"))
+
+    @override_settings(LANGUAGE_CODE="fr", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_french(self):
+        self.assertEqual(self.widget.clean("1\xa0234,5"), Decimal("1234.5"))
 
     def test_render_coerce_to_string_is_False(self):
         self.widget = widgets.DecimalWidget(coerce_to_string=False)
@@ -494,6 +526,22 @@ class IntegerWidgetTest(TestCase, RowDeprecationTestMixin):
         self.assertEqual(self.widget.clean(""), None)
         self.assertEqual(self.widget.clean(" "), None)
         self.assertEqual(self.widget.clean("\n\t\r"), None)
+
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators(self):
+        self.assertEqual(self.widget.clean("1,234.5"), 1234)
+
+    @override_settings(LANGUAGE_CODE="ar", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_arabic(self):
+        self.assertEqual(self.widget.clean("1.234,5"), 1234)
+
+    @override_settings(LANGUAGE_CODE="zh-hans", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_chinese_simplified(self):
+        self.assertEqual(self.widget.clean("1234.5"), 1234)
+
+    @override_settings(LANGUAGE_CODE="fr", USE_THOUSAND_SEPARATOR=True)
+    def test_clean_numeric_separators_french(self):
+        self.assertEqual(self.widget.clean("1\xa0234,5"), 1234)
 
     def test_render_invalid_type(self):
         self.assertEqual(self.widget.render("a"), "")


### PR DESCRIPTION
Fixes #1927.

An alternative approach to #1928, trying to make export-import work as a roundtrip in most languages.

This does have the weird behaviour that if you export in one language and import in another, that might not work. But that’s already the case since #1025, if the two languages have different numeric separators.

Tested by new widget unit tests plus trying using the test project in French.