### PR TITLE
Update pyupgrade args from Python 3.8 to 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v3.19.0
     hooks:
     - id: pyupgrade
-      args: [--py38-plus]
+      args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.10.0
     hooks:

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -1,7 +1,7 @@
 import os.path
+from collections.abc import Iterable
 from copy import deepcopy
 from itertools import chain
-from typing import Iterable
 
 from django import forms
 from django.conf import settings


### PR DESCRIPTION
**Problem**

This package is using Python 3.9, but pyupgrade's target version is set to 3.8+

**Solution**

as per title