### PR TITLE
Allow custom fields and methods in modelresource_factory

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,7 +122,7 @@ The following is a list of much appreciated contributors:
 * josx (José Luis Di Biase)
 * Jan Rydzewski
 * rpsands (Ryan P. Sands)
-* 2ykwang (Yeongkwang Yang)
+* 2ykwang (Youngkwang Yang)
 * KamilRizatdinov (Kamil Rizatdinov)
 * Mark Walker
 * shimakaze-git

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -239,6 +239,8 @@ value changes::
   * The ``original`` attribute will be null if :attr:`~import_export.options.ResourceOptions.skip_diff` is True.
   * The ``instance`` attribute will be null if :attr:`~import_export.options.ResourceOptions.store_instance` is False.
 
+.. _using_modelresource_factory:
+
 Using modelresource_factory
 ==========================
 
@@ -257,7 +259,7 @@ Create a simple resource for export::
     ...     model=Book,
     ...     meta_options={'fields': ('id', 'name', 'author')}
     ... )
-    >>> 
+    >>>
     >>> # Export data
     >>> dataset = BookResource().export()
     >>> print(dataset.csv)
@@ -276,7 +278,7 @@ Import data with custom configuration::
     ...         'import_id_fields': ('name',)
     ...     }
     ... )
-    >>> 
+    >>>
     >>> # Import data
     >>> dataset = tablib.Dataset(['New Book', 'author@example.com'], headers=['name', 'author_email'])
     >>> result = ImportResource().import_data(dataset)
@@ -300,7 +302,7 @@ You can add custom fields and dehydrate methods::
     ...         'custom_title': lambda obj: f"{obj.name} by {obj.author.name if obj.author else 'Unknown'}"
     ...     }
     ... )
-    >>> 
+    >>>
     >>> dataset = BookResource().export()
     >>> print(dataset.csv)
     id,name,custom_title

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -239,6 +239,73 @@ value changes::
   * The ``original`` attribute will be null if :attr:`~import_export.options.ResourceOptions.skip_diff` is True.
   * The ``instance`` attribute will be null if :attr:`~import_export.options.ResourceOptions.store_instance` is False.
 
+Using modelresource_factory
+==========================
+
+The :func:`~import_export.resources.modelresource_factory` function dynamically creates
+``ModelResource`` classes for you. This is useful for creating resources without writing
+custom classes.
+
+Basic usage
+-----------
+
+Create a simple resource for export::
+
+    >>> from import_export import resources
+    >>> from core.models import Book
+    >>> BookResource = resources.modelresource_factory(
+    ...     model=Book,
+    ...     meta_options={'fields': ('id', 'name', 'author')}
+    ... )
+    >>> 
+    >>> # Export data
+    >>> dataset = BookResource().export()
+    >>> print(dataset.csv)
+    id,name,author
+    1,Some book,1
+
+Import data with custom configuration::
+
+    >>> from import_export import resources
+    >>> from core.models import Book
+    >>> # Create a resource for import with specific fields
+    >>> ImportResource = resources.modelresource_factory(
+    ...     model=Book,
+    ...     meta_options={
+    ...         'fields': ('name', 'author_email'),
+    ...         'import_id_fields': ('name',)
+    ...     }
+    ... )
+    >>> 
+    >>> # Import data
+    >>> dataset = tablib.Dataset(['New Book', 'author@example.com'], headers=['name', 'author_email'])
+    >>> result = ImportResource().import_data(dataset)
+    >>> print(result.has_errors())
+    False
+
+Adding custom fields
+-------------------
+
+You can add custom fields and dehydrate methods::
+
+    >>> from import_export import resources, fields
+    >>> from core.models import Book
+    >>> BookResource = resources.modelresource_factory(
+    ...     model=Book,
+    ...     meta_options={'fields': ('id', 'name', 'custom_title')},
+    ...     custom_fields={
+    ...         'custom_title': fields.Field(column_name='Custom Title', readonly=True)
+    ...     },
+    ...     dehydrate_methods={
+    ...         'custom_title': lambda obj: f"{obj.name} by {obj.author.name if obj.author else 'Unknown'}"
+    ...     }
+    ... )
+    >>> 
+    >>> dataset = BookResource().export()
+    >>> print(dataset.csv)
+    id,name,custom_title
+    1,Some book,Some book by Author Name
+
 Validation during import
 ========================
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
     If upgrading from v3, v4 introduces breaking changes.  Please refer to :doc:`release notes<release_notes>`.
 
+4.3.9 (unreleased)
+------------------
+
+- Allow specifying meta options in the :ref:`model_resourcefactory<using_modelresource_factory>` (`2078 <https://github.com/django-import-export/django-import-export/pull/2078>`_)
+- Allow custom fields and methods in :ref:`model_resourcefactory<using_modelresource_factory>` (`2081 <https://github.com/django-import-export/django-import-export/pull/2081>`_)
+
 4.3.8 (2025-06-23)
 ------------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -92,7 +92,8 @@ Let's import some data!
 In the fourth line we use :func:`~import_export.resources.modelresource_factory`
 to create a default :class:`~import_export.resources.ModelResource`.
 The ``ModelResource`` class created this way is equal to the one shown in the
-example in section :ref:`base-modelresource`.
+example in section :ref:`base-modelresource`. For more advanced usage of this function,
+see :ref:`advanced_usage:Using modelresource_factory`.
 
 In fifth line a :class:`~tablib.Dataset` with columns ``id`` and ``name``, and
 one book entry, are created. A field (or combination of fields) which uniquely identifies an instance always needs to

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -93,7 +93,7 @@ In the fourth line we use :func:`~import_export.resources.modelresource_factory`
 to create a default :class:`~import_export.resources.ModelResource`.
 The ``ModelResource`` class created this way is equal to the one shown in the
 example in section :ref:`base-modelresource`. For more advanced usage of this function,
-see :ref:`advanced_usage:Using modelresource_factory`.
+see :ref:`using_modelresource_factory`.
 
 In fifth line a :class:`~tablib.Dataset` with columns ``id`` and ``name``, and
 one book entry, are created. A field (or combination of fields) which uniquely identifies an instance always needs to

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1393,46 +1393,6 @@ def modelresource_factory(
     :param dehydrate_methods: Dictionary mapping field names
                               to dehydrate method (Callable)
 
-    ** Basic Usage: **
-
-    .. code-block:: python
-
-        # Simple resource creation
-        BookResource = modelresource_factory(model=Book)
-
-        # With meta options
-        BookResource = modelresource_factory(
-            model=Book,
-            meta_options={'fields': ('id', 'name'), 'use_bulk': True}
-        )
-
-    ** Usage:**
-
-    .. code-block:: python
-
-        from import_export.fields import Field
-        from import_export.widgets import CharWidget
-
-        # Complex example with multiple features
-        UserResource = modelresource_factory(
-            model=User,
-            meta_options={
-                'fields': ('id', 'username', 'email', 'full_name'),
-                'exclude': ('password',),
-                'widgets': {'email': {'coerce_to_string': True}}
-            },
-            custom_fields={
-                'full_name': Field(
-                    attribute='get_full_name',
-                    column_name='Full Name',
-                    readonly=True
-                )
-            },
-            dehydrate_methods={
-                'full_name': lambda obj: f"{obj.first_name} {obj.last_name}".title()
-            }
-        )
-
     :returns: ModelResource class
     """
 

--- a/tests/core/tests/test_resources/test_modelresource/test_resource_factory.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_resource_factory.py
@@ -1,7 +1,7 @@
-from core.models import Book
+from core.models import Author, Book
 from django.test import TestCase
 
-from import_export import resources
+from import_export import fields, resources, widgets
 
 
 class ModelResourceFactoryTest(TestCase):
@@ -9,6 +9,12 @@ class ModelResourceFactoryTest(TestCase):
         BookResource = resources.modelresource_factory(Book)
         self.assertIn("id", BookResource.fields)
         self.assertEqual(BookResource._meta.model, Book)
+
+    def test_create_with_meta(self):
+        BookResource = resources.modelresource_factory(
+            Book, meta_options={"clean_model_instances": True}
+        )
+        self.assertEqual(BookResource._meta.clean_model_instances, True)
 
     def test_create_with_meta_options(self):
         BookResource = resources.modelresource_factory(
@@ -25,6 +31,160 @@ class ModelResourceFactoryTest(TestCase):
         self.assertEqual(BookResource._meta.exclude, ("imported",))
         self.assertTrue(BookResource._meta.use_bulk)
         self.assertTrue(BookResource._meta.clean_model_instances)
+
+    def test_custom_fields(self):
+        custom_field = fields.Field(column_name="Custom Title", readonly=True)
+
+        BookResource = resources.modelresource_factory(
+            Book, custom_fields={"custom_title": custom_field}
+        )
+
+        self.assertIn("custom_title", BookResource.fields)
+        self.assertEqual(BookResource.fields["custom_title"], custom_field)
+        self.assertEqual(
+            BookResource.fields["custom_title"].column_name, "Custom Title"
+        )
+        self.assertTrue(BookResource.fields["custom_title"].readonly)
+
+    def test_custom_fields_validation(self):
+        with self.assertRaises(ValueError) as cm:
+            resources.modelresource_factory(
+                Book, custom_fields={"invalid_field": "not a field object"}
+            )
+
+        self.assertIn("must be a Field instance", str(cm.exception))
+        self.assertIn("custom_fields['invalid_field']", str(cm.exception))
+
+    def test_dehydrate_methods(self):
+        def custom_dehydrate_custom_title(obj):
+            return f"{obj.name} - Custom"
+
+        BookResource = resources.modelresource_factory(
+            Book,
+            custom_fields={"custom_title": fields.Field(column_name="Custom Title")},
+            dehydrate_methods={"custom_title": custom_dehydrate_custom_title},
+        )
+
+        self.assertTrue(hasattr(BookResource, "dehydrate_custom_title"))
+
+        resource = BookResource()
+        book = Book.objects.create(name="Test Book")
+        result = resource.dehydrate_custom_title(book)
+        self.assertEqual(result, "Test Book - Custom")
+
+    def test_dehydrate_methods_validation(self):
+        with self.assertRaises(ValueError) as cm:
+            resources.modelresource_factory(
+                Book, dehydrate_methods={"field_name": "not callable"}
+            )
+
+        self.assertIn("must be callable", str(cm.exception))
+        self.assertIn("dehydrate_methods['field_name']", str(cm.exception))
+
+    def test_lambda_dehydrate_methods(self):
+        BookResource = resources.modelresource_factory(
+            Book,
+            custom_fields={"custom_title": fields.Field(column_name="Custom Title")},
+            dehydrate_methods={
+                "custom_title": (
+                    lambda obj: (
+                        f"{obj.name} by {getattr(obj.author, 'name', 'Unknown')}"
+                    )
+                )
+            },
+        )
+
+        author = Author.objects.create(name="Test Author")
+        book = Book.objects.create(name="Test Book", author=author)
+
+        resource = BookResource()
+        result = resource.dehydrate_custom_title(book)
+        self.assertEqual(result, "Test Book by Test Author")
+
+        book_no_author = Book.objects.create(name="Book")
+        result = resource.dehydrate_custom_title(book_no_author)
+        self.assertEqual(result, "Book by Unknown")
+
+    def test_comprehensive_example(self):
+        """Test a comprehensive example with multiple features"""
+        BookResource = resources.modelresource_factory(
+            Book,
+            meta_options={
+                "fields": ("id", "name", "author", "custom_title", "status"),
+                "import_id_fields": ("name",),
+                "use_bulk": True,
+            },
+            custom_fields={
+                "custom_title": fields.Field(column_name="Custom Title", readonly=True),
+                "status": fields.Field(
+                    attribute="imported",
+                    column_name="Import Status",
+                    widget=widgets.BooleanWidget(),
+                ),
+            },
+            dehydrate_methods={"custom_title": lambda obj: f"{obj.name} - {obj.pk}"},
+        )
+
+        resource = BookResource()
+
+        self.assertEqual(
+            resource._meta.fields, ("id", "name", "author", "custom_title", "status")
+        )
+        self.assertEqual(resource._meta.import_id_fields, ("name",))
+        self.assertTrue(resource._meta.use_bulk)
+
+        self.assertIn("custom_title", resource.fields)
+        self.assertIn("status", resource.fields)
+        self.assertTrue(resource.fields["custom_title"].readonly)
+
+        self.assertTrue(hasattr(resource, "dehydrate_custom_title"))
+
+        book = Book.objects.create(name="Test Book")
+        custom_title_result = resource.dehydrate_custom_title(book)
+        self.assertEqual(custom_title_result, f"Test Book - {book.pk}")
+
+        dataset = resource.export([book])
+        self.assertEqual(len(dataset), 1)
+
+    def test_field_with_dehydrate_method_attribute(self):
+        BookResource1 = resources.modelresource_factory(
+            Book,
+            custom_fields={
+                "custom_title": fields.Field(
+                    column_name="Custom Title",
+                    dehydrate_method=lambda obj: f"Field method: {obj.name}",
+                )
+            },
+        )
+
+        BookResource2 = resources.modelresource_factory(
+            Book,
+            custom_fields={"custom_title": fields.Field(column_name="Custom Title")},
+            dehydrate_methods={
+                "custom_title": lambda obj: f"Factory method: {obj.name}"
+            },
+        )
+
+        book = Book.objects.create(name="Test Book")
+
+        resource1 = BookResource1()
+        field1 = resource1.fields["custom_title"]
+        self.assertTrue(callable(field1.dehydrate_method))
+
+        resource2 = BookResource2()
+        self.assertTrue(hasattr(resource2, "dehydrate_custom_title"))
+        result2 = resource2.dehydrate_custom_title(book)
+        self.assertEqual(result2, "Factory method: Test Book")
+
+    def test_empty_parameters(self):
+        BookResource = resources.modelresource_factory(
+            Book,
+            custom_fields={},
+            dehydrate_methods={},
+        )
+
+        self.assertIn("id", BookResource.fields)
+        self.assertEqual(BookResource._meta.model, Book)
 
     def test_resource_class_inheritance(self):
         class CustomModelResource(resources.ModelResource):

--- a/tests/core/tests/test_resources/test_modelresource/test_resource_factory.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_resource_factory.py
@@ -10,8 +10,80 @@ class ModelResourceFactoryTest(TestCase):
         self.assertIn("id", BookResource.fields)
         self.assertEqual(BookResource._meta.model, Book)
 
-    def test_create_with_meta(self):
+    def test_create_with_meta_options(self):
         BookResource = resources.modelresource_factory(
-            Book, meta_options={"clean_model_instances": True}
+            Book,
+            meta_options={
+                "fields": ("id", "name"),
+                "exclude": ("imported",),
+                "use_bulk": True,
+                "clean_model_instances": True,
+            },
         )
-        self.assertEqual(BookResource._meta.clean_model_instances, True)
+
+        self.assertEqual(BookResource._meta.fields, ("id", "name"))
+        self.assertEqual(BookResource._meta.exclude, ("imported",))
+        self.assertTrue(BookResource._meta.use_bulk)
+        self.assertTrue(BookResource._meta.clean_model_instances)
+
+    def test_resource_class_inheritance(self):
+        class CustomModelResource(resources.ModelResource):
+            def custom_method(self):
+                return "custom"
+
+        BookResource = resources.modelresource_factory(
+            Book,
+            resource_class=CustomModelResource,
+        )
+
+        resource = BookResource()
+
+        self.assertTrue(hasattr(resource, "custom_method"))
+        self.assertEqual(resource.custom_method(), "custom")
+
+    def test_widgets_in_meta_options(self):
+        BookResource = resources.modelresource_factory(
+            Book,
+            meta_options={
+                "fields": ("id", "name", "price"),
+                "widgets": {
+                    "price": {"coerce_to_string": True},
+                    "name": {"coerce_to_string": True},
+                },
+            },
+        )
+
+        # Check that meta options were set correctly
+        self.assertEqual(BookResource._meta.fields, ("id", "name", "price"))
+        self.assertIn("price", BookResource._meta.widgets)
+        self.assertIn("name", BookResource._meta.widgets)
+
+    def test_complex_meta_options(self):
+        """Test complex meta options configuration"""
+        BookResource = resources.modelresource_factory(
+            Book,
+            meta_options={
+                "fields": ("id", "name", "author", "price"),
+                "exclude": ("imported",),
+                "import_id_fields": ("name",),
+                "export_order": ("name", "author", "price", "id"),
+                "use_bulk": True,
+                "batch_size": 500,
+                "skip_unchanged": True,
+                "clean_model_instances": True,
+                "widgets": {"price": {"coerce_to_string": True}},
+            },
+        )
+
+        resource = BookResource()
+
+        # Verify all meta options
+        self.assertEqual(resource._meta.fields, ("id", "name", "author", "price"))
+        self.assertEqual(resource._meta.exclude, ("imported",))
+        self.assertEqual(resource._meta.import_id_fields, ("name",))
+        self.assertEqual(resource._meta.export_order, ("name", "author", "price", "id"))
+        self.assertTrue(resource._meta.use_bulk)
+        self.assertEqual(resource._meta.batch_size, 500)
+        self.assertTrue(resource._meta.skip_unchanged)
+        self.assertTrue(resource._meta.clean_model_instances)
+        self.assertIn("price", resource._meta.widgets)


### PR DESCRIPTION
**Problem**

modelresource_factory function had limited customization capabilities

**Solution**

Added custom_fields, dehydrate_methods parameters to `modelresource_factory` 

**Acceptance Criteria**

tests written for new functionality and added usage documentation in getting_started.rst



issue: #2080

