### PR TITLE
Improve logic of bulk create, update and create methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -160,3 +160,4 @@ The following is a list of much appreciated contributors:
 * dahvo (David Mark Awad)
 * jurrian
 * merwok
+* rodolvbg (Rodolfo Becerra)


### PR DESCRIPTION
**Problem**

The previous implementation of `bulk_create`, `bulk_update`, `bulk_delete` had redundant conditional checks that could be simplified. Specifically, the nested condition:
```python
if len(self.instances) > 0:
    if not using_transactions and dry_run:
        pass
````
could be merged into a more concise, readable statement. The existing logic was unnecessarily verbose and harder to maintain, especially as similar conditions appear elsewhere in the codebase.


**Solution**

I simplified the conditional logic by combining the checks into a single if statement and move the try except inside the if:
```python
if len(self.instances) > 0 and (using_transactions or not dry_run):
    try:
        ....
```
This improves readability by removing unnecessary nesting while maintaining the original logic. Also execute the try/except only if the condition is True. The condition still ensures that methods are only executed when:
- There are instances.
- Either transactions are being used, or it’s not a dry run.

This refactor makes the code cleaner, easier to understand, and reduces redundancy.


**Acceptance Criteria**
- Tests written: No changes to logic or functionality were made, so existing tests remain valid and should cover this refactor. If required, I can add tests specifically for verifying the conditions.
- Screenshots: Not applicable, as this is a backend logic update without any UI changes.
- Documentation: Since this change is purely internal and does not affect public APIs or usage, no documentation updates were necessary.