### PR TITLE
Add get_queryset to ManyToManyWidget

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 5.0.0 (unreleased)
 ------------------
 
+- Added :meth:`~import_export.widgets.ManyToManyWidget.get_queryset` to customize the related objects available during import (`2172 <https://github.com/django-import-export/django-import-export/pull/2172>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)
 - Add support for Django 6.0, remove support for Python 3.9 (`2112 <https://github.com/django-import-export/django-import-export/pull/2112>`_)
 - Fix Admin UI form field name collision for exports (`2108 <https://github.com/django-import-export/django-import-export/pull/2108>`_)

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -823,6 +823,7 @@ class ManyToManyWidget(Widget):
         :param row: The dataset's current row.
         :param \\*args: Optional args.
         :param \\**kwargs: Optional kwargs.
+        :return: A QuerySet containing all objects for this model.
         """
         return self.model.objects.all()
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -812,6 +812,20 @@ class ManyToManyWidget(Widget):
         self.field = field
         super().__init__(**kwargs)
 
+    def get_queryset(self, value, row, *args, **kwargs):
+        """
+        Returns a queryset of all objects for this Model.
+
+        Override this method to limit the pool of objects from which related
+        objects are retrieved.
+
+        :param value: The field's value in the dataset.
+        :param row: The dataset's current row.
+        :param \\*args: Optional args.
+        :param \\**kwargs: Optional kwargs.
+        """
+        return self.model.objects.all()
+
     def clean(self, value, row=None, **kwargs):
         """
         Converts a separated string of values into a QuerySet for ManyToMany
@@ -829,12 +843,13 @@ class ManyToManyWidget(Widget):
         """
         if not value:
             return self.model.objects.none()
+        queryset = self.get_queryset(value, row, **kwargs)
         if isinstance(value, (float, int)):
             ids = [int(value)]
         else:
             ids = value.split(self.separator)
             ids = filter(None, [i.strip() for i in ids])
-        return self.model.objects.filter(**{"%s__in" % self.field: ids})
+        return queryset.filter(**{"%s__in" % self.field: ids})
 
     def render(self, value, **kwargs):
         """

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -884,6 +884,19 @@ class ManyToManyWidget(TestCase):
         self.assertIn(self.cat1, cleaned_data)
         self.assertIn(self.cat2, cleaned_data)
 
+    def test_clean_uses_get_queryset(self):
+        class FilteredWidget(widgets.ManyToManyWidget):
+            def get_queryset(self, value, row, *args, **kwargs):
+                return self.model.objects.filter(name=row["category"])
+
+        widget = FilteredWidget(Category)
+        value = f"{self.cat1.pk},{self.cat2.pk}"
+        cleaned_data = widget.clean(
+            value, row={"category": self.cat1.name}, row_number=1
+        )
+
+        self.assertQuerySetEqual(cleaned_data, [self.cat1])
+
     def test_clean_typo(self):
         value = "%s," % self.cat1.pk
         cleaned_data = self.widget.clean(value)


### PR DESCRIPTION
## Summary

- add `ManyToManyWidget.get_queryset()` as a customization point
- use the returned queryset when resolving many-to-many values
- add a regression test demonstrating row-dependent queryset filtering

Closes #2053.

## Tests

- `PYTHONPATH=".:tests" .venv/bin/python -W error -m django test core.tests.test_widgets.ManyToManyWidget --settings=settings`
- `PYTHONPATH=".:tests" .venv/bin/python -W error -m django test core.tests.test_widgets --settings=settings`
