### PR TITLE
Fix CachedInstanceLoader to raise MultipleObjectsReturned on duplicate import id (#2162)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 5.0.0 (unreleased)
 ------------------
 
+- Fixed ``CachedInstanceLoader`` to raise ``MultipleObjectsReturned`` for a duplicated import id instead of silently returning one match, consistent with ``ModelInstanceLoader`` (`2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)
 - Add support for Django 6.0, remove support for Python 3.9 (`2112 <https://github.com/django-import-export/django-import-export/pull/2112>`_)
 - Fix Admin UI form field name collision for exports (`2108 <https://github.com/django-import-export/django-import-export/pull/2108>`_)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -49,6 +49,11 @@ Breaking changes
     from import_export.formats.base_formats import get_default_formats
     formats = get_default_formats()
 
+* ``CachedInstanceLoader`` now raises ``MultipleObjectsReturned`` when the configured import id matches more than
+  one existing object, matching ``ModelInstanceLoader`` instead of silently returning one of the matches.
+  Ensure that custom ``import_id_fields`` values uniquely identify one row.
+  See `PR 2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_.
+
 Removed deprecations
 """"""""""""""""""""
 

--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -73,8 +73,8 @@ class CachedInstanceLoader(ModelInstanceLoader):
             if key in self._duplicate_ids:
                 model = self.resource._meta.model
                 raise model.MultipleObjectsReturned(
-                    "get() returned more than one %s -- the import id "
-                    "matches multiple objects." % model.__name__
+                    "CachedInstanceLoader found multiple %s objects for import id "
+                    "%s=%r." % (model.__name__, self.pk_field.attribute, key)
                 )
             return self.all_instances.get(key)
         return None

--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -74,7 +74,7 @@ class CachedInstanceLoader(ModelInstanceLoader):
                 model = self.resource._meta.model
                 raise model.MultipleObjectsReturned(
                     "CachedInstanceLoader found multiple %s objects for import id "
-                    "%s=%r." % (model.__name__, self.pk_field.attribute, key)
+                    "field %r." % (model.__name__, self.pk_field.attribute)
                 )
             return self.all_instances.get(key)
         return None

--- a/import_export/instance_loaders.py
+++ b/import_export/instance_loaders.py
@@ -53,15 +53,28 @@ class CachedInstanceLoader(ModelInstanceLoader):
         # If the pk field is missing, all instances in dataset are new
         # and cache is empty.
         self.all_instances = {}
+        # Import ids that match more than one instance. These are tracked so
+        # that get_instance() can raise MultipleObjectsReturned instead of
+        # silently returning one of them, consistent with ModelInstanceLoader.
+        self._duplicate_ids = set()
         if self.dataset.dict and self.pk_field.column_name in self.dataset.dict[0]:
             ids = [self.pk_field.clean(row) for row in self.dataset.dict]
             qs = self.get_queryset().filter(**{"%s__in" % self.pk_field.attribute: ids})
 
-            self.all_instances = {
-                self.pk_field.get_value(instance): instance for instance in qs
-            }
+            for instance in qs:
+                key = self.pk_field.get_value(instance)
+                if key in self.all_instances:
+                    self._duplicate_ids.add(key)
+                self.all_instances[key] = instance
 
     def get_instance(self, row):
         if self.all_instances:
-            return self.all_instances.get(self.pk_field.clean(row))
+            key = self.pk_field.clean(row)
+            if key in self._duplicate_ids:
+                model = self.resource._meta.model
+                raise model.MultipleObjectsReturned(
+                    "get() returned more than one %s -- the import id "
+                    "matches multiple objects." % model.__name__
+                )
+            return self.all_instances.get(key)
         return None

--- a/tests/core/tests/test_instance_loaders.py
+++ b/tests/core/tests/test_instance_loaders.py
@@ -69,3 +69,35 @@ class CachedInstanceLoaderWithAbsentImportIdFieldTest(TestCase):
     def test_get_instance(self):
         obj = self.instance_loader.get_instance(self.dataset.dict[0])
         self.assertEqual(obj, None)
+
+
+class CachedInstanceLoaderDuplicateImportIdTest(TestCase):
+    """When the import id matches more than one row, ``CachedInstanceLoader``
+    must raise ``MultipleObjectsReturned`` instead of silently returning one of
+    them, consistent with ``ModelInstanceLoader`` (#2162).
+    """
+
+    def setUp(self):
+        self.resource = resources.modelresource_factory(Book)()
+        self.resource._meta.import_id_fields = ["name"]
+        self.dataset = tablib.Dataset(headers=["id", "name", "author_email"])
+        # Two existing rows share the same import id ("name").
+        Book.objects.create(name="Dup")
+        Book.objects.create(name="Dup")
+        self.dataset.append(["", "Dup", "test@example.com"])
+
+    def test_cached_loader_raises_for_duplicate_import_id(self):
+        instance_loader = instance_loaders.CachedInstanceLoader(
+            self.resource, self.dataset
+        )
+        with self.assertRaises(Book.MultipleObjectsReturned):
+            instance_loader.get_instance(self.dataset.dict[0])
+
+    def test_model_loader_raises_for_duplicate_import_id(self):
+        # Documents the behavior that CachedInstanceLoader is made consistent
+        # with: the uncached loader already raises here.
+        instance_loader = instance_loaders.ModelInstanceLoader(
+            self.resource, self.dataset
+        )
+        with self.assertRaises(Book.MultipleObjectsReturned):
+            instance_loader.get_instance(self.dataset.dict[0])

--- a/tests/core/tests/test_instance_loaders.py
+++ b/tests/core/tests/test_instance_loaders.py
@@ -90,8 +90,20 @@ class CachedInstanceLoaderDuplicateImportIdTest(TestCase):
         instance_loader = instance_loaders.CachedInstanceLoader(
             self.resource, self.dataset
         )
-        with self.assertRaises(Book.MultipleObjectsReturned):
+        with self.assertRaisesMessage(
+            Book.MultipleObjectsReturned,
+            "CachedInstanceLoader found multiple Book objects for import id "
+            "name='Dup'.",
+        ):
             instance_loader.get_instance(self.dataset.dict[0])
+
+    def test_cached_loader_returns_unique_import_id_match(self):
+        book = Book.objects.create(name="Unique")
+        dataset = tablib.Dataset(headers=["id", "name", "author_email"])
+        dataset.append(["", "Unique", "test@example.com"])
+        instance_loader = instance_loaders.CachedInstanceLoader(self.resource, dataset)
+
+        self.assertEqual(instance_loader.get_instance(dataset.dict[0]), book)
 
     def test_model_loader_raises_for_duplicate_import_id(self):
         # Documents the behavior that CachedInstanceLoader is made consistent

--- a/tests/core/tests/test_instance_loaders.py
+++ b/tests/core/tests/test_instance_loaders.py
@@ -93,9 +93,13 @@ class CachedInstanceLoaderDuplicateImportIdTest(TestCase):
         with self.assertRaisesMessage(
             Book.MultipleObjectsReturned,
             "CachedInstanceLoader found multiple Book objects for import id "
-            "name='Dup'.",
-        ):
+            "field 'name'.",
+        ) as cm:
             instance_loader.get_instance(self.dataset.dict[0])
+        # The user-supplied import id value must not leak into the message: it
+        # could otherwise end up in logs that render it unescaped. Only the
+        # configured field name (not the row value) is reported.
+        self.assertNotIn("Dup", str(cm.exception))
 
     def test_cached_loader_returns_unique_import_id_match(self):
         book = Book.objects.create(name="Unique")


### PR DESCRIPTION
Fixes #2162.

### Problem

`CachedInstanceLoader` silently returns one arbitrary match when several source rows share the same import id, whereas `ModelInstanceLoader` raises `MultipleObjectsReturned` for the same data. As noted on the issue, the two loaders should behave consistently and the cached path should not quietly overwrite values.

### Fix

While building the cache, `CachedInstanceLoader` now detects when more than one row maps to the same id and records those duplicated ids. `get_instance()` raises `MultipleObjectsReturned` for a duplicated id, matching `ModelInstanceLoader`. The single-match and no-match paths are unchanged, so existing behaviour for well-formed data is preserved.

### Tests

Added `CachedInstanceLoaderDuplicateImportIdTest` with two cases: the cached loader now raises `MultipleObjectsReturned` on a duplicated id (fails before this change, passes after), and a companion test pinning the already-correct `ModelInstanceLoader` behaviour so the two stay consistent. The full `core` suite shows no new failures (the pre-existing binary-storage / tz failures are unrelated and present on `main`).

I use AI tooling to assist this work, under my direction and review; the diagnosis, fix, and tests were verified by me.
