### PR TITLE
Avoid showing export action when there's no permission

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ This release contains breaking changes.  Please refer to :doc:`release notes<rel
 - Added warning log for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
 - Accept numbers using the numeric separators of the current language in number widgets (:meth:`~import_export.widgets.FloatWidget`, :meth:`~import_export.widgets.IntegerWidget`, :meth:`~import_export.widgets.DecimalWidget`) (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
 - Fix v3 regression: handle native types on export to spreadsheet (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
+- Fix export button displayed on change screen when export permission not assigned (`1942 <https://github.com/django-import-export/django-import-export/issues/1942>`_)
 - Fix crash for Django 5.1 when rows are skipped (`1944 <https://github.com/django-import-export/django-import-export/issues/1944>`_)
 
 4.1.1 (2024-07-08)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -944,13 +944,14 @@ class ExportActionMixin(ExportMixin):
         Adds the export action to the list of available actions.
         """
         actions = super().get_actions(request)
-        actions.update(
-            export_admin_action=(
-                type(self).export_admin_action,
-                "export_admin_action",
-                _("Export selected %(verbose_name_plural)s"),
+        if self.has_export_permission(request):
+            actions.update(
+                export_admin_action=(
+                    type(self).export_admin_action,
+                    "export_admin_action",
+                    _("Export selected %(verbose_name_plural)s"),
+                )
             )
-        )
         return actions
 
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -934,7 +934,7 @@ class ExportActionMixin(ExportMixin):
         """
         actions = super().get_actions(request)
         if not self.has_export_permission(request):
