### PR TITLE
Feature/membership check improvements

### DIFF
--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -233,7 +233,7 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
                 }
                 content_type_id = ContentType.objects.get_for_model(self.model).pk
                 for row in result:
-                    if row.import_type in logentry_map.keys():
+                    if row.import_type in logentry_map:
                         with warnings.catch_warnings():
                             if django.VERSION >= (5,):
                                 from django.utils.deprecation import (
@@ -584,9 +584,10 @@ class ImportMixin(BaseImportMixin, ImportExportMixinBase):
             RowResult.IMPORT_TYPE_UPDATE: CHANGE,
             RowResult.IMPORT_TYPE_DELETE: DELETION,
         }
+        missing = object()
         for import_type, instances in rows.items():
-            if import_type in logentry_map.keys():
-                action_flag = logentry_map[import_type]
+            action_flag = logentry_map.get(import_type, missing)
+            if action_flag is not missing:
                 self._create_log_entry(
                     user_pk, rows[import_type], import_type, action_flag
                 )

--- a/import_export/declarative.py
+++ b/import_export/declarative.py
@@ -107,7 +107,7 @@ class ModelDeclarativeMetaclass(DeclarativeMetaclass):
                 if opts.exclude and f.name in opts.exclude:
                     continue
 
-                if f.name in set(declared_fields.keys()):
+                if f.name in declared_fields:
                     # If model field is declared in `ModelResource`,
                     # remove it from `declared_fields`
                     # to keep exact order of model fields

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -424,9 +424,11 @@ class Resource(metaclass=DeclarativeMetaclass):
 
     def get_import_fields(self):
         import_fields = []
+        missing = object()
         for field_name in self.get_import_order():
-            if field_name in self.fields:
-                import_fields.append(self.fields[field_name])
+            field = self.fields.get(field_name)
+            if field is not missing:
+                import_fields.append(field)
                 continue
             # issue 1815
             # allow for fields to be referenced by column_name in `fields` list
@@ -1101,8 +1103,10 @@ class Resource(metaclass=DeclarativeMetaclass):
 
     def _select_field(self, target_field_name):
         # select field from fields based on either declared name or column name
-        if target_field_name in self.fields:
-            return self.fields[target_field_name]
+        missing = object()
+        field = self.fields.get(target_field_name, missing)
+        if field is not missing:
+            return field
 
         for field_name, field in self.fields.items():
             if target_field_name == field.column_name:

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -426,7 +426,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         import_fields = []
         missing = object()
         for field_name in self.get_import_order():
-            field = self.fields.get(field_name)
+            field = self.fields.get(field_name, missing)
             if field is not missing:
                 import_fields.append(field)
                 continue


### PR DESCRIPTION
**Problem**

Some dictionary lookups or membership checks are not done efficiently. Like `if key in set(some_dict.keys())`: this runs in linear time, since it first makes a set of all the keys in the dictionary.

**Solution**

Dropping `.keys()` where necessary, and if we check a dictionary to then get the corresponding value, we can replace:

```
if key in some_dict:
  val = some_dict[key]
```

by:

```
missing = object()
temp_val = some_dict.get(key, missing)
if temp_val is not missing:
    val = temp_val
```

and:

```
if some_key in my_dict.keys()
```

or:

```
if some_key in set(my_dict.keys())
```

is equivalent to just:

```
if some_key in my_dict
```

**Acceptance Criteria**

The tests run, and a bit faster (although that does not say much). The code just uses the fact that membership checks can be done on the dict directly, saving a few indirections.