### PR TITLE
Fix crash when exporting tz-aware datetime instances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 
 - Removed dependency files in favour of ``pyproject.toml`` (`1982 <https://github.com/django-import-export/django-import-export/issues/1982>`_)
 - Documentation updates (`1989 <https://github.com/django-import-export/django-import-export/issues/1989>`_)
+- Fix crash on export of tz-aware datetime to binary formats (`1995 <https://github.com/django-import-export/django-import-export/issues/1995>`_)
 
 4.2.0 (2024-10-23)
 ------------------

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -713,6 +713,7 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             request,
             queryset,
             force_native_type=force_native_type,
+            file_format=type(file_format),
             **kwargs,
         )
         export_data = file_format.export_data(data)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -713,7 +713,6 @@ class ExportMixin(BaseExportMixin, ImportExportMixinBase):
             request,
             queryset,
             force_native_type=force_native_type,
-            file_format=type(file_format),
             **kwargs,
         )
         export_data = file_format.export_data(data)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -15,6 +15,7 @@ from django.utils.formats import number_format, sanitize_separators
 from django.utils.translation import gettext_lazy as _
 
 from import_export.exceptions import WidgetError
+from import_export.formats.base_formats import XLS, XLSX
 
 logger = logging.getLogger(__name__)
 
@@ -308,7 +309,11 @@ class DateTimeWidget(_ParseDateTimeMixin, Widget):
     def render(self, value, obj=None, **kwargs):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string is False or kwargs.get("force_native_type"):
-            return value
+            return (
+                value.replace(tzinfo=None)
+                if kwargs.get("file_format") in [XLS, XLSX]
+                else value
+            )
         if not value or not isinstance(value, datetime):
             return ""
         if settings.USE_TZ:

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -307,10 +307,9 @@ class DateTimeWidget(_ParseDateTimeMixin, Widget):
 
     def render(self, value, obj=None, **kwargs):
         self._obj_deprecation_warning(obj)
-        if self.coerce_to_string is False or kwargs.get("force_native_type"):
-            return (
-                value.replace(tzinfo=None) if kwargs.get("force_native_type") else value
-            )
+        force_native_type = kwargs.get("force_native_type")
+        if self.coerce_to_string is False or force_native_type:
+            return value.replace(tzinfo=None) if force_native_type else value
         if not value or not isinstance(value, datetime):
             return ""
         if settings.USE_TZ:

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -15,7 +15,6 @@ from django.utils.formats import number_format, sanitize_separators
 from django.utils.translation import gettext_lazy as _
 
 from import_export.exceptions import WidgetError
-from import_export.formats.base_formats import XLS, XLSX
 
 logger = logging.getLogger(__name__)
 
@@ -310,9 +309,7 @@ class DateTimeWidget(_ParseDateTimeMixin, Widget):
         self._obj_deprecation_warning(obj)
         if self.coerce_to_string is False or kwargs.get("force_native_type"):
             return (
-                value.replace(tzinfo=None)
-                if kwargs.get("file_format") in [XLS, XLSX]
-                else value
+                value.replace(tzinfo=None) if kwargs.get("force_native_type") else value
             )
         if not value or not isinstance(value, datetime):
             return ""

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -864,3 +864,18 @@ class ExportTzAwareDateTest(AdminTestMixin, TestCase):
         }
         response = self.client.post(self.book_export_url, data)
         self.assertEqual(response.status_code, 200)
+
+    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
+    def test_datetime_export_ods(self, mock_choose_export_resource_class):
+        mock_choose_export_resource_class.return_value = self.BookResource_
+        date_added = datetime(2024, 11, 8, 14, 40, tzinfo=ZoneInfo("UTC"))
+        Book.objects.create(id=101, name="Moonraker", added=date_added)
+
+        data = {
+            "format": "4",
+            "bookresource_id": True,
+            "bookresource_title": True,
+            "bookresource_added": True,
+        }
+        response = self.client.post(self.book_export_url, data)
+        self.assertEqual(response.status_code, 200)

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -822,6 +822,7 @@ class ExportBinaryFieldsTest(AdminTestMixin, TestCase):
         self.assertEqual(datetime(2000, 8, 2), wb.active["C2"].value)
 
 
+@override_settings(USE_TZ=True)
 class ExportTzAwareDateTest(AdminTestMixin, TestCase):
     # issue 1995
     # test that tz aware dates do not crash on export
@@ -831,9 +832,8 @@ class ExportTzAwareDateTest(AdminTestMixin, TestCase):
             model = Book
             fields = ("id", "name", "added")
 
-    @override_settings(USE_TZ=True)
     @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
-    def test_datetime_export(self, mock_choose_export_resource_class):
+    def test_datetime_export_xlsx(self, mock_choose_export_resource_class):
         mock_choose_export_resource_class.return_value = self.BookResource_
         date_added = datetime(2024, 11, 8, 14, 40, tzinfo=ZoneInfo("UTC"))
         Book.objects.create(id=101, name="Moonraker", added=date_added)
@@ -848,6 +848,19 @@ class ExportTzAwareDateTest(AdminTestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         content = response.content
         wb = load_workbook(filename=BytesIO(content))
-        self.assertEqual(101, wb.active["A2"].value)
-        self.assertEqual(True, wb.active["B2"].value)
-        self.assertEqual(datetime(2010, 8, 2), wb.active["C2"].value)
+        self.assertEqual(date_added.replace(tzinfo=None), wb.active["B2"].value)
+
+    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
+    def test_datetime_export_xls(self, mock_choose_export_resource_class):
+        mock_choose_export_resource_class.return_value = self.BookResource_
+        date_added = datetime(2024, 11, 8, 14, 40, tzinfo=ZoneInfo("UTC"))
+        Book.objects.create(id=101, name="Moonraker", added=date_added)
+
+        data = {
+            "format": "1",
+            "bookresource_id": True,
+            "bookresource_title": True,
+            "bookresource_added": True,
+        }
+        response = self.client.post(self.book_export_url, data)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
**Problem**

Closes #1995 

**Solution**

Added check for binary format in `DateTimeWidget` and remove tzinfo if so.

**Acceptance Criteria**

- added tests