### PR TITLE
Add __repr__ method to InvalidRow for improved debugging

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,10 +5,11 @@ Changelog
 
     If upgrading from v3, v4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
-4.2.2 (2024-11-18)
+4.2.2 (unreleased)
 ------------------
 
 - Handle ``IllegalCharacterError`` in xlsx exports `(`2001 <https://github.com/django-import-export/django-import-export/issues/2001>`_)
+- Add ``__repr__`` method to InvalidRow for improved debugging `(`2003 <https://github.com/django-import-export/django-import-export/issues/2003>`_)
 
 4.2.1 (2024-11-11)
 ------------------

--- a/import_export/results.py
+++ b/import_export/results.py
@@ -176,6 +176,13 @@ class InvalidRow:
             count += len(error_list)
         return count
 
+    def __repr__(self):
+        return (
+            f"<{type(self).__name__}(row={self.number}, "
+            f"error={self.error!r}, "
+            f"error_count={self.error_count})>"
+        )
+
 
 class ErrorRow:
     """A row that resulted in one or more errors being raised during import."""

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -52,7 +52,8 @@ class InvalidRowTest(SimpleTestCase):
 
         self.assertEqual(
             repr(error),
-            "<InvalidRow(row=1, error=ValidationError(['invalid row']), error_count=1)>",
+            "<InvalidRow(row=1, error=ValidationError(['invalid row']),"
+            " error_count=1)>",
         )
 
 

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from tablib import Dataset
 
-from import_export.results import Error, Result, RowResult, InvalidRow
+from import_export.results import Error, InvalidRow, Result, RowResult
 
 
 class ErrorTest(SimpleTestCase):
@@ -46,11 +46,13 @@ class ErrorTest(SimpleTestCase):
 class InvalidRowTest(SimpleTestCase):
     def test_repr(self):
         try:
-            raise ValidationError(message='invalid row')
+            raise ValidationError(message="invalid row")
         except ValidationError as exc:
             error = InvalidRow(validation_error=exc, number=1, values={})
 
-        self.assertEqual(repr(error), "<InvalidRow(row=1, error='invalid row', error_count=1)>")
+        self.assertEqual(
+            repr(error), "<InvalidRow(row=1, error='invalid row', error_count=1)>"
+        )
 
 
 class ResultTest(SimpleTestCase):

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from tablib import Dataset
 
-from import_export.results import Error, Result, RowResult
+from import_export.results import Error, Result, RowResult, InvalidRow
 
 
 class ErrorTest(SimpleTestCase):
@@ -41,6 +41,16 @@ class ErrorTest(SimpleTestCase):
             "ZeroDivisionError: division by zero\n",
             error.traceback,
         )
+
+
+class InvalidRowTest(SimpleTestCase):
+    def test_repr(self):
+        try:
+            raise ValidationError(message='invalid row')
+        except ValidationError as exc:
+            error = InvalidRow(validation_error=exc, number=1, values={})
+
+        self.assertEqual(repr(error), "<InvalidRow(row=1, error='invalid row', error_count=1)>")
 
 
 class ResultTest(SimpleTestCase):

--- a/tests/core/tests/test_results.py
+++ b/tests/core/tests/test_results.py
@@ -51,7 +51,8 @@ class InvalidRowTest(SimpleTestCase):
             error = InvalidRow(validation_error=exc, number=1, values={})
 
         self.assertEqual(
-            repr(error), "<InvalidRow(row=1, error='invalid row', error_count=1)>"
+            repr(error),
+            "<InvalidRow(row=1, error=ValidationError(['invalid row']), error_count=1)>",
         )
 
 


### PR DESCRIPTION
**Problem**

What problem have you solved?
This commit introduces a `__repr__` method for InvalidRow, allowing exceptions to be more easily inspected during debugging.

**Solution**
Adding `__repr__` method :shrug: 

How did you solve the problem?

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 