### PR TITLE
Enhance readonly field handling in JSONField resources for import behavior

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -902,13 +902,14 @@ Data manipulation on export
 Accessing fields within ``JSONField`` or ``JSONObject``
 -------------------------------------------------------
 In the same way that it is possible to refer to the relationships of the model by defining a field with double underscore ``__``
-syntax, values within ``JSONObject``/ ``JSONField`` can also be accessed but in this case it is necessary to specify it in ``attribute``::
+syntax, values within ``JSONObject``/ ``JSONField`` can also be accessed but in this case it is necessary to specify it in ``attribute``.
+If you will use the resource for import as well, you must mark the field as readonly. If you only want the field for export, marking it as readonly is not necessary::
 
     from import_export.fields import Field
 
     class BookResource(resources.ModelResource):
-        author_name = Field(attribute="author_json__name")
-        author_birthday = Field(attribute="author_json__birthday")
+        author_name = Field(attribute="author_json__name", readonly=True)
+        author_birthday = Field(attribute="author_json__birthday", readonly=True)
 
         class Meta:
             model = Book
@@ -935,6 +936,7 @@ In this case, the export looks like this:
     Remember that the types that are annotated/stored within these fields are primitive JSON
     data types (strings, numbers, boolean, null) and also composite JSON data types (array and object).
     That is why, in the example, the birthday field within the author_json dictionary is displayed as a string.
+    It is recommended that you always declare these fields as readonly even if you only want to use them for export.
 
 Using dehydrate methods
 -----------------------


### PR DESCRIPTION
In #2098, I introduced a change intended to allow fields that were or had nested dict to be exported using the `__` lookup.
These changes were documented in #2100.

**Problem**

I realized that when using resources that had this field, an error was returned during import. (This error is represented in the tests.)

**Solution**

Make it explicit in the documentation that in these types of fields it is necessary to make `readonly=True` explicit, mainly if the resource is also going to be used for import, although for export it is not necessary, it does not hurt to make it explicit.

**Acceptance Criteria**