### PR TITLE
Fix crash when Resource fields declared incorrectly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Here are some examples of how it has been used in the wild:
 * Manage user access to an application by importing externally version controlled auth user lists
 * Add `hooks <https://django-import-export.readthedocs.io/en/latest/advanced_usage.html#advanced-data-manipulation-on-export>`_ to anonymize data on export
 * `Modify import / export UI forms <https://django-import-export.readthedocs.io/en/latest/admin_integration.html#customize-admin-import-forms>`_ to add dynamic filtering on import / export.
-* Build a migration layer between platforms, for example *django-import-export* has been used to export from `Wordpress <https://wordpress.org/>` to `Wagtail <https://wagtail.org/>`
+* Build a migration layer between platforms, for example *django-import-export* has been used to process exports from `Wordpress <https://wordpress.org/>` and import to `Wagtail <https://wagtail.org/>`
 
 Getting started
 ===============

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ Here are some examples of how it has been used in the wild:
 * Manage user access to an application by importing externally version controlled auth user lists
 * Add `hooks <https://django-import-export.readthedocs.io/en/latest/advanced_usage.html#advanced-data-manipulation-on-export>`_ to anonymize data on export
 * `Modify import / export UI forms <https://django-import-export.readthedocs.io/en/latest/admin_integration.html#customize-admin-import-forms>`_ to add dynamic filtering on import / export.
+* Build a migration layer between platforms, for example *django-import-export* has been used to export from `Wordpress <https://wordpress.org/>` to `Wagtail <https://wagtail.org/>`
 
 Getting started
 ===============

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -112,8 +112,8 @@ The ``attribute`` parameter is optional, and if omitted it means that:
 
   1. The field will be ignored during import.
 
-  2. The field can be exported if the Resource attribute name ('published_field') relates to a field on the associated
-     model.
+  2. The field will be present during export, but will have an empty value unless a
+     :ref:`dehydrate<advanced_data_manipulation_on_export>` method is defined.
 
 If using the ``fields`` attribute to :ref:`declare fields<field_declaration>` then the declared resource attribute
 name must appear in the ``fields`` list::

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -108,8 +108,12 @@ column name (i.e. row header)::
         class Meta:
             model = Book
 
-The ``attribute`` parameter is optional and if not supplied it will default to the declared resource attribute name
-(e.g. 'published_field').
+The ``attribute`` parameter is optional, and if omitted it means that:
+
+  1. The field will be ignored during import.
+
+  2. The field can be exported if the Resource attribute name ('published_field') relates to a field on the associated
+     model.
 
 If using the ``fields`` attribute to :ref:`declare fields<field_declaration>` then the declared resource attribute
 name must appear in the ``fields`` list::

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -18,10 +18,12 @@ In a simple case, the name of the row headers will map exactly onto the names of
 process will handle this mapping.  In more complex cases, model attributes and row headers may differ, and we will need
 to declare explicitly declare this mapping. See :ref:`field_declaration` for more information.
 
-Declare import fields
----------------------
+.. _declare_fields:
 
-You can optionally use the ``fields`` declaration to affect which fields are handled during import.
+Declare fields
+--------------
+
+You can optionally use the ``fields`` declaration to affect which fields are handled during import / export.
 
 To affect which model fields will be included in a resource, use the ``fields`` option to whitelist fields::
 
@@ -42,19 +44,10 @@ Or the ``exclude`` option to blacklist fields::
 If both ``fields`` and ``exclude`` are declared, the ``fields`` declaration takes precedence, and ``exclude`` is
 ignored.
 
-In cases where a :ref:`custom column name<field_declaration>` is used, declare the name of the model attribute in the
-``fields`` list., not the column alias.
-
 .. _field_ordering:
 
 Field ordering
 --------------
-
-The precedence for the order of fields for import / export is defined as follows:
-
-  * ``import_order`` or ``export_order`` (if defined)
-  * ``fields`` (if defined)
-  * The order derived from the underlying model instance.
 
 When importing or exporting, the ordering defined by ``fields`` is used, however an explicit order for importing or
 exporting fields can be set using the either the ``import_order`` or ``export_order`` options::
@@ -66,6 +59,12 @@ exporting fields can be set using the either the ``import_order`` or ``export_or
             fields = ('id', 'name', 'author', 'price',)
             import_order = ('id', 'price',)
             export_order = ('id', 'price', 'author', 'name')
+
+The precedence for the order of fields for import / export is defined as follows:
+
+  * ``import_order`` or ``export_order`` (if defined)
+  * ``fields`` (if defined)
+  * The order derived from the underlying model instance.
 
 Where ``import_order`` or ``export_order`` contains a subset of ``fields`` then the ``import_order`` and
 ``export_order`` fields will be processed first.
@@ -104,14 +103,23 @@ column name (i.e. row header)::
     from import_export.fields import Field
 
     class BookResource(resources.ModelResource):
-        published = Field(attribute='published', column_name='published_date')
+        published_field = Field(attribute='published', column_name='published_date')
 
         class Meta:
             model = Book
 
-The ``attribute`` parameter is optional and if not supplied then the field will be skipped during import and export.
-It is possible to enable export for the field by declaring a :ref:`dehydrate<advanced_data_manipulation_on_export>`
-method.
+The ``attribute`` parameter is optional and if not supplied it will default to the declared resource attribute name
+(e.g. 'published_field').
+
+If using the ``fields`` attribute to :ref:`declare fields<field_declaration>` then the declared resource attribute
+name must appear in the ``fields`` list::
+
+    class BookResource(ModelResource):
+        published_field = Field(attribute='published', column_name='published_date')
+
+        class Meta:
+            fields = ("published_field",)
+            model = Book
 
 .. seealso::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,7 @@ This release contains breaking changes.  Please refer to :doc:`release notes<rel
 - Accept numbers using the numeric separators of the current language in number widgets (:meth:`~import_export.widgets.FloatWidget`, :meth:`~import_export.widgets.IntegerWidget`, :meth:`~import_export.widgets.DecimalWidget`) (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
 - Fix v3 regression: handle native types on export to spreadsheet (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
 - Fix export button displayed on change screen when export permission not assigned (`1942 <https://github.com/django-import-export/django-import-export/issues/1942>`_)
-- Added warning log for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
+- Added warning for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
 - Fix v3 regression: handle native types on export to spreadsheet (`1939 <https://github.com/django-import-export/django-import-export/issues/1939>`_)
 - Fix crash for Django 5.1 when rows are skipped (`1944 <https://github.com/django-import-export/django-import-export/issues/1944>`_)
 - Document overriding formats (`1868 <https://github.com/django-import-export/django-import-export/issues/1868>`_)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
 This release contains breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
 - Upgraded tablib version (`1627 <https://github.com/django-import-export/django-import-export/issues/1627>`_)
+- Document overriding formats (`1868 <https://github.com/django-import-export/django-import-export/issues/1868>`_)
 - Consistent queryset creation in ModelAdmin export mixin (`1890 <https://github.com/django-import-export/django-import-export/pull/1890>`_)
 - Deprecated :meth:`~import_export.admin.ExportMixin.get_valid_export_item_pks` in favour of :meth:`~import_export.admin.ExportMixin.get_queryset` (`1890 <https://github.com/django-import-export/django-import-export/pull/1890>`_)
 - Improve deprecation warning for ``ExportViewFormMixin`` to report at point of class definition (`1900 <https://github.com/django-import-export/django-import-export/pull/1900>`_)
@@ -20,12 +21,12 @@ This release contains breaking changes.  Please refer to :doc:`release notes<rel
 - Add support for Django 5.1 (`1926 <https://github.com/django-import-export/django-import-export/issues/1926>`_)
 - Accept numbers using the numeric separators of the current language in number widgets (:meth:`~import_export.widgets.FloatWidget`, :meth:`~import_export.widgets.IntegerWidget`, :meth:`~import_export.widgets.DecimalWidget`) (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
 - Fix v3 regression: handle native types on export to spreadsheet (`1927 <https://github.com/django-import-export/django-import-export/issues/1927>`_)
-- Fix export button displayed on change screen when export permission not assigned (`1942 <https://github.com/django-import-export/django-import-export/issues/1942>`_)
 - Added warning for declared fields excluded from fields whitelist (`1930 <https://github.com/django-import-export/django-import-export/issues/1930>`_)
 - Fix v3 regression: handle native types on export to spreadsheet (`1939 <https://github.com/django-import-export/django-import-export/issues/1939>`_)
+- Fix export button displayed on change screen when export permission not assigned (`1942 <https://github.com/django-import-export/django-import-export/issues/1942>`_)
 - Fix crash for Django 5.1 when rows are skipped (`1944 <https://github.com/django-import-export/django-import-export/issues/1944>`_)
 - Allow callable in dehydrate method (`1950 <https://github.com/django-import-export/django-import-export/issues/1950>`_)
-- Document overriding formats (`1868 <https://github.com/django-import-export/django-import-export/issues/1868>`_)
+- Fix crash when Resource fields declared incorrectly (`1963 <https://github.com/django-import-export/django-import-export/issues/1963>`_)
 
 4.1.1 (2024-07-08)
 ------------------

--- a/import_export/declarative.py
+++ b/import_export/declarative.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections import OrderedDict
 
 from django.apps import apps
@@ -86,7 +87,7 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                     and field_name not in opts.fields
                     and column_name not in opts.fields
                 ):
-                    logger.warning(
+                    warnings.warn(
                         f"ignoring field '{field_name}' because not declared "
                         "in 'fields' whitelist"
                     )

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1046,7 +1046,9 @@ class Resource(metaclass=DeclarativeMetaclass):
         export_order = self.get_export_order()
         for field_name in export_order:
             if field_name in fields_:
-                export_fields.append(self._select_field(field_name))
+                field = self._select_field(field_name)
+                if field is not None:
+                    export_fields.append(field)
         return export_fields
 
     def export_resource(self, instance, selected_fields=None, **kwargs):
@@ -1055,7 +1057,7 @@ class Resource(metaclass=DeclarativeMetaclass):
 
     def get_export_headers(self, selected_fields=None):
         export_fields = self.get_export_fields(selected_fields)
-        return [force_str(field.column_name) for field in export_fields]
+        return [force_str(field.column_name) for field in export_fields if field]
 
     def get_user_visible_fields(self):
         return self.get_import_fields()
@@ -1111,10 +1113,8 @@ class Resource(metaclass=DeclarativeMetaclass):
             if target_field_name == field.column_name:
                 return field
         # it should have been possible to identify the declared field
-        # but raise an error if not
-        raise ValueError(
-            _(f"cannot identify field for export with name '{target_field_name}'")
-        )
+        # but warn if not
+        warn(f"cannot identify field for export with name '{target_field_name}'")
 
     def _get_ordered_field_names(self, order_field):
         """

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -18,7 +18,6 @@ class ChildAdmin(ImportMixin, admin.ModelAdmin):
 
 
 class BookResource(ModelResource):
-    author_email = Field(column_name="Author Email")
 
     class Meta:
         model = Book

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -18,8 +18,10 @@ class ChildAdmin(ImportMixin, admin.ModelAdmin):
 
 
 class BookResource(ModelResource):
+    # author_email = Field(column_name="Author Email")
 
     class Meta:
+        # fields = ("author_name",)
         model = Book
 
     def for_delete(self, row, instance):

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -18,10 +18,8 @@ class ChildAdmin(ImportMixin, admin.ModelAdmin):
 
 
 class BookResource(ModelResource):
-    # author_email = Field(column_name="Author Email")
 
     class Meta:
-        # fields = ("author_name",)
         model = Book
 
     def for_delete(self, row, instance):

--- a/tests/core/admin.py
+++ b/tests/core/admin.py
@@ -18,6 +18,8 @@ class ChildAdmin(ImportMixin, admin.ModelAdmin):
 
 
 class BookResource(ModelResource):
+    author_email = Field(column_name="Author Email")
+
     class Meta:
         model = Book
 

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -503,6 +503,7 @@ class CustomColumnNameExportTest(AdminTestMixin, TestCase):
         self.book = Book.objects.create(
             name="Moonraker", author=self.author, published=date(1955, 4, 5)
         )
+        self.orig_fields = EBookResource._meta.fields
         EBookResource._meta.fields = (
             "id",
             "author_email",
@@ -513,7 +514,7 @@ class CustomColumnNameExportTest(AdminTestMixin, TestCase):
 
     def tearDown(self):
         super().tearDown()
-        EBookResource._meta.fields = ("id", "author_email", "name", "published")
+        EBookResource._meta.fields = self.orig_fields
 
     def test_export_with_custom_field(self):
         data = {
@@ -666,25 +667,18 @@ class DeclaredFieldWithIncorrectNameInFieldsExportTest(AdminTestMixin, TestCase)
     issue #1959
     """
 
-    class _BookResource(ModelResource):
-        author_email = Field(column_name="Author Email")
-
-        class Meta:
-            fields = ("a",)
-            model = Book
-
     def setUp(self):
         super().setUp()
         self.author = Author.objects.create(id=11, name="Ian Fleming")
         self.book = Book.objects.create(
             name="Moonraker", author_email="ian@fleming.com", author=self.author
         )
-
+        self.orig_fields = EBookResource._meta.fields
         EBookResource._meta.fields = ("a",)
 
     def tearDown(self):
         super().tearDown()
-        EBookResource._meta.fields = ("id", "author_email", "name", "published")
+        EBookResource._meta.fields = self.orig_fields
 
     def test_export_with_declared_author_email_field(self):
         data = {

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -574,13 +574,16 @@ class DeclaredFieldWithAttributeExportTest(AdminTestMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.resource = DeclaredFieldWithAttributeExportTest._BookResource()
         self.author = Author.objects.create(id=11, name="Ian Fleming")
         self.book = Book.objects.create(
             name="Moonraker", author=self.author, published=date(1955, 4, 5)
         )
 
-    def test_export_with_declared_author_name_field(self):
+    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
+    def test_export_with_declared_author_name_field(
+        self, mock_choose_export_resource_class
+    ):
+        mock_choose_export_resource_class.return_value = self._BookResource
         data = {
             "format": "0",
             "resource": "0",
@@ -607,13 +610,16 @@ class DeclaredFieldWithAttributeAndFieldsExportTest(AdminTestMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.resource = DeclaredFieldWithAttributeAndFieldsExportTest._BookResource()
         self.author = Author.objects.create(id=11, name="Ian Fleming")
         self.book = Book.objects.create(
             name="Moonraker", author=self.author, published=date(1955, 4, 5)
         )
 
-    def test_export_with_declared_author_name_field(self):
+    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
+    def test_export_with_declared_author_name_field(
+        self, mock_choose_export_resource_class
+    ):
+        mock_choose_export_resource_class.return_value = self._BookResource
         data = {
             "format": "0",
             "resource": "0",
@@ -638,12 +644,15 @@ class DeclaredFieldWithNoAttributeExportTest(AdminTestMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.resource = DeclaredFieldWithAttributeExportTest._BookResource()
         self.book = Book.objects.create(
             name="Moonraker", author_email="ian@fleming.com"
         )
 
-    def test_export_with_declared_author_email_field(self):
+    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
+    def test_export_with_declared_author_email_field(
+        self, mock_choose_export_resource_class
+    ):
+        mock_choose_export_resource_class.return_value = self._BookResource
         data = {"format": "0", "resource": "0", "bookresource_author_email": True}
         response = self._post_url_response(self.book_export_url, data)
         s = "Author Email\r\nian@fleming.com\r\n"

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -694,7 +694,7 @@ class DeclaredFieldWithIncorrectNameInFieldsExportTest(AdminTestMixin, TestCase)
                 "cannot identify field for export with name 'a'",
                 str(w.warnings[-1].message),
             )
-        s = "id\r\n1\r\n"
+        s = f"id\r\n{self.book.id}\r\n"
         self.assertEqual(s, response.content.decode())
 
 

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -630,6 +630,34 @@ class DeclaredFieldWithAttributeAndFieldsExportTest(AdminTestMixin, TestCase):
         self.assertEqual(s, response.content.decode())
 
 
+class DeclaredFieldWithNoAttributeExportTest(AdminTestMixin, TestCase):
+    """
+    If a custom field is declared with no attribute the field should be skipped.
+    """
+
+    class _BookResource(ModelResource):
+        author_email = Field(column_name="Author Email")
+
+        class Meta:
+            model = Book
+
+    def setUp(self):
+        super().setUp()
+        self.book = Book.objects.create(
+            name="Moonraker", author_email="ian@fleming.com"
+        )
+
+    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
+    def test_export_with_declared_author_email_field(
+        self, mock_choose_export_resource_class
+    ):
+        mock_choose_export_resource_class.return_value = self._BookResource
+        data = {"format": "0", "resource": "0", "bookresource_author_email": True}
+        response = self._post_url_response(self.book_export_url, data)
+        s = 'Author Email\r\n""\r\n'
+        self.assertEqual(s, response.content.decode())
+
+
 class FilteredExportTest(AdminTestMixin, TestCase):
     """
     Tests that exports can be filtered by a custom form field.

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -561,9 +561,9 @@ class CustomColumnNameExportTest(AdminTestMixin, TestCase):
 
 class DeclaredFieldExportTest(AdminTestMixin, TestCase):
     """
-    If a custom field is declared, export should work if either the Field's
+    If a custom field is declared, export should work
     if no `fields` declaration is present.
-    issue 1953
+    (issue 1953)
     """
 
     class _BookResource(ModelResource):

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -630,35 +630,6 @@ class DeclaredFieldWithAttributeAndFieldsExportTest(AdminTestMixin, TestCase):
         self.assertEqual(s, response.content.decode())
 
 
-class DeclaredFieldWithNoAttributeExportTest(AdminTestMixin, TestCase):
-    """
-    If a custom field is declared, with no attribute, the Resource attribute should be
-    used. (issue 1960)
-    """
-
-    class _BookResource(ModelResource):
-        author_email = Field(column_name="Author Email")
-
-        class Meta:
-            model = Book
-
-    def setUp(self):
-        super().setUp()
-        self.book = Book.objects.create(
-            name="Moonraker", author_email="ian@fleming.com"
-        )
-
-    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
-    def test_export_with_declared_author_email_field(
-        self, mock_choose_export_resource_class
-    ):
-        mock_choose_export_resource_class.return_value = self._BookResource
-        data = {"format": "0", "resource": "0", "bookresource_author_email": True}
-        response = self._post_url_response(self.book_export_url, data)
-        s = "Author Email\r\nian@fleming.com\r\n"
-        self.assertEqual(s, response.content.decode())
-
-
 class FilteredExportTest(AdminTestMixin, TestCase):
     """
     Tests that exports can be filtered by a custom form field.

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -1,4 +1,3 @@
-import warnings
 from datetime import date, datetime
 from io import BytesIO
 from unittest import mock
@@ -695,11 +694,11 @@ class DeclaredFieldWithIncorrectNameInFieldsExportTest(AdminTestMixin, TestCase)
             "ebookresource_a": True,
             "author": self.author.id,
         }
-        with warnings.catch_warnings(record=True, category=UserWarning) as w:
+        with self.assertWarns(UserWarning) as w:
             response = self._post_url_response(self.ebook_export_url, data)
-            self.assertEqual(1, len(w))
             self.assertEqual(
-                "cannot identify field for export with name 'a'", str(w[-1].message)
+                "cannot identify field for export with name 'a'",
+                str(w.warnings[-1].message),
             )
         s = "id\r\n1\r\n"
         self.assertEqual(s, response.content.decode())

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -632,7 +632,8 @@ class DeclaredFieldWithAttributeAndFieldsExportTest(AdminTestMixin, TestCase):
 
 class DeclaredFieldWithNoAttributeExportTest(AdminTestMixin, TestCase):
     """
-    If a custom field is declared with no attribute the field should be skipped.
+    If a custom field is declared with no attribute the field will be present
+    but with an empty string.
     """
 
     class _BookResource(ModelResource):

--- a/tests/core/tests/test_resources/test_modelresource/test_export.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_export.py
@@ -117,8 +117,3 @@ class ExportFunctionalityTest(TestCase):
         self.book.save()
         dataset = resource.export()
         self.assertEqual("Ian Fleming", dataset.dict[0]["Author Name"])
-
-    def test_select_field_raises_ValueError(self):
-        r = "cannot identify field for export with name 'unknown'"
-        with self.assertRaisesRegex(ValueError, r):
-            self.resource._select_field("unknown")

--- a/tests/core/tests/test_resources/test_modelresource/test_resource_fields.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_resource_fields.py
@@ -1,8 +1,13 @@
+import warnings
+
 import tablib
 from core.models import Book
 from django.test import TestCase
 
 from import_export import fields, resources
+
+# ignore warnings which result from invalid field declaration (#1930)
+warnings.simplefilter("ignore")
 
 
 class ModelResourceFieldDeclarations(TestCase):
@@ -16,6 +21,7 @@ class ModelResourceFieldDeclarations(TestCase):
             fields = ("id", "price")
 
     def setUp(self):
+
         self.book = Book.objects.create(name="Moonraker", price=".99")
         self.resource = ModelResourceFieldDeclarations.MyBookResource()
 


### PR DESCRIPTION
**Problem**

Closes #1959

**Solution**

- Now a `warning` is issued rather than raising a `ValueError`
- Also updated log warning in `declarative.py` to warning (as per [this comment](https://github.com/django-import-export/django-import-export/pull/1930/files#r1704297805))

**Acceptance Criteria**

- Added tests