-            return actions        
+            return actions
         actions.update(
             export_admin_action=(
                 type(self).export_admin_action,

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -933,6 +933,8 @@ class ExportActionMixin(ExportMixin):
         Adds the export action to the list of available actions.
         """
         actions = super().get_actions(request)
+        if not self.has_export_permission(request):
+            return actions        
         actions.update(
             export_admin_action=(
                 type(self).export_admin_action,

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -884,7 +884,7 @@ class ExportActionMixin(ExportMixin):
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         extra_context = extra_context or {}
-        extra_context["show_change_form_export"] = self.show_change_form_export
+        extra_context["show_change_form_export"] = self.show_change_form_export and self.has_export_permission(request)
         return super().change_view(
             request,
             object_id,

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -884,7 +884,9 @@ class ExportActionMixin(ExportMixin):
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         extra_context = extra_context or {}
-        extra_context["show_change_form_export"] = self.show_change_form_export and self.has_export_permission(request)
+        extra_context["show_change_form_export"] = (
+            self.show_change_form_export and self.has_export_permission(request)
+        )
         return super().change_view(
             request,
             object_id,

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -944,8 +944,6 @@ class ExportActionMixin(ExportMixin):
         Adds the export action to the list of available actions.
         """
         actions = super().get_actions(request)
-        if not self.has_export_permission(request):
-            return actions
         actions.update(
             export_admin_action=(
                 type(self).export_admin_action,

--- a/tests/core/tests/admin_integration/mixins.py
+++ b/tests/core/tests/admin_integration/mixins.py
@@ -11,7 +11,6 @@ class AdminTestMixin:
     category_change_url = "/admin/core/category/"
     category_export_url = "/admin/core/category/export/"
     uuid_category_change_url = "/admin/core/uuidcategory/"
-    category_export_url = "/admin/core/category/export/"
     uuid_category_export_url = "/admin/core/uuidcategory/export/"
     book_import_url = "/admin/core/book/import/"
     book_export_url = "/admin/core/book/export/"

--- a/tests/core/tests/test_permissions.py
+++ b/tests/core/tests/test_permissions.py
@@ -1,7 +1,7 @@
 import os.path
 
-from admin_integration.mixins import AdminTestMixin
 from core.models import Category
+from core.tests.admin_integration.mixins import AdminTestMixin
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.test.testcases import TestCase

--- a/tests/core/tests/test_permissions.py
+++ b/tests/core/tests/test_permissions.py
@@ -1,12 +1,13 @@
 import os.path
 
+from admin_integration.mixins import AdminTestMixin
 from core.models import Category
 from django.contrib.auth.models import Permission, User
 from django.test.testcases import TestCase
 from django.test.utils import override_settings
 
 
-class ImportExportPermissionTest(TestCase):
+class ImportExportPermissionTest(AdminTestMixin, TestCase):
     def setUp(self):
         user = User.objects.create_user("admin", "admin@example.com", "password")
         user.is_staff = True
@@ -23,7 +24,7 @@ class ImportExportPermissionTest(TestCase):
     @override_settings(IMPORT_EXPORT_IMPORT_PERMISSION_CODE="change")
     def test_import(self):
         # user has no permission to import
-        response = self.client.get("/admin/core/book/import/")
+        response = self.client.get(self.book_import_url)
         self.assertEqual(response.status_code, 403)
 
         # POST the import form
@@ -38,16 +39,16 @@ class ImportExportPermissionTest(TestCase):
                 "import_file": f,
             }
 
-            response = self.client.post("/admin/core/book/import/", data)
+            response = self.client.post(self.book_import_url, data)
             self.assertEqual(response.status_code, 403)
 
-            response = self.client.post("/admin/core/book/process_import/", {})
+            response = self.client.post(self.book_process_import_url, {})
             self.assertEqual(response.status_code, 403)
 
         # user has sufficient permission to import
         self.set_user_model_permission("change", "book")
 
-        response = self.client.get("/admin/core/book/import/")
+        response = self.client.get(self.book_import_url)
         self.assertEqual(response.status_code, 200)
 
         # POST the import form
@@ -62,29 +63,29 @@ class ImportExportPermissionTest(TestCase):
                 "import_file": f,
             }
 
-            response = self.client.post("/admin/core/book/import/", data)
+            response = self.client.post(self.book_import_url, data)
             self.assertEqual(response.status_code, 200)
             confirm_form = response.context["confirm_form"]
 
             data = confirm_form.initial
-            response = self.client.post("/admin/core/book/process_import/", data)
+            response = self.client.post(self.book_process_import_url, data)
             self.assertEqual(response.status_code, 302)
 
     @override_settings(IMPORT_EXPORT_EXPORT_PERMISSION_CODE="change")
     def test_export_with_permission_set(self):
-        response = self.client.get("/admin/core/book/export/")
+        response = self.client.get(self.book_export_url)
         self.assertEqual(response.status_code, 403)
 
         data = {"format": "0"}
-        response = self.client.post("/admin/core/book/export/", data)
+        response = self.client.post(self.book_export_url, data)
         self.assertEqual(response.status_code, 403)
 
         self.set_user_model_permission("change", "book")
-        response = self.client.get("/admin/core/book/export/")
+        response = self.client.get(self.book_export_url)
         self.assertEqual(response.status_code, 200)
 
         data = {"format": "0"}
-        response = self.client.post("/admin/core/book/export/", data)
+        response = self.client.post(self.book_export_url, data)
         self.assertEqual(response.status_code, 200)
 
     @override_settings(IMPORT_EXPORT_EXPORT_PERMISSION_CODE="change")
@@ -94,18 +95,18 @@ class ImportExportPermissionTest(TestCase):
             "action": ["export_admin_action"],
             "_selected_action": [str(self.cat1.id)],
         }
-        response = self.client.post("/admin/core/category/", data)
+        response = self.client.post(self.category_change_url, data)
         self.assertEqual(response.status_code, 403)
 
         self.set_user_model_permission("change", "category")
-        response = self.client.post("/admin/core/category/", data)
+        response = self.client.post(self.category_change_url, data)
         self.assertEqual(response.status_code, 200)
 
     @override_settings(IMPORT_EXPORT_EXPORT_PERMISSION_CODE="add")
     def test_check_export_button(self):
         self.set_user_model_permission("change", "book")
 
-        response = self.client.get("/admin/core/book/")
+        response = self.client.get(self.core_book_url)
         widget = "import_link"
         self.assertIn(widget, response.content.decode())
         widget = "export_link"
@@ -115,7 +116,7 @@ class ImportExportPermissionTest(TestCase):
     def test_check_import_button(self):
         self.set_user_model_permission("change", "book")
 
-        response = self.client.get("/admin/core/book/")
+        response = self.client.get(self.core_book_url)
         widget = "import_link"
         self.assertNotIn(widget, response.content.decode())
         widget = "export_link"

--- a/tests/core/tests/test_permissions.py
+++ b/tests/core/tests/test_permissions.py
@@ -124,7 +124,7 @@ class ImportExportPermissionTest(AdminTestMixin, TestCase):
         widget = "export_link"
         self.assertIn(widget, response.content.decode())
 
-    @override_settings(IMPORT_EXPORT_IMPORT_PERMISSION_CODE="export")
+    @override_settings(IMPORT_EXPORT_EXPORT_PERMISSION_CODE="export")
     def test_export_button_for_export_permission(self):
         content_type = ContentType.objects.get_for_model(Category)
         Permission.objects.create(
@@ -149,6 +149,7 @@ class ImportExportPermissionTest(AdminTestMixin, TestCase):
         )
         self.assertNotIn(export_btn, response.content.decode())
 
+        # add export permission and the button should be displayed
         self.set_user_model_permission("export", "category")
         response = self.client.get(self.change_url)
         self.assertIn(export_btn, response.content.decode())

--- a/tests/core/tests/test_permissions.py
+++ b/tests/core/tests/test_permissions.py
@@ -153,3 +153,25 @@ class ImportExportPermissionTest(AdminTestMixin, TestCase):
         self.set_user_model_permission("export", "category")
         response = self.client.get(self.change_url)
         self.assertIn(export_btn, response.content.decode())
+
+    @override_settings(IMPORT_EXPORT_EXPORT_PERMISSION_CODE="export")
+    def test_action_dropdown_contains_export_action(self):
+        content_type = ContentType.objects.get_for_model(Category)
+        Permission.objects.create(
+            codename="export_category",
+            name="Can export category",
+            content_type=content_type,
+        )
+        self.set_user_model_permission("view", "category")
+        self.cat1 = Category.objects.create(name="Cat 1")
+
+        response = self.client.get(self.category_change_url)
+        export_option = (
+            '<option value="export_admin_action">Export selected categories</option>'
+        )
+        self.assertNotIn(export_option, response.content.decode())
+
+        # add export permission and the button should be displayed
+        self.set_user_model_permission("export", "category")
+        response = self.client.get(self.category_change_url)
+        self.assertIn(export_option, response.content.decode())


### PR DESCRIPTION
**Problem**

Even if the user does not have permission to export, "Export..." will still show up in the dropdown action, and only errors out later when the export is submitted.

**Solution**

Add a permission check in "get_actions"

**Acceptance Criteria**

Run several local tests.