### PR TITLE
Allow callable in dehydrate_method

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -759,9 +759,30 @@ In this case, the export looks like this:
     full_title,id,name,author,author_email,imported,published,price,categories
     Some book by 1,2,Some book,1,,0,2012-12-05,8.85,1
 
-It is also possible to pass a method name in to the :meth:`~import_export.fields.Field` constructor.  If this method
-name is supplied, then that method
-will be called as the 'dehydrate' method.
+It is also possible to pass a method name or a callable to the :meth:`~import_export.fields.Field` constructor. If this method name or callable is supplied, then it will be called as the 'dehydrate' method. For example:
+
+    from import_export.fields import Field
+
+    # Using method name
+    class BookResource(resources.ModelResource):
+        full_title = Field(dehydrate_method='custom_dehydrate_method')
+
+        class Meta:
+            model = Book
+
+        def custom_dehydrate_method(self, book):
+            return f"{book.name} by {book.author.name}"
+
+    # Using a callable directly
+    def custom_dehydrate_callable(book):
+        return f"{book.name} by {book.author.name}"
+
+    class BookResource(resources.ModelResource):
+        full_title = Field(dehydrate_method=custom_dehydrate_callable)
+
+        class Meta:
+            model = Book
+
 
 Filtering querysets during export
 =================================

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -759,7 +759,7 @@ In this case, the export looks like this:
     full_title,id,name,author,author_email,imported,published,price,categories
     Some book by 1,2,Some book,1,,0,2012-12-05,8.85,1
 
-It is also possible to pass a method name or a callable to the :meth:`~import_export.fields.Field` constructor. If this method name or callable is supplied, then it will be called as the 'dehydrate' method. For example:
+It is also possible to pass a method name or a callable to the :meth:`~import_export.fields.Field` constructor. If this method name or callable is supplied, then it will be called as the 'dehydrate' method. For example::
 
     from import_export.fields import Field
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ This release contains breaking changes.  Please refer to :doc:`release notes<rel
 - Accept numbers using the numeric separators of the current language in number widgets (:meth:`~import_export.widgets.FloatWidget`, :meth:`~import_export.widgets.IntegerWidget`, :meth:`~import_export.widgets.DecimalWidget`) (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
 - Fix v3 regression: handle native types on export to spreadsheet (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
 - Fix crash for Django 5.1 when rows are skipped (`1944 <https://github.com/django-import-export/django-import-export/issues/1944>`_)
+- Allow callable in dehydrate method (`1950 <https://github.com/django-import-export/django-import-export/issues/1950>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -31,8 +31,9 @@ class Field:
       This can be used if the widget returns null, but there is a default instance
       value which should not be overwritten.
 
-    :param dehydrate_method: Lets you choose your own method for dehydration rather
-        than using `dehydrate_{field_name}` syntax.
+    :param dehydrate_method: You can provide a `dehydrate_method` as a string to use
+        instead of the default `dehydrate_{field_name}` syntax, or you can provide
+        a callable that will be executed with the instance as its argument.
 
     :param m2m_add: changes save of this field to add the values, if they do not exist,
         to a ManyToMany field instead of setting all values.  Only useful if field is

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1035,7 +1035,11 @@ class Resource(metaclass=DeclarativeMetaclass):
         field_name = self.get_field_name(field)
         dehydrate_method = field.get_dehydrate_method(field_name)
 
-        method = getattr(self, dehydrate_method, None)
+        if callable(dehydrate_method):
+            method = dehydrate_method
+        else:
+            method = getattr(self, dehydrate_method, None)
+
         if method is not None:
             return method(instance)
         return field.export(instance, **kwargs)

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -110,7 +110,7 @@ class FieldTest(TestCase):
         method_name = field.get_dehydrate_method(resource_field_name)
         self.assertEqual(method_name, custom_dehydrate_method)
 
-    def testget_dehydrate_method_with_callable(self):
+    def test_get_dehydrate_method_with_callable(self):
         field = fields.Field(
             attribute="foo", column_name="bar", dehydrate_method=lambda x: x
         )

--- a/tests/core/tests/test_fields.py
+++ b/tests/core/tests/test_fields.py
@@ -110,6 +110,14 @@ class FieldTest(TestCase):
         method_name = field.get_dehydrate_method(resource_field_name)
         self.assertEqual(method_name, custom_dehydrate_method)
 
+    def testget_dehydrate_method_with_callable(self):
+        field = fields.Field(
+            attribute="foo", column_name="bar", dehydrate_method=lambda x: x
+        )
+        resource_field_name = "field"
+        method = field.get_dehydrate_method(resource_field_name)
+        self.assertTrue(callable(method))
+
     def testget_dehydrate_method_without_params_raises_attribute_error(self):
         field = fields.Field(attribute="foo", column_name="bar")
 

--- a/tests/core/tests/test_resources/test_modelresource/test_relationship.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_relationship.py
@@ -45,6 +45,23 @@ class RelationshipFieldTest(TestCase):
         full_title = resource.export_field(resource.fields["full_title"], self.book)
         self.assertEqual(full_title, f"{self.book.name} by {self.book.author.name}")
 
+    def test_dehydrating_field_using_callable(self):
+        class B(resources.ModelResource):
+            full_title = fields.Field(
+                column_name="Full title",
+                dehydrate_method=lambda obj: f"{obj.name} by {obj.author.name}",
+            )
+
+            class Meta:
+                model = Book
+                fields = ("author__name", "full_title")
+
+        author = Author.objects.create(name="Author")
+        self.book.author = author
+        resource = B()
+        full_title = resource.export_field(resource.fields["full_title"], self.book)
+        self.assertEqual(full_title, f"{self.book.name} by {self.book.author.name}")
+
     def test_dehydrate_field_using_custom_dehydrate_field_method(self):
         class B(resources.ModelResource):
             full_title = fields.Field(


### PR DESCRIPTION
**Problem**

Can't reuse a `dehydrate` function across multiple Fields

**Solution**

Allow a callable to be set as the `dehydrate_method`

**Acceptance Criteria**

Run several local tests.