### PR TITLE
Added test for empty datetime field

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -308,10 +308,10 @@ class DateTimeWidget(_ParseDateTimeMixin, Widget):
     def render(self, value, obj=None, **kwargs):
         self._obj_deprecation_warning(obj)
         force_native_type = kwargs.get("force_native_type")
-        if self.coerce_to_string is False or force_native_type:
-            return value.replace(tzinfo=None) if force_native_type else value
         if not value or not isinstance(value, datetime):
             return ""
+        if self.coerce_to_string is False or force_native_type:
+            return value.replace(tzinfo=None) if force_native_type else value
         if settings.USE_TZ:
             value = timezone.localtime(value)
         return format_datetime(value, self.formats[0])

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -894,3 +894,6 @@ class ExportTzAwareDateTest(AdminTestMixin, TestCase):
         }
         response = self.client.post(self.book_export_url, data)
         self.assertEqual(response.status_code, 200)
+        content = response.content
+        wb = load_workbook(filename=BytesIO(content))
+        self.assertIsNone(wb.active["B2"].value)

--- a/tests/core/tests/admin_integration/test_export.py
+++ b/tests/core/tests/admin_integration/test_export.py
@@ -879,3 +879,18 @@ class ExportTzAwareDateTest(AdminTestMixin, TestCase):
         }
         response = self.client.post(self.book_export_url, data)
         self.assertEqual(response.status_code, 200)
+
+    @patch("import_export.mixins.BaseExportMixin.choose_export_resource_class")
+    def test_datetime_export_empty_field(self, mock_choose_export_resource_class):
+        mock_choose_export_resource_class.return_value = self.BookResource_
+        date_added = None
+        Book.objects.create(id=101, name="Moonraker", added=date_added)
+
+        data = {
+            "format": "2",
+            "bookresource_id": True,
+            "bookresource_title": True,
+            "bookresource_added": True,
+        }
+        response = self.client.post(self.book_export_url, data)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
**Problem**

Closes #1995 

**Solution**

Move check so that empty fields (None) are handled before datetime update logic.

**Acceptance Criteria**

- Added test
- Manual testing