### PR TITLE
Use stacklevel=2 for declarative field warning

### DIFF
--- a/import_export/declarative.py
+++ b/import_export/declarative.py
@@ -89,7 +89,8 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                 ):
                     warnings.warn(
                         f"ignoring field '{field_name}' because not declared "
-                        "in 'fields' whitelist"
+                        "in 'fields' whitelist",
+                        stacklevel=2,
                     )
                     continue
                 declared_fields[field_name] = field


### PR DESCRIPTION
**Problem**

The warning shows up in `declarative.py`, not the user code.

**Solution**

Use `stacklevel=2` to skip out of the `__new__` method to the class declaration.

See https://www.youtube.com/watch?v=CtFdXBEwYfk for an explanation.

Install flake8-bugbear for [its B028 rule](https://github.com/PyCQA/flake8-bugbear?tab=readme-ov-file#list-of-warnings) to catch this in the future.

**Acceptance Criteria**

I edited my local install like this in order to fix the warnings after upgrading 4.1.1 -> 4.3.3.