### PR TITLE
Chore: improve logging for debugging purposes

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -780,7 +780,7 @@ class Resource(metaclass=DeclarativeMetaclass):
             # There is no point logging a transaction error for each row
             # when only the original error is likely to be relevant
             if not isinstance(e, TransactionManagementError):
-                logger.warning(e, exc_info=True)
+                logger.debug(e, exc_info=True)
             row_result.errors.append(
                 self.get_error_result_class()(e, row=row, number=kwargs["row_number"])
             )

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -780,7 +780,7 @@ class Resource(metaclass=DeclarativeMetaclass):
             # There is no point logging a transaction error for each row
             # when only the original error is likely to be relevant
             if not isinstance(e, TransactionManagementError):
-                logger.debug(e, exc_info=e)
+                logger.warning(e, exc_info=True)
             row_result.errors.append(
                 self.get_error_result_class()(e, row=row, number=kwargs["row_number"])
             )


### PR DESCRIPTION
When tryin to fix tests or see why the import does not work, i usually get a cryptic error message not pointing to the part of the code that failed. It just gives the exception but not where it comes from. By adding exc_info=True, the traceback is visible and its much easier to debug. Also i think warning level should be used instead of debug for these import errors

**Problem**

What problem have you solved?

**Solution**

How did you solve the problem?

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 