### PR TITLE
Added CachedForeignKeyWidget

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -166,3 +166,4 @@ The following is a list of much appreciated contributors:
 * siddharth1012 (Siddharth Saraswat)
 * borisovodov (Boris Ovodov)
 * ghostishev (Yevhen Hostishchev)
+* Lokker29 (Bohdan Bilokon)

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -512,7 +512,8 @@ given arg, then the import process will raise either ``DoesNotExist`` or ``Multi
 See also :ref:`creating-non-existent-relations`.
 
 Refer to the :class:`~.ForeignKeyWidget` documentation for more detailed information.
-If importing large datasets, see the notes in :ref:`foreign_key_widget_performance`.
+If importing large datasets, see the notes in :ref:`foreign_key_widget_performance`
+and consider using :class:`~.CachedForeignKeyWidget`
 
 .. note::
 

--- a/docs/api_widgets.rst
+++ b/docs/api_widgets.rst
@@ -41,5 +41,8 @@ Widgets
 .. autoclass:: import_export.widgets.ForeignKeyWidget
    :members:
 
+.. autoclass:: import_export.widgets.CachedForeignKeyWidget
+   :members:
+
 .. autoclass:: import_export.widgets.ManyToManyWidget
    :members:

--- a/docs/bulk_import.rst
+++ b/docs/bulk_import.rst
@@ -51,9 +51,8 @@ You can subclass ``ForeignKeyWidget`` and override ``get_queryset()`` to limit t
 However, overriding ``get_queryset()`` alone does not necessarily eliminate per-row database queries, because
 ``ForeignKeyWidget.clean()`` calls ``.get()`` for each row.
 
-If import performance is critical, consider implementing a custom widget that caches related objects by lookup value
-(for example, building a mapping of ``{lookup_value: related_instance}`` once and reusing it during the import),
-instead of calling ``.get()`` repeatedly.
+If import performance is critical, consider using :class:`~import_export.widgets.CachedForeignKeyWidget` instead.
+This widget caches all related objects in memory before the import begins, eliminating per-row database queries.
 
 .. _performance_tuning:
 
@@ -69,6 +68,9 @@ Consider the following if you need to improve the performance of imports.
 
 * If your import is updating or creating instances, and you have a set of existing instances which can be stored in
   memory, use :class:`~import_export.instance_loaders.CachedInstanceLoader`
+
+* If your import has relations on per-row basis, consider using
+  :class:`~import_export.widgets.CachedForeignKeyWidget` for ForeignKey fields.
 
 * By default, import rows are compared with the persisted representation, and the difference is stored against each row
   result.  If you don't need this diff, then disable it with ``skip_diff = True``.

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import numbers
+from collections import defaultdict, namedtuple
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from warnings import warn
@@ -613,17 +614,23 @@ class ForeignKeyWidget(Widget):
         val = super().clean(value)
         if val:
             if self.use_natural_foreign_keys:
-                # natural keys will always be a tuple, which ends up as a json list.
-                value = json.loads(value)
-                return self.model.objects.get_by_natural_key(*value)
+                return self.get_instance_by_natural_key(value)
             else:
-                lookup_kwargs = self.get_lookup_kwargs(value, row, **kwargs)
-                obj = self.get_queryset(value, row, **kwargs).get(**lookup_kwargs)
+                obj = self.get_instance_by_lookup_fields(value, row, **kwargs)
                 if self.key_is_id:
                     return obj.pk
                 return obj
         else:
             return None
+
+    def get_instance_by_natural_key(self, value):
+        # natural keys will always be a tuple, which ends up as a json list.
+        value = json.loads(value)
+        return self.model.objects.get_by_natural_key(*value)
+
+    def get_instance_by_lookup_fields(self, value, row, **kwargs):
+        lookup_kwargs = self.get_lookup_kwargs(value, row, **kwargs)
+        return self.get_queryset(value, row, **kwargs).get(**lookup_kwargs)
 
     def get_lookup_kwargs(self, value, row, **kwargs):
         """
@@ -667,6 +674,138 @@ class ForeignKeyWidget(Widget):
                 return None
 
         return value
+
+
+class _CachedQuerySetWrapper:
+    """
+    A wrapper around a Django QuerySet that caches its results in a dictionary
+    for quick lookups.
+
+    This class has the same 'get()' method signature as a QuerySet
+    because it is intended to be used as a drop-in replacement for QuerySet
+    in case of ForeignKeyWidget that calls 'get()' method for every row
+    in the import dataset.
+    """
+
+    def __init__(self, queryset):
+        self.queryset = queryset
+        self.model = queryset.model
+
+    def _get_instances(self, queryset, key_cls):
+        """
+        Converts a queryset into a dictionary mapping lookup fields values
+        to lists of instances. The values of the returned dict are lists
+        to handle potential multiple instances with the same lookup fields values.
+        """
+        if hasattr(self, "_instances"):
+            return self._instances
+
+        self._instances = defaultdict(list)
+        for instance in queryset:
+            key = key_cls(
+                **{field: getattr(instance, field) for field in key_cls._fields}
+            )
+            self._instances[key].append(instance)
+
+        return self._instances
+
+    def get(self, **lookup_fields):
+        Key = namedtuple("Key", list(lookup_fields.keys()))
+
+        instances = self._get_instances(self.queryset, Key)
+        key = Key(**lookup_fields)
+        result = instances.get(key, [])
+
+        if len(result) == 1:
+            return result[0]
+
+        if len(result) == 0:
+            raise self.model.DoesNotExist(
+                "%s matching query does not exist." % self.model._meta.object_name
+            )
+        raise self.model.MultipleObjectsReturned(
+            "get() returned more than one %s -- it returned %s!"
+            % (self.model._meta.object_name, len(result))
+        )
+
+
+class CachedForeignKeyWidget(ForeignKeyWidget):
+    """
+    A :class:`~import_export.widgets.ForeignKeyWidget` subclass that caches
+    the queryset results to minimize database hits during import. The default
+    :class:`~import_export.widgets.ForeignKeyWidget` makes query for each row,
+    which can be inefficient for large imports. This widget fetches all related
+    instances once and caches them in memory for subsequent lookups.
+
+    Using this class has some limitations:
+
+    - It does not support caching when ``use_natural_foreign_keys=True`` is set.
+
+    - It calls :meth:`~import_export.widgets.ForeignKeyWidget.get_queryset` only once,
+      so if the queryset depends on the row data, this widget may not work as expected.
+      You must be sure that the queryset is static for all rows.
+      Avoid using :class:`~import_export.widgets.CachedForeignKeyWidget`
+      in the following way::
+
+            class FullNameForeignKeyWidget(CachedForeignKeyWidget):
+                def get_queryset(self, value, row, *args, **kwargs):
+                    return self.model.objects.filter(
+                        first_name__iexact=row["first_name"],
+                        last_name__iexact=row["last_name"]
+                    )
+
+      It makes more sense to filter by static values::
+
+            class ActiveForeignKeyWidget(CachedForeignKeyWidget):
+                def get_queryset(self, value, row, *args, **kwargs):
+                    return self.model.objects.filter(active=True)
+
+    - It stores data in a hash table where the key is a tuple of the fields that
+      returned by :meth:`~import_export.widgets.ForeignKeyWidget.get_lookup_kwargs`.
+      You must be sure that the lookup fields are the same for all rows.
+      If the lookup fields differ between rows, this widget may not work as expected.
+      The following example is incorrect usage::
+
+            class MultiColumnForeignKeyWidget(CachedForeignKeyWidget):
+                def get_lookup_kwargs(self, value, row, **kwargs):
+                    if row['active'] == 'yes':
+                        return {self.field: value, 'active': True}
+                    else:
+                        return {self.field: value, 'inactive': True}
+
+    - It performs lookup on Python side, so the filtering logic
+      with non-text data types may not work::
+
+            class MultiColumnForeignKeyWidget(CachedForeignKeyWidget):
+                def get_lookup_kwargs(self, value, row, **kwargs):
+                    # row['birthday'] is a string like '01-01-2000'.
+                    #
+                    # It won't match the instance because the birthday values
+                    # in the cached instances are datetime objects, not strings.
+                    return {self.field: value, 'birthday': row['birthday']}
+
+    - It does not support complex lookups like ``__gt``, ``__lt``,
+      or filtering over relationships in the ``get_lookup_kwargs()``.
+      For example, the following code won't work::
+
+            class BookForeignKeyWidget(CachedForeignKeyWidget):
+                def get_lookup_kwargs(self, value, row, **kwargs):
+                    return {f'{self.field}__author': value}
+
+    :param model: The Model the ForeignKey refers to (required).
+    :param field: A field on the related model used for looking up a particular
+        object.
+    :param use_natural_foreign_keys: Use natural key functions to identify
+        related object, default to False
+    """
+
+    def get_instance_by_lookup_fields(self, value, row, **kwargs):
+        if not hasattr(self, "_cached_qs"):
+            queryset = self.get_queryset(value, row, **kwargs)
+            self._cached_qs = _CachedQuerySetWrapper(queryset)
+
+        lookup_kwargs = self.get_lookup_kwargs(value, row, **kwargs)
+        return self._cached_qs.get(**lookup_kwargs)
 
 
 class ManyToManyWidget(Widget):

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -5,13 +5,15 @@ from unittest import mock
 from unittest.mock import patch
 
 import django
+import tablib
 from core.models import Author, Book, Category
 from core.tests.utils import ignore_utcnow_deprecation_warning
+from django.db import connection
 from django.test import TestCase
-from django.test.utils import override_settings
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils import timezone
 
-from import_export import widgets
+from import_export import fields, resources, widgets
 from import_export.exceptions import WidgetError
 
 
@@ -664,6 +666,191 @@ class ForeignKeyWidgetTest(TestCase, RowDeprecationTestMixin):
     def test_natural_foreign_key_with_key_is_id(self):
         with self.assertRaises(WidgetError) as e:
             widgets.ForeignKeyWidget(
+                Author, use_natural_foreign_keys=True, key_is_id=True
+            )
+        self.assertEqual(
+            "use_natural_foreign_keys and key_is_id " "cannot both be True",
+            str(e.exception),
+        )
+
+
+class CachedForeignKeyWidgetTest(TestCase, RowDeprecationTestMixin):
+    def setUp(self):
+        self.widget = widgets.CachedForeignKeyWidget(Author)
+        self.natural_key_author_widget = widgets.CachedForeignKeyWidget(
+            Author, use_natural_foreign_keys=True
+        )
+        self.natural_key_book_widget = widgets.CachedForeignKeyWidget(
+            Book, use_natural_foreign_keys=True
+        )
+        self.author = Author.objects.create(name="Foo")
+        self.book = Book.objects.create(name="Bar", author=self.author)
+
+    def tearDown(self):
+        if hasattr(self.widget, "_cached_qs"):
+            del self.widget._cached_qs
+        if hasattr(self.natural_key_author_widget, "_cached_qs"):
+            del self.natural_key_author_widget._cached_qs
+        if hasattr(self.natural_key_book_widget, "_cached_qs"):
+            del self.natural_key_book_widget._cached_qs
+
+    def test_clean(self):
+        self.assertEqual(self.widget.clean(self.author.id), self.author)
+
+    def test_clean_empty(self):
+        self.assertEqual(self.widget.clean(""), None)
+
+    def test_render(self):
+        self.assertEqual(self.widget.render(self.author), self.author.pk)
+
+    def test_render_empty(self):
+        self.assertEqual(self.widget.render(None), "")
+
+    def test_cache_hit(self):
+        author2 = Author.objects.create(name="Baz")
+        with CaptureQueriesContext(connection) as ctx:
+            self.assertEqual(self.widget.clean(self.author.id), self.author)  # query
+            self.assertEqual(self.widget.clean(author2.id), author2)  # cache hit
+            self.assertEqual(len(ctx.captured_queries), 1)
+
+        with CaptureQueriesContext(connection) as ctx:
+            self.assertEqual(
+                self.widget.clean(self.author.id), self.author
+            )  # cache hit
+            self.assertEqual(self.widget.clean(author2.id), author2)  # cache hit
+            self.assertEqual(len(ctx.captured_queries), 0)
+
+    def test_cache_is_not_shared_for_different_resource_instances(self):
+        class BookResource(resources.ModelResource):
+            author = fields.Field(
+                attribute="author",
+                column_name="Author",
+                widget=widgets.CachedForeignKeyWidget(Author),
+            )
+
+            class Meta:
+                model = Book
+
+        headers = ["Author"]
+        row = [self.author.id]
+        dataset = tablib.Dataset(row, headers=headers)
+        resource = BookResource()
+
+        self.assertFalse(hasattr(resource.fields["author"].widget, "_cached_qs"))
+        resource.import_data(dataset, dry_run=True)
+        self.assertTrue(hasattr(resource.fields["author"].widget, "_cached_qs"))
+
+        resource2 = BookResource()  # new instance. The cache must be reset
+        self.assertFalse(hasattr(resource2.fields["author"].widget, "_cached_qs"))
+
+    def test_clean_multi_column(self):
+        class BirthdayWidget(widgets.CachedForeignKeyWidget):
+            def get_queryset(self, value, row, *args, **kwargs):
+                return self.model.objects.filter(birthday=row["birthday"])
+
+        author2 = Author.objects.create(name="Foo")
+        author2.birthday = "2016-01-01"
+        author2.save()
+        birthday_widget = BirthdayWidget(Author, "name")
+        row_dict = {"name": "Foo", "birthday": author2.birthday}
+        self.assertEqual(birthday_widget.clean("Foo", row=row_dict), author2)
+
+    def test_invalid_get_queryset(self):
+        class BirthdayWidget(widgets.CachedForeignKeyWidget):
+            def get_queryset(self, value, row):
+                return self.model.objects.filter(birthday=row["birthday"])
+
+        birthday_widget = BirthdayWidget(Author, "name")
+        row_dict = {"name": "Foo", "age": 38}
+        with self.assertRaises(TypeError):
+            birthday_widget.clean("Foo", row=row_dict, row_number=1)
+
+    def test_lookup_multiple_columns(self):
+        # issue 1516 - override the values used to lookup an entry
+        class BookWidget(widgets.CachedForeignKeyWidget):
+            def get_lookup_kwargs(self, value, row, *args, **kwargs):
+                return {"name": row["name"], "author_email": row["authoremail"]}
+
+        target_book = Book.objects.create(
+            name="Baz", author=self.author, author_email="baz@email.com"
+        )
+        row_dict = {"name": "Baz", "authoremail": "baz@email.com"}
+        book_widget = BookWidget(Book, "name")
+        # prove that the overridden kwargs identify a row
+        res = book_widget.clean("non-existent name", row=row_dict)
+        self.assertEqual(target_book, res)
+
+    def test_render_handles_value_error(self):
+        class TestObj:
+            @property
+            def attr(self):
+                raise ValueError("some error")
+
+        t = TestObj()
+        self.widget = widgets.CachedForeignKeyWidget(mock.Mock(), "attr")
+        self.assertIsNone(self.widget.render(t))
+
+    def test_multiple_objects_error(self):
+        Author.objects.create(name=self.author.name)  # an author with duplicated name
+        widget = widgets.CachedForeignKeyWidget(Author, "name")
+
+        with self.assertRaises(Author.MultipleObjectsReturned) as e:
+            widget.clean(self.author.name)
+
+        self.assertEqual(
+            str(e.exception), "get() returned more than one Author -- it returned 2!"
+        )
+
+    def test_object_does_not_exist_error(self):
+        with self.assertRaises(Author.DoesNotExist) as e:
+            self.widget.clean("non-existent-id")
+
+        self.assertEqual(str(e.exception), "Author matching query does not exist.")
+
+    def test_author_natural_key_clean(self):
+        """
+        Ensure that we can import an author by its natural key. Note that
+        this will always need to be an iterable.
+        Generally this will be rendered as a list.
+        """
+        self.assertEqual(
+            self.natural_key_author_widget.clean(json.dumps(self.author.natural_key())),
+            self.author,
+        )
+
+    def test_author_natural_key_render(self):
+        """
+        Ensure we can render an author by its natural key. Natural keys will always be
+        tuples.
+        """
+        self.assertEqual(
+            self.natural_key_author_widget.render(self.author),
+            json.dumps(self.author.natural_key()),
+        )
+
+    def test_book_natural_key_clean(self):
+        """
+        Use the book case to validate a composite natural key of book name and author
+        can be cleaned.
+        """
+        self.assertEqual(
+            self.natural_key_book_widget.clean(json.dumps(self.book.natural_key())),
+            self.book,
+        )
+
+    def test_book_natural_key_render(self):
+        """
+        Use the book case to validate a composite natural key of book name and author
+        can be rendered
+        """
+        self.assertEqual(
+            self.natural_key_book_widget.render(self.book),
+            json.dumps(self.book.natural_key()),
+        )
+
+    def test_natural_foreign_key_with_key_is_id(self):
+        with self.assertRaises(WidgetError) as e:
+            widgets.CachedForeignKeyWidget(
                 Author, use_natural_foreign_keys=True, key_is_id=True
             )
         self.assertEqual(


### PR DESCRIPTION
**Problem**

the N+1 problem with ForeignKeyWidget ([StackOverflow](https://stackoverflow.com/q/78304608/32132395))

**Solution**

There is a new widget - CachedForeignKeyWidget. It loads all instances of the queryset into the memory as dictionary during importing the first row. All other rows will hit the dictionary during lookup.

**Acceptance Criteria**

Tests are written. Documentation is updated.