### PR TITLE
Fix TypeError saving calling LogEntry.objects.log_actions()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
     If upgrading from v3, v4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.3.8 (unreleased)
+------------------
+
+- Fix `TypeError` calling `log_actions()` on Django 5.1.7+ (`2045 <https://github.com/django-import-export/django-import-export/pull/2045>`_)
+
 4.3.7 (2025-02-25)
 ------------------
 

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -593,12 +593,19 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
 
     def _create_log_entry(self, user_pk, rows, import_type, action_flag):
         if len(rows) > 0:
+            kwargs = {}
+            if (
+                django.VERSION < (5, 1, 7)
+                or django.VERSION[:4] == (5, 2, 0, "alpha")
+                or django.VERSION[:5] == (5, 2, 0, "beta", 1)
+            ):
+                kwargs["single_object"] = len(rows) == 1
             LogEntry.objects.log_actions(
                 user_pk,
                 rows,
                 action_flag,
                 change_message=_("%s through import_export" % import_type),
-                single_object=len(rows) == 1,
+                **kwargs,
             )
 
 


### PR DESCRIPTION
**Problem**

Fix this error on Django 5.1.7:

```
  File "/.../import_export/admin.py", line 596, in _create_log_entry
    LogEntry.objects.log_actions(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        user_pk,
        ^^^^^^^^
    ...<3 lines>...
        single_object=len(rows) == 1,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: LogEntryManager.log_actions() got an unexpected keyword argument 'single_object'
```

This is caused by Django 5.1.7 making a backwards-incompatible change to `log_actions()`, dropping the `single_object` argument, for [Ticket #36217](https://code.djangoproject.com/ticket/36217) in https://github.com/django/django/pull/19214 . The fix here conditionally passes that argument on versions where it is required.

**Solution**

See above.

**Acceptance Criteria**

Tests failed locally before with just `tox -e py313-django51`, and pass after.