### PR TITLE
Fix crash for Django 5.1 when rows are skipped

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -686,7 +686,6 @@ the data in the import row is the same as the persisted data or not.  You can co
 row if it is duplicate by using setting :attr:`~import_export.options.ResourceOptions.skip_unchanged`.
 
 If :attr:`~import_export.options.ResourceOptions.skip_unchanged` is enabled, then the import process will check each
-ns
 defined import field and perform a simple comparison with the existing instance, and if all comparisons are equal, then
 the row is skipped.  Skipped rows are recorded in the row :class:`~import_export.results.RowResult` object.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,7 @@ Changelog
 - Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
 - Added warning log for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
 - Accept numbers using the numeric separators of the current language in number widgets (:meth:`~import_export.widgets.FloatWidget`, :meth:`~import_export.widgets.IntegerWidget`, :meth:`~import_export.widgets.DecimalWidget`) (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
-- Fix crash for Django 5.1 when rows are skipped (`1937 <https://github.com/django-import-export/django-import-export/issues/1937>`_)
+- Fix crash for Django 5.1 when rows are skipped (`1944 <https://github.com/django-import-export/django-import-export/issues/1944>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 - Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
 - Added warning log for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
 - Accept numbers using the numeric separators of the current language in number widgets (:meth:`~import_export.widgets.FloatWidget`, :meth:`~import_export.widgets.IntegerWidget`, :meth:`~import_export.widgets.DecimalWidget`) (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
+- Fix crash for Django 5.1 when rows are skipped (`1937 <https://github.com/django-import-export/django-import-export/issues/1937>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -222,7 +222,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     def generate_log_entries(self, result, request):
         if not self.get_skip_admin_log():
             # Add imported objects to LogEntry
-            if django.VERSION >= (6, 0):
+            if django.VERSION >= (6,):
                 self._log_actions(result, request)
             else:
                 logentry_map = {
@@ -238,7 +238,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     ):
                         with warnings.catch_warnings():
                             warnings.filterwarnings(
-                                "ignore", category=PendingDeprecationWarning
+                                "ignore", category=DeprecationWarning
                             )
                             LogEntry.objects.log_action(
                                 user_id=request.user.pk,

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -587,10 +587,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             RowResult.IMPORT_TYPE_DELETE: DELETION,
         }
         for import_type, instances in rows.items():
-            if import_type not in (
-                RowResult.IMPORT_TYPE_SKIP,
-                RowResult.IMPORT_TYPE_ERROR,
-            ):
+            if import_type in logentry_map.keys():
                 action_flag = logentry_map[import_type]
                 self._create_log_entry(
                     user_pk, rows[import_type], import_type, action_flag

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -222,7 +222,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     def generate_log_entries(self, result, request):
         if not self.get_skip_admin_log():
             # Add imported objects to LogEntry
-            if django.VERSION >= (5, 1):
+            if django.VERSION >= (6, 0):
                 self._log_actions(result, request)
             else:
                 logentry_map = {

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -222,7 +222,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
     def generate_log_entries(self, result, request):
         if not self.get_skip_admin_log():
             # Add imported objects to LogEntry
-            if django.VERSION >= (6,):
+            if django.VERSION >= (5, 1):
                 self._log_actions(result, request)
             else:
                 logentry_map = {
@@ -587,8 +587,11 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             RowResult.IMPORT_TYPE_DELETE: DELETION,
         }
         for import_type, instances in rows.items():
-            action_flag = logentry_map[import_type]
-            self._create_log_entry(user_pk, rows[import_type], import_type, action_flag)
+            if import_type in logentry_map.keys():
+                action_flag = logentry_map[import_type]
+                self._create_log_entry(
+                    user_pk, rows[import_type], import_type, action_flag
+                )
 
     def _create_log_entry(self, user_pk, rows, import_type, action_flag):
         if len(rows) > 0:

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -14,7 +14,6 @@ from django.shortcuts import render
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
-from django.utils.deprecation import RemovedInDjango60Warning
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
@@ -238,9 +237,15 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                         and row.import_type != row.IMPORT_TYPE_SKIP
                     ):
                         with warnings.catch_warnings():
-                            warnings.filterwarnings(
-                                "ignore", category=RemovedInDjango60Warning
-                            )
+                            if django.VERSION >= (5,):
+                                from django.utils.deprecation import (
+                                    RemovedInDjango60Warning,
+                                )
+
+                                cat = RemovedInDjango60Warning
+                            else:
+                                cat = DeprecationWarning
+                            warnings.simplefilter("ignore", category=cat)
                             LogEntry.objects.log_action(
                                 user_id=request.user.pk,
                                 content_type_id=content_type_id,

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -232,10 +232,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                 }
                 content_type_id = ContentType.objects.get_for_model(self.model).pk
                 for row in result:
-                    if (
-                        row.import_type != row.IMPORT_TYPE_ERROR
-                        and row.import_type != row.IMPORT_TYPE_SKIP
-                    ):
+                    if row.import_type in logentry_map.keys():
                         with warnings.catch_warnings():
                             if django.VERSION >= (5,):
                                 from django.utils.deprecation import (

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -587,7 +587,10 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             RowResult.IMPORT_TYPE_DELETE: DELETION,
         }
         for import_type, instances in rows.items():
-            if import_type in logentry_map.keys():
+            if import_type not in (
+                RowResult.IMPORT_TYPE_SKIP,
+                RowResult.IMPORT_TYPE_ERROR,
+            ):
                 action_flag = logentry_map[import_type]
                 self._create_log_entry(
                     user_pk, rows[import_type], import_type, action_flag

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -14,6 +14,7 @@ from django.shortcuts import render
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
+from django.utils.deprecation import RemovedInDjango60Warning
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
@@ -238,7 +239,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                     ):
                         with warnings.catch_warnings():
                             warnings.filterwarnings(
-                                "ignore", category=DeprecationWarning
+                                "ignore", category=RemovedInDjango60Warning
                             )
                             LogEntry.objects.log_action(
                                 user_id=request.user.pk,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,14 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [
-    "tablib[all]>=3.6.1"
+    "tablib[all]"
 ]
 cli = ["tablib[cli]"]
 ods = ["tablib[ods]"]
 pandas = ["tablib[pandas]"]
-xls = ["tablib[xls]==3.5.0"]
-xlsx = ["tablib[xlsx]==3.5.0"]
-yaml = ["tablib[yaml]==3.5.0"]
+xls = ["tablib[xls]"]
+xlsx = ["tablib[xlsx]"]
+yaml = ["tablib[yaml]"]
 
 [project.urls]
 Documentation = "https://django-import-export.readthedocs.io/en/stable/"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django>=3.2
+Django>=4.2
 tablib>=3.6.1
 diff-match-patch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,5 @@ pytz==2023.3
 memory-profiler==0.61.0
 django-extensions==3.2.3
 coverage==7.3.2
-tablib[all]==3.5.0
+tablib[all]>=3.6.1
 setuptools-scm==8.0.4

--- a/tests/core/tests/admin_integration/test_import_functionality.py
+++ b/tests/core/tests/admin_integration/test_import_functionality.py
@@ -5,6 +5,7 @@ from core.admin import BookAdmin, EBookResource, ImportMixin
 from core.models import Author, Book, Parent
 from core.tests.admin_integration.mixins import AdminTestMixin
 from django.contrib.admin.models import DELETION, LogEntry
+from django.core.exceptions import ValidationError
 from django.test.testcases import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
@@ -268,6 +269,18 @@ class ImportLogEntryTest(AdminTestMixin, TestCase):
         data = confirm_form.initial
         with mock.patch("core.admin.BookResource.skip_row") as mock_skip:
             mock_skip.side_effect = ValueError("some unknown error")
+            self._post_url_response(self.book_process_import_url, data, follow=True)
+        self.assertEqual(0, LogEntry.objects.count())
+
+    def test_import_log_entry_validation_error_row(self):
+        # ensure that validation error rows do not create log entries
+        response = self._do_import_post(self.book_import_url, "books.csv")
+
+        self.assertEqual(response.status_code, 200)
+        confirm_form = response.context["confirm_form"]
+        data = confirm_form.initial
+        with mock.patch("core.admin.BookResource.skip_row") as mock_skip:
+            mock_skip.side_effect = ValidationError("some unknown error")
             self._post_url_response(self.book_process_import_url, data, follow=True)
         self.assertEqual(0, LogEntry.objects.count())
 

--- a/tests/core/tests/admin_integration/test_import_functionality.py
+++ b/tests/core/tests/admin_integration/test_import_functionality.py
@@ -247,6 +247,18 @@ class ImportLogEntryTest(AdminTestMixin, TestCase):
         m.skip_admin_log = True
         self.assertTrue(m.get_skip_admin_log())
 
+    @patch("import_export.resources.Resource.skip_row")
+    def test_import_log_entry_skip_row(self, mock_skip_row):
+        # test issue 1937
+        mock_skip_row.return_value = True
+        response = self._do_import_post(self.book_import_url, "books.csv")
+
+        self.assertEqual(response.status_code, 200)
+        confirm_form = response.context["confirm_form"]
+        data = confirm_form.initial
+        self._post_url_response(self.book_process_import_url, data, follow=True)
+        self.assertEqual(0, LogEntry.objects.count())
+
 
 @override_settings(IMPORT_EXPORT_SKIP_ADMIN_CONFIRM=True)
 class TestImportSkipConfirm(AdminTestMixin, TransactionTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ min_version = 4.0
 envlist =
        {py38,py39}-{django42}
        {py310,py311,py312}-{django42,django50,django51,djangomain}
-       # tablib dev temporarily removed - see issue #1602
-       # py311-djangomain-tablibdev
+       py311-djangomain-tablibdev
 
 [gh-actions]
 python =
@@ -27,7 +26,7 @@ deps =
     tablibdev: -egit+https://github.com/jazzband/tablib.git@master\#egg=tablib
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
-    django51: Django>=5.1rc1,<5.2
+    django51: Django>=5.1,<5.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
     -rrequirements/test.txt
 


### PR DESCRIPTION
**Problem**

Closes #1937 

**Solution**

The problem was that 'skip' and 'error' rows are included when writing `LogEntry`.  This is a regression from v3, where these rows are ignored.

**Acceptance Criteria**

Added tests which proves the fix.