### PR TITLE
Fix typo in contributing Guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -165,7 +165,7 @@ Once you have cloned and checked out the repository, you can install a new devel
 
   python -m venv django-import-export-venv
   source django-import-export-venv/bin/activate
-  pip install .[tests]
+  python -m pip install '.[tests]'
 
 Run tests
 ^^^^^^^^^
@@ -179,7 +179,7 @@ Build documentation
 
 To build a local version of the documentation::
 
-  pip install -r requirements/docs.txt
+  python -m pip install -r requirements/docs.txt
   make build-html-doc
 
 The documentation will be present in ``docs/_build/html/index.html``.


### PR DESCRIPTION
Update the instructions for installing optional dependencies in the contributing guide.

`pip install .[tests]` didn't work.

I also added `python -m` in front of the `pip install ..` commands, because this is a better way to invoke pip, and also because you already have other examples using `python -m `.

**Problem**

I tried following the steps for running tests locally from the contributing guide.
I found the step `pip install .[tests]` doesn't work.

**Solution**

`pip install '.[tests]'` works.

**Acceptance Criteria**

I tried using pip 25.0.1..
```
pip install .[tests]            
zsh: no matches found: .[tests]
```

```
pip install '.[tests]'
Processing /Users/mariatta/github/django-import-export
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
```