### PR TITLE
Extend "Using celery" section in docs

### DIFF
--- a/docs/celery.rst
+++ b/docs/celery.rst
@@ -4,5 +4,7 @@
 Using celery
 ===========
 
-You can use the 3rd party `django-import-export-celery <https://github.com/auto-mat/django-import-export-celery>`_
-application to process long imports and exports in celery.
+You can use one of the third-party applications to process long imports and exports in Celery:
+
+* `django-import-export-celery <https://github.com/auto-mat/django-import-export-celery>`_ (`PyPI <https://pypi.org/project/django-import-export-celery>`_)
+* `django-import-export-extensions <https://github.com/saritasa-nest/django-import-export-extensions>`_ (`PyPI <https://pypi.org/project/django-import-export-extensions>`_)


### PR DESCRIPTION
**Problem**

Run import/export in background

**Solution**

Extend `django-import-export` in another open-source package

**Acceptance Criteria**

> Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 

There are only changes of documentation

---

Hi everyone!

This package is great, but we often needed the functionality of background tasks. So, we decided to extend `django-import-export` to support Celery. Along the way, we added several additional features.

Now, we’re excited to share it with the community! I think it would be helpful to include a link to another solution that provides Celery integration.