### PR TITLE
Update pyupgrade target version to 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v3.19.1
     hooks:
     - id: pyupgrade
-      args: [--py38-plus]
+      args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:

--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -1,7 +1,7 @@
 import os.path
+from collections.abc import Iterable
 from copy import deepcopy
 from itertools import chain
-from typing import Iterable
 
 from django import forms
 from django.conf import settings


### PR DESCRIPTION
**Problem**

Make pyupgrade upgrade source to Python 3.9+ syntax.

**Solution**

Updated target version. (This was missed when Python 3.8 was dropped in #1979.)

**Acceptance Criteria**

`pre-commit run pyupgrade --all-files` made one change, an import update, included in this commit.