### PR TITLE
fix: allow Resource subclasses to be subscripted

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 - Removed the deprecated :meth:`~import_export.admin.ExportMixin.get_valid_export_item_pks` method in favour of :meth:`~import_export.admin.ExportMixin.get_queryset` (`1898 <https://github.com/django-import-export/django-import-export/pull/1898>`_)
 - Refactor bulk updates to use attribute not field (`2145 <https://github.com/django-import-export/django-import-export/issues/2145>`_)
 - Replace ``DEFAULT_FORMATS`` and ``BINARY_FORMATS`` constants with ``get_default_formats()`` and ``get_binary_formats()`` functions to avoid expensive library imports at Django startup (`2149 <https://github.com/django-import-export/django-import-export/issues/2149>`_)
+- Allow ``Resource`` subclasses to be subscripted, e.g. ``ModelResource[MyModel]`` (`2069 <https://github.com/django-import-export/django-import-export/issues/2069>`_)
 
 4.4.1 (2026-05-05)
 -------------------

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import types
 from collections import OrderedDict
 from copy import deepcopy
 from html import escape
@@ -72,6 +73,10 @@ class Resource(metaclass=DeclarativeMetaclass):
     Resource defines how objects are mapped to their import and export
     representations and handle importing and exporting data.
     """
+
+    # Allow ``Resource[Model]`` subscription so resources can be parameterised
+    # with the model they operate on (used for typing).
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __init__(self, **kwargs):
         """

--- a/tests/core/tests/test_resources/test_misc.py
+++ b/tests/core/tests/test_resources/test_misc.py
@@ -49,3 +49,17 @@ class ResourcesHelperFunctionsTest(TestCase):
 
         for model, expected_result in cases.items():
             self.assertEqual(resources.has_natural_foreign_key(model), expected_result)
+
+
+class ResourceSubscriptTest(TestCase):
+    def test_resource_is_subscriptable(self):
+        alias = resources.ModelResource[Book]
+        self.assertEqual(alias.__origin__, resources.ModelResource)
+        self.assertEqual(alias.__args__, (Book,))
+
+    def test_subclass_can_subscript_resource_base(self):
+        class BookResource(resources.ModelResource[Book]):
+            class Meta:
+                model = Book
+
+        self.assertTrue(issubclass(BookResource, resources.ModelResource))


### PR DESCRIPTION
**Problem**

Following the type stubs, `class MyResource(ModelResource[MyModel])` raises `TypeError: type 'ModelResource' is not subscriptable` at runtime (#2069).

**Solution**

Add `__class_getitem__` to `Resource` (via `types.GenericAlias`) so resources can be parameterised with the model they operate on, matching how Django parameterises `QuerySet`/`Manager`.

**Acceptance Criteria**

Tests added in `tests/core/tests/test_resources/test_misc.py`; changelog updated.

Closes #2069
