### PR TITLE
change export_items to CharField to avoid exceeding POST parameter limit

### DIFF
--- a/import_export/forms.py
+++ b/import_export/forms.py
@@ -92,9 +92,7 @@ class ConfirmImportForm(forms.Form):
 
 
 class ExportForm(ImportExportFormBase):
-    export_items = forms.MultipleChoiceField(
-        widget=forms.MultipleHiddenInput(), required=False
-    )
+    export_items = forms.CharField(widget=forms.HiddenInput(), required=False)
 
 
 class SelectableFieldsExportForm(ExportForm):

--- a/import_export/templates/admin/import_export/export.html
+++ b/import_export/templates/admin/import_export/export.html
@@ -18,7 +18,7 @@
     {# export request has originated from an Admin UI action #}
     {% if form.initial.export_items %}
       <p>
-      {% blocktranslate count len=form.initial.export_items|length trimmed %}
+      {% blocktranslate count len=export_items_length trimmed %}
         Export {{ len }} selected item.
         {% plural %}
         Export {{ len }} selected items.

--- a/import_export/validators.py
+++ b/import_export/validators.py
@@ -1,0 +1,20 @@
+from django.core.exceptions import ValidationError
+
+
+class ExportItemsValidator:
+    def __init__(self, admin_instance, request):
+        self.admin_instance = admin_instance
+        self.request = request
+
+    def __call__(self, value):
+        export_ids = {str(i).strip() for i in value.strip("[]").split(",")}
+        valid_ids = {
+            str(pk)
+            for pk in self.admin_instance.get_valid_export_item_pks(self.request)
+        }
+        invalid_ids = export_ids - valid_ids
+        if invalid_ids:
+            raise ValidationError(
+                "Select a valid choice. "
+                f"{','.join(invalid_ids)} is not one of the available choices."
+            )

--- a/tests/core/tests/admin_integration/test_action_export.py
+++ b/tests/core/tests/admin_integration/test_action_export.py
@@ -59,7 +59,9 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertIn("form", response.context)
         export_form = response.context["form"]
         data = export_form.initial
-        self.assertEqual([self.cat1.id], data["export_items"])
+        export_items_str = data["export_items"]
+        export_items = [int(item) for item in export_items_str.split(",")]
+        self.assertEqual([self.cat1.id], export_items)
         self.assertIn("Export 1 selected item.", response.content.decode())
 
     def test_export_displays_ui_select_page_multiple_items(self):
@@ -71,9 +73,9 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertIn("form", response.context)
         export_form = response.context["form"]
         data = export_form.initial
-        self.assertEqual(
-            sorted([self.cat1.id, self.cat2.id]), sorted(data["export_items"])
-        )
+        export_items_str = data["export_items"]
+        export_items = [int(item) for item in export_items_str.split(",")]
+        self.assertEqual(sorted([self.cat1.id, self.cat2.id]), sorted(export_items))
         self.assertIn("Export 2 selected items.", response.content.decode())
 
     def test_action_export_model_with_custom_PK(self):
@@ -87,7 +89,9 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
         self.assertIn("form", response.context)
         export_form = response.context["form"]
         data = export_form.initial
-        self.assertEqual([cat.pk], data["export_items"])
+        export_items_str = data["export_items"]
+        export_items = [str(item) for item in export_items_str.split(",")]
+        self.assertEqual([str(cat.pk)], export_items)
         self.assertIn("Export 1 selected item.", response.content.decode())
 
     def test_export_post(self):
@@ -129,7 +133,7 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
     def test_export_admin_action_with_restricted_pks(self):
         data = {
             "format": "0",
-            "export_items": [str(self.cat1.id)],
+            "export_items": str(self.cat1.id),
             **self.resource_fields_payload,
         }
         # mock returning a set of pks which is not in the submitted range
@@ -147,7 +151,7 @@ class ExportActionAdminIntegrationTest(AdminTestMixin, TestCase):
     def test_export_admin_action_with_restricted_pks_deprecated(self):
         data = {
             "format": "0",
-            "export_items": [str(self.cat1.id)],
+            "export_items": str(self.cat1.id),
             **self.resource_fields_payload,
         }
         with self.assertWarnsRegex(


### PR DESCRIPTION
**Problem**

When exporting many rows (>1000), too many fields are added to the request and rasies [SuspiciousOperation](https://docs.djangoproject.com/en/5.1/ref/exceptions/#django.core.exceptions.SuspiciousOperation) (TooManyFields)

**Solution**

changed the 'export_items' in the form from a multiselect, to a char field, so all  hidden fields are added to a single string