### PR TITLE
Fix error display twice issue on export field select page

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -162,3 +162,4 @@ The following is a list of much appreciated contributors:
 * merwok
 * rodolvbg (Rodolfo Becerra)
 * Andy Zickler
+* kuldeepkhatke (Kuldeep Khatke)

--- a/import_export/templates/admin/import_export/export.html
+++ b/import_export/templates/admin/import_export/export.html
@@ -13,9 +13,6 @@
 {% endblock %}
 
 {% block content %}
-{% if form.errors %}
-  {{ form.errors }}
-{% endif %}
 <form action="{{ export_url }}" method="POST">
   {% csrf_token %}
     {# export request has originated from an Admin UI action #}


### PR DESCRIPTION
**Problem**

Fixes #2065

**Solution**

How did you solve the problem?
Removed errors to display on top as form.errors. 
as field errors & non field errors display code is already written.
Such that no need of extra form.errors

**Acceptance Criteria**

After fix only single error msg showing properly
![image](https://github.com/user-attachments/assets/73ae3fff-4cdf-484b-941d-5bdb451cbd4a)
