### PR TITLE
Fix/2063 get parameters forward on confirm

### DIFF
--- a/import_export/templates/admin/import_export/import.html
+++ b/import_export/templates/admin/import_export/import.html
@@ -23,7 +23,7 @@
 
   {% if confirm_form %}
     {% block confirm_import_form %}
-    <form action="{% url opts|admin_urlname:"process_import" %}" method="POST">
+    <form action="{% url opts|admin_urlname:"process_import" %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" method="POST">
       {% csrf_token %}
       {{ confirm_form.as_p }}
       <p>


### PR DESCRIPTION
**Problem**

Call an import view with GET parameters and confirm it will call /process_import/ without the GET parameters

#### Steps to Reproduce: 

  1. Create an import view
  2. Call this view with GET parameters
  3. before_import_row can access the GET parameters via kwargs['request'].GET
  4. Press confirm import
  5. before_import_row has no more access to GET parameters because they are missing in the post call

**Solution**

Changing this
`<form action="{% url opts|admin_urlname:"process_import" %}}" method="POST">`
to this
`<form action="{% url opts|admin_urlname:"process_import" %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" method="POST">` 
fixes the issue

https://github.com/django-import-export/django-import-export/blob/main/import_export/templates/admin/import_export/import.html#L26

**Acceptance Criteria**

Added new test cases for the changes. Screenshot below: 

<img width="463" height="383" alt="image" src="https://github.com/user-attachments/assets/d6c8fb27-be41-4dad-831a-9230c43eff31" />
