### PR TITLE
Normalize JSON key order in diffs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 5.0.0 (unreleased)
 ------------------
 
+- Fixed JSON object key order causing false changes in the import preview (`2173 <https://github.com/django-import-export/django-import-export/pull/2173>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)
 - Add support for Django 6.0, remove support for Python 3.9 (`2112 <https://github.com/django-import-export/django-import-export/pull/2112>`_)
 - Fix Admin UI form field name collision for exports (`2108 <https://github.com/django-import-export/django-import-export/pull/2108>`_)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Changelog
 ------------------
 
 - Fixed JSON object key order causing false changes in the import preview (`2173 <https://github.com/django-import-export/django-import-export/pull/2173>`_)
+- Fixed pk sequence reset in :meth:`~import_export.resources.ModelResource.after_import` (`2166 <https://github.com/django-import-export/django-import-export/issues/2166>`_)
+- Fixed ``CachedInstanceLoader`` to raise ``MultipleObjectsReturned`` for a duplicated import id instead of silently returning one match, consistent with ``ModelInstanceLoader`` (`2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)
 - Add support for Django 6.0, remove support for Python 3.9 (`2112 <https://github.com/django-import-export/django-import-export/pull/2112>`_)
 - Fix Admin UI form field name collision for exports (`2108 <https://github.com/django-import-export/django-import-export/pull/2108>`_)
@@ -16,6 +18,7 @@ Changelog
 - Refactor bulk updates to use attribute not field (`2145 <https://github.com/django-import-export/django-import-export/issues/2145>`_)
 - Replace ``DEFAULT_FORMATS`` and ``BINARY_FORMATS`` constants with ``get_default_formats()`` and ``get_binary_formats()`` functions to avoid expensive library imports at Django startup (`2149 <https://github.com/django-import-export/django-import-export/issues/2149>`_)
 - Allow ``Resource`` subclasses to be subscripted, e.g. ``ModelResource[MyModel]`` (`2069 <https://github.com/django-import-export/django-import-export/issues/2069>`_)
+- Fixed ``.ods`` import failing with ``UnicodeDecodeError`` because ODS was classified as a text format and read in text mode instead of binary (`2176 <https://github.com/django-import-export/django-import-export/pull/2176>`_)
 
 4.4.1 (2026-05-05)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,11 +8,11 @@ Changelog
 5.0.0 (unreleased)
 ------------------
 
-- Fixed JSON object key order causing false changes in the import preview (`2173 <https://github.com/django-import-export/django-import-export/pull/2173>`_)
 - Fixed pk sequence reset in :meth:`~import_export.resources.ModelResource.after_import` (`2166 <https://github.com/django-import-export/django-import-export/issues/2166>`_)
 - Fixed ``CachedInstanceLoader`` to raise ``MultipleObjectsReturned`` for a duplicated import id instead of silently returning one match, consistent with ``ModelInstanceLoader`` (`2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)
 - Add support for Django 6.0, remove support for Python 3.9 (`2112 <https://github.com/django-import-export/django-import-export/pull/2112>`_)
+- Fixed JSON object key order causing false changes in the import preview (`2173 <https://github.com/django-import-export/django-import-export/pull/2173>`_)
 - Fix Admin UI form field name collision for exports (`2108 <https://github.com/django-import-export/django-import-export/pull/2108>`_)
 - Removed the deprecated :meth:`~import_export.admin.ExportMixin.get_valid_export_item_pks` method in favour of :meth:`~import_export.admin.ExportMixin.get_queryset` (`1898 <https://github.com/django-import-export/django-import-export/pull/1898>`_)
 - Refactor bulk updates to use attribute not field (`2145 <https://github.com/django-import-export/django-import-export/issues/2145>`_)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -65,7 +65,10 @@ class Diff:
 
     @classmethod
     def _read_field_values(cls, resource, instance):
-        return [f.export(instance) for f in resource.get_import_fields()]
+        return [
+            f.export(instance, sort_json_keys=True)
+            for f in resource.get_import_fields()
+        ]
 
 
 class Resource(metaclass=DeclarativeMetaclass):

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -489,7 +489,7 @@ class JSONWidget(Widget):
         """
         if value is None:
             return None
-        return json.dumps(value)
+        return json.dumps(value, sort_keys=True)
 
 
 class ForeignKeyWidget(Widget):

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -484,10 +484,11 @@ class JSONWidget(Widget):
 
     def render(self, value, **kwargs):
         """
+        Set the ``sort_json_keys`` keyword argument to ``True`` to sort the
+        keys in JSON objects.
+
         :return: A JSON formatted string derived from ``value``.
           ``coerce_to_string`` has no effect on the return value.
-          Set the ``sort_json_keys`` keyword argument to ``True`` to sort the
-          keys in JSON objects.
         """
         if value is None:
             return None

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -486,10 +486,12 @@ class JSONWidget(Widget):
         """
         :return: A JSON formatted string derived from ``value``.
           ``coerce_to_string`` has no effect on the return value.
+          Set the ``sort_json_keys`` keyword argument to ``True`` to sort the
+          keys in JSON objects.
         """
         if value is None:
             return None
-        return json.dumps(value, sort_keys=True)
+        return json.dumps(value, sort_keys=kwargs.get("sort_json_keys", False))
 
 
 class ForeignKeyWidget(Widget):

--- a/tests/core/tests/test_resources/test_modelresource/test_data_import.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_data_import.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest import mock
 
 import tablib
@@ -6,7 +7,7 @@ from core.models import Book
 from core.tests.resources import BookResource, BookResourceWithStoreInstance
 from django.test import TestCase, skipUnlessDBFeature
 
-from import_export import results
+from import_export import fields, resources, results, widgets
 from import_export.resources import Diff
 
 
@@ -30,6 +31,18 @@ class DataImportTests(TestCase):
             "other </ins><span>book</span>",
         )
         self.assertFalse(html[headers.index("author_email")])
+
+    def test_get_diff_json_key_order(self):
+        class JSONResource(resources.Resource):
+            data = fields.Field(attribute="data", widget=widgets.JSONWidget())
+
+        resource = JSONResource()
+        diff = Diff(resource, SimpleNamespace(data={"a": 1, "b": 2}), False)
+        diff.compare_with(resource, SimpleNamespace(data={"b": 2, "a": 1}))
+        html = diff.as_html()[0]
+
+        self.assertNotIn("<ins", html)
+        self.assertNotIn("<del", html)
 
     def test_import_data_update(self):
         result = self.resource.import_data(self.dataset, raise_errors=True)

--- a/tests/core/tests/test_resources/test_modelresource/test_data_import.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_data_import.py
@@ -44,6 +44,27 @@ class DataImportTests(TestCase):
         self.assertNotIn("<ins", html)
         self.assertNotIn("<del", html)
 
+    def test_import_data_skips_unchanged_json_with_different_key_order(self):
+        class JSONResource(resources.ModelResource):
+            data = fields.Field(attribute="data", widget=widgets.JSONWidget())
+
+            class Meta:
+                model = Book
+                fields = ("id", "data")
+                skip_unchanged = True
+
+            def after_init_instance(self, instance, new, row, **kwargs):
+                instance.data = {"a": 1, "b": 2}
+
+        dataset = tablib.Dataset(headers=["id", "data"])
+        dataset.append([self.book.pk, '{"b": 2, "a": 1}'])
+
+        result = JSONResource().import_data(dataset, raise_errors=True)
+
+        self.assertEqual(results.RowResult.IMPORT_TYPE_SKIP, result.rows[0].import_type)
+        self.assertNotIn("<ins", result.rows[0].diff[1])
+        self.assertNotIn("<del", result.rows[0].diff[1])
+
     def test_import_data_update(self):
         result = self.resource.import_data(self.dataset, raise_errors=True)
 

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -932,6 +932,14 @@ class JSONWidgetTest(TestCase):
     def test_render(self):
         self.assertEqual(self.widget.render(self.value), '{"value": 23}')
 
+    def test_render_sort_json_keys(self):
+        value = {"b": 2, "a": 1}
+
+        self.assertEqual(self.widget.render(value), '{"b": 2, "a": 1}')
+        self.assertEqual(
+            self.widget.render(value, sort_json_keys=True), '{"a": 1, "b": 2}'
+        )
+
     def test_clean_single_quoted_string(self):
         self.assertEqual(self.widget.clean("{'value': 23}"), self.value)
         self.assertEqual(self.widget.clean("{'value': null}"), {"value": None})


### PR DESCRIPTION
## Summary

- render JSON with deterministic key ordering
- prevent skipped imports from showing a diff when only JSON key order changes
- add a regression test for semantically equivalent JSON objects

Closes #2123.

## Tests

- `PYTHONPATH=".:tests" .venv/bin/python -W error -m django test core.tests.test_resources.test_modelresource.test_data_import core.tests.test_widgets --settings=settings`
