### PR TITLE
Updates save instance function signature in release notes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -163,3 +163,4 @@ The following is a list of much appreciated contributors:
 * rodolvbg (Rodolfo Becerra)
 * Andy Zickler
 * kuldeepkhatke (Kuldeep Khatke)
+* siddharth1012 (Siddharth Saraswat)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -306,7 +306,7 @@ This section describes methods in which the parameters have changed.
        * ``using_transactions`` param now in ``kwargs``
 
    * - ``save_instance(self, instance, is_create, using_transactions=True, dry_run=False)``
-     - ``save_instance(self, instance, is_create, row, ***kwargs)``
+     - ``save_instance(self, instance, is_create, row, **kwargs)``
      - * ``dry_run`` param now in ``kwargs``
        * ``using_transactions`` param now in ``kwargs``
        * ``row`` added as mandatory arg


### PR DESCRIPTION
**Problem**
Typo in save_instance Function Signature in Release Notes: ***kwargs Should Be **kwargs

<img width="1851" height="669" alt="image" src="https://github.com/user-attachments/assets/e7b088c1-9400-432c-9c86-1abfe12cb49b" />


**Solution**
Removed extra asterisks from the function signature parameter

**Acceptance Criteria**

Screenshot of changes:

<img width="927" height="194" alt="image" src="https://github.com/user-attachments/assets/53e4593e-d88e-4482-87ce-d907b05c05b0" />
