### PR TITLE
Fix CachedForeignKeyWidget type mismatch on non-string lookup fields

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -703,7 +703,7 @@ class _CachedQuerySetWrapper:
         self._instances = defaultdict(list)
         for instance in queryset:
             key = key_cls(
-                **{field: getattr(instance, field) for field in key_cls._fields}
+                **{field: str(getattr(instance, field)) for field in key_cls._fields}
             )
             self._instances[key].append(instance)
 
@@ -713,7 +713,7 @@ class _CachedQuerySetWrapper:
         Key = namedtuple("Key", list(lookup_fields.keys()))
 
         instances = self._get_instances(self.queryset, Key)
-        key = Key(**lookup_fields)
+        key = Key(**{k: str(v) for k, v in lookup_fields.items()})
         result = instances.get(key, [])
 
         if len(result) == 1:

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -697,6 +697,10 @@ class CachedForeignKeyWidgetTest(TestCase, RowDeprecationTestMixin):
     def test_clean(self):
         self.assertEqual(self.widget.clean(self.author.id), self.author)
 
+    def test_clean_with_string_pk(self):
+        """Ensure lookup works when value is a string (as from CSV import)."""
+        self.assertEqual(self.widget.clean(str(self.author.id)), self.author)
+
     def test_clean_empty(self):
         self.assertEqual(self.widget.clean(""), None)
 


### PR DESCRIPTION
## Summary
- `_CachedQuerySetWrapper` builds cache keys from instance attributes (native Python types like `int`) but lookups use values from import data (strings from CSV). This type mismatch causes `DoesNotExist` errors when the lookup field is non-string (e.g. `pk`, or related fields like `author__pk`).
- Fix coerces both cache keys and lookup keys to `str` for consistent matching.
- Adds regression test that passes a string PK value (as would arrive from CSV import).

Reported in PR #2146 review discussion.

## Test plan
- [x] New test `test_clean_with_string_pk` verifies string PK lookup works
- [x] Full test suite passes (731 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)