### PR TITLE
fixed pip install docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ install-base-requirements: ## install package requirements
 	pip install .
 
 install-test-requirements: ## install requirements for testing
-	pip install .[tests]
+	pip install '.[tests]'
 
 install-docs-requirements:  ## install requirements for docs
-	pip install --editable .[docs]
+	pip install --editable '.[docs]'
 
 install-requirements: install-base-requirements install-test-requirements install-docs-requirements
 

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ install-base-requirements: ## install package requirements
 	pip install .
 
 install-test-requirements: ## install requirements for testing
-	pip install '.[tests]'
+	pip install .[tests]
 
 install-docs-requirements:  ## install requirements for docs
-	pip install --editable '.[docs]'
+	pip install --editable .[docs]
 
 install-requirements: install-base-requirements install-test-requirements install-docs-requirements
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     If upgrading from v3, v4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.3.0 (unreleased)
+------------------
+
+- Removed dependency files in favour of ``pyproject.toml`` (`1982 <https://github.com/django-import-export/django-import-export/issues/1982>`_)
+
 4.2.0 (2024-10-23)
 ------------------
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -51,7 +51,7 @@ Bulk testing
 There is a helper script available to generate and profile bulk loads.  See ``scripts/bulk_import.py``.
 
 You can use this script by configuring environment variables as defined above, and then installing and running the test
-application.  In order to run the helper script, you will need to install ``pip install .[tests]``, and then add
+application.  In order to run the helper script, you will need to install ``pip install '.[tests]'``, and then add
 `django-extensions` to `settings.py` (`INSTALLED_APPS`).
 
 You can then run the script as follows:

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -51,7 +51,7 @@ Bulk testing
 There is a helper script available to generate and profile bulk loads.  See ``scripts/bulk_import.py``.
 
 You can use this script by configuring environment variables as defined above, and then installing and running the test
-application.  In order to run the helper script, you will need to install ``pip install '.[tests]'``, and then add
+application.  In order to run the helper script, you will need to install ``make install-test-requirements``, and then add
 `django-extensions` to `settings.py` (`INSTALLED_APPS`).
 
 You can then run the script as follows:


### PR DESCRIPTION
**Problem**

Last commit to main specified incorrect format for `pip install`.
This PR corrects it.

