### PR TITLE
Allow specifying meta options in the modelresource_factory, fixing #20177

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1370,11 +1370,13 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         return cls.__name__
 
 
-def modelresource_factory(model, resource_class=ModelResource):
+def modelresource_factory(model, resource_class=ModelResource, meta_options=None):
     """
     Factory for creating ``ModelResource`` class for given Django model.
     """
-    attrs = {"model": model}
+    if meta_options is None:
+        meta_options = {}
+    attrs = {**meta_options, "model": model}
     Meta = type("Meta", (object,), attrs)
 
     class_name = model.__name__ + "Resource"

--- a/tests/core/tests/test_resources/test_modelresource/test_resource_factory.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_resource_factory.py
@@ -9,3 +9,9 @@ class ModelResourceFactoryTest(TestCase):
         BookResource = resources.modelresource_factory(Book)
         self.assertIn("id", BookResource.fields)
         self.assertEqual(BookResource._meta.model, Book)
+
+    def test_create_with_meta(self):
+        BookResource = resources.modelresource_factory(
+            Book, meta_options={"clean_model_instances": True}
+        )
+        self.assertEqual(BookResource._meta.clean_model_instances, True)


### PR DESCRIPTION
**Problem**

The `modelresource_factory` is not very customizable w.r.t. meta items.

**Solution**

By adding a parameter, one can inject extra data into the `Meta`.

**Acceptance Criteria**

written a test for this.