### PR TITLE
Improves field value extraction for dict-based querysets

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -99,13 +99,6 @@ class Field:
         """
         Returns the value of the instance's attribute.
         """
-
-        # The objects of a queryset can be dictionaries if the values method is used.
-        if isinstance(instance, dict):
-            if self.attribute not in instance:
-                return None
-            return instance[self.attribute]
-
         if self.attribute is None:
             return None
 
@@ -114,8 +107,11 @@ class Field:
 
         for attr in attrs:
             try:
-                value = getattr(value, attr, None)
-            except (ValueError, ObjectDoesNotExist):
+                if isinstance(value, dict):
+                    value = value[attr]
+                else:
+                    value = getattr(value, attr, None)
+            except (ValueError, ObjectDoesNotExist, KeyError):
                 # needs to have a primary key value before a many-to-many
                 # relationship can be used.
                 return None


### PR DESCRIPTION
**Problem**

Prior to this PR, `attribute` was already handled if the `queryset` returned a `list`/`queryset` of `dict`. But what if one of the fields is a `JSONObject`/`JSONField` and we only want to get the value of the key? We would have to use the dehydrate methods.

**Solution**

My solution is to iterate the lookup as before, but checking whether the `attribute_name` is an attribute of an object or the value of a key. This way, it would be possible within many nested `JSONObjects` (`JSONObject(key_1=JSONObject(key_2=Value("value")))`).

**Acceptance Criteria**

<!---
Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 
-->