### PR TITLE
Update 'Creating non-existent relations' documentation

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -537,7 +537,7 @@ Then if the import was being called from another module, we would pass the ``pub
 
     >>> resource = BookResource(publisher_id=1)
 
-If you need to pass dynamic values to the Resource from an `Admin integration`_, refer to
+If you need to pass dynamic values to the Resource when importing via the Admin UI, refer to
 See :ref:`dynamically_set_resource_values`.
 
 Django Natural Keys

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -440,7 +440,7 @@ table using the field value will return exactly one result.
 This is implemented as a ``Model.objects.get()`` query, so if the instance in not uniquely identifiable based on the
 given arg, then the import process will raise either ``DoesNotExist`` or ``MultipleObjectsReturned`` errors.
 
-See also :ref:`advanced_usage:Creating non existent relations`.
+See also :ref:`creating-non-existent-relations`.
 
 Refer to the :class:`~.ForeignKeyWidget` documentation for more detailed information.
 
@@ -476,6 +476,8 @@ declaration.
 
         class Meta:
             model = Book
+
+.. _creating-non-existent-relations:
 
 Creating non-existent relations
 -------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -182,7 +182,7 @@ See `this issue <https://github.com/django-import-export/django-import-export/is
 How to create relation during import if it does not exist
 ---------------------------------------------------------
 
-See :ref:`advanced_usage:Creating non existent relations`.
+See :ref:`creating-non-existent-relations`.
 
 How to handle large file uploads
 ---------------------------------


### PR DESCRIPTION
**Problem**

It looks like there is an error in the documentation do with handling non-existent relations during import.

The docs [here](https://django-import-export.readthedocs.io/en/4.3.4/advanced_usage.html#creating-non-existent-relations) describe creating non-existent relations by overriding `before_import_row()` and creating relations there.  

However the flaw in this is that although it will create the relations, it will not associate the relations with the instance being imported.

It would work if the `id` was in the dataset:

```python
    def before_import_row(self, row, **kwargs):
        author_id = row["author"]
        Author.objects.get_or_create(id=author_id, name="J. R. R. Tolkien")
```

But this is not what is currently documented, and it is quite difficult to understand exactly what is going on.

A better solution might be to override `after_init_instance()`, because then you can create the relation *and* assign it to the instance.  However this is sub-optimal because if the import dataset relation field has the same name, then the instance relation will be over-written when the field is read later in the import process.

For example, this will crash because the `author` field (a FK relation) gets overwritten with 'J. R. R. Tolkien' and crashes:

```python
class BookResource(resources.ModelResource):
    def after_init_instance(self, instance, new, row, **kwargs):
        author_name = row["author"]
        instance.author, created = Author.objects.get_or_create(name=author_name)

    class Meta:
        model = Book

def main():
    rows = [
        (3, "Lord of the Rings", "J. R. R. Tolkien"),
    ]
    dataset = tablib.Dataset(*rows, headers=["id", "name", "author"])
    resource = BookResource()
    result = resource.import_data(dataset, collect_failed_rows=False, raise_errors=True)
    print(result)

if __name__ == "__main__":
    main()
```

```
import_export.exceptions.ImportError: 1: {'author_id': ["Field 'id' expected a number but got 'J. R. R. Tolkien'."]}
```

**Solution**

Re-wrote the documentation to use a preferred method, which is to override `ForeignKeyWidget.clean()`.  This overcomes the limitations described here.

**Acceptance Criteria**

No code changes.  Checked docs locally.

[Related SO issue](https://stackoverflow.com/a/79403936/39296).