### PR TITLE
Django import export guru

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ Help and support
 * Become a `sponsor <https://github.com/sponsors/django-import-export>`_
 * `Raise a security issue <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_
 * Join our `discord <https://discord.gg/aCcec52kY4>`_
-* Ask `Django Import Export Guru <hhttps://gurubase.io/g/django-import-export)>`_
+* Ask `Django Import Export Guru <hhttps://gurubase.io/g/django-import-export>`_
 
 Commercial support
 ==================

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,11 @@ django-import-export
 .. |discord|  image:: https://img.shields.io/discord/1240294048653119508?style=flat
    :alt: Discord
 
-|build| |coveralls| |pypi| |docs| |pyver| |djangover| |downloads| |xfollow| |discord|
+.. |gurubase|  image:: https://img.shields.io/badge/Gurubase-Ask%20Django%20Import%20Export%20Guru-006BFF
+   :alt: Gurubase
+   :target: https://gurubase.io/g/django-import-export
+
+|build| |coveralls| |pypi| |docs| |pyver| |djangover| |downloads| |xfollow| |discord| |gurubase|
 
 Introduction
 ============
@@ -114,6 +118,7 @@ Help and support
 * Become a `sponsor <https://github.com/sponsors/django-import-export>`_
 * `Raise a security issue <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_
 * Join our `discord <https://discord.gg/aCcec52kY4>`_
+* Ask `Django Import Export Guru <hhttps://gurubase.io/g/django-import-export)>`_
 
 Commercial support
 ==================

--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ Help and support
 * Become a `sponsor <https://github.com/sponsors/django-import-export>`_
 * `Raise a security issue <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_
 * Join our `discord <https://discord.gg/aCcec52kY4>`_
-* Ask `Django Import Export Guru <https://gurubase.io/g/django-import-export>`_
+* `Ask Django Import Export Guru <https://gurubase.io/g/django-import-export>`_
 
 Commercial support
 ==================

--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ Help and support
 * Become a `sponsor <https://github.com/sponsors/django-import-export>`_
 * `Raise a security issue <https://github.com/django-import-export/django-import-export/blob/main/SECURITY.md>`_
 * Join our `discord <https://discord.gg/aCcec52kY4>`_
-* Ask `Django Import Export Guru <hhttps://gurubase.io/g/django-import-export>`_
+* Ask `Django Import Export Guru <https://gurubase.io/g/django-import-export>`_
 
 Commercial support
 ==================


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Django Import Export Guru](https://gurubase.io/g/django-import-export) to Gurubase. Django Import Export Guru uses the data from this repo and data from the [docs](https://django-import-export.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Django Import Export Guru", which highlights that Django Import Export now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Django Import Export Guru in Gurubase, just let me know that's totally fine.