### PR TITLE
Link to rendered changelog page from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ tests = [
 [project.urls]
 Documentation = "https://django-import-export.readthedocs.io/en/stable/"
 Repository = "https://github.com/django-import-export/django-import-export"
-Changelog = "https://github.com/django-import-export/django-import-export/blob/main/docs/changelog.rst"
+Changelog = "https://django-import-export.readthedocs.io/en/stable/changelog.html"
 
 [tool.setuptools]
 platforms = ["OS Independent"]


### PR DESCRIPTION
**Problem**

Previously the link went to [GitHub’s view](https://github.com/django-import-export/django-import-export/blob/main/docs/changelog.rst) which doesn't correctly render all Sphinx syntax.

**Solution**

Pointed to RtD.

**Acceptance Criteria**

Checked the link.