### PR TITLE
Fix skip_row() false positives from datetime sub-second precision loss

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -580,7 +580,9 @@ class Resource(metaclass=DeclarativeMetaclass):
                     v.pk for v in original_values
                 ):
                     return False
-            elif field.get_value(instance) != field.get_value(original):
+            elif not field.widget.is_equal(
+                field.get_value(instance), field.get_value(original)
+            ):
                 return False
         return True
 

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -96,6 +96,26 @@ class Widget:
         """
         return force_str(value) if value is not None else ""
 
+    def is_equal(self, instance_value, original_value):
+        """
+        Compare a freshly-parsed import value against the previously
+        persisted value, for the purposes of
+        :meth:`~import_export.resources.Resource.skip_row`.
+
+        By default this is a plain equality check. Widgets whose
+        :meth:`render` loses precision on round-trip (for example,
+        ``DateTimeWidget``'s default text format has no sub-second
+        precision) should override this to compare values at the
+        same precision that would actually survive an export, so
+        that re-importing unmodified, previously-exported data is
+        correctly detected as unchanged.
+
+        :param instance_value: The value parsed from the imported row.
+        :param original_value: The value from the previously persisted
+            instance.
+        """
+        return instance_value == original_value
+
 
 class NumberWidget(Widget):
     """
@@ -354,6 +374,20 @@ class DateTimeWidget(_ParseDateTimeMixin, Widget):
 
         return format_datetime(value, self.formats[0])
 
+    def is_equal(self, instance_value, original_value):
+        # The default text format ("%Y-%m-%d %H:%M:%S") has no
+        # sub-second precision, and even native (xlsx) export/import
+        # round-trips can lose microsecond precision depending on the
+        # spreadsheet format's own numeric storage. Compare at
+        # whole-second precision so re-importing unmodified data
+        # (which necessarily lost sub-second precision on export) is
+        # correctly detected as unchanged. See GH #2018.
+        if isinstance(instance_value, datetime):
+            instance_value = instance_value.replace(microsecond=0)
+        if isinstance(original_value, datetime):
+            original_value = original_value.replace(microsecond=0)
+        return instance_value == original_value
+
 
 class TimeWidget(_ParseDateTimeMixin, Widget):
     """
@@ -381,6 +415,15 @@ class TimeWidget(_ParseDateTimeMixin, Widget):
         if not value or not isinstance(value, time):
             return ""
         return value.strftime(self.formats[0])
+
+    def is_equal(self, instance_value, original_value):
+        # Same rationale as DateTimeWidget.is_equal: the default text
+        # format ("%H:%M:%S") has no sub-second precision.
+        if isinstance(instance_value, time):
+            instance_value = instance_value.replace(microsecond=0)
+        if isinstance(original_value, time):
+            original_value = original_value.replace(microsecond=0)
+        return instance_value == original_value
 
 
 class DurationWidget(Widget):

--- a/tests/core/tests/test_resources/test_diffs.py
+++ b/tests/core/tests/test_resources/test_diffs.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest import mock
 
 import tablib
@@ -116,3 +117,53 @@ class SkipHtmlDiffTest(TestCase):
         with mock.patch("import_export.resources.Diff.as_html") as mock_as_html:
             resource.import_data(self.dataset, dry_run=True)
             mock_as_html.assert_not_called()
+
+
+class SkipRowDateTimePrecisionTest(TestCase):
+    """
+    Regression test for
+    https://github.com/django-import-export/django-import-export/issues/2018
+
+    Re-importing unmodified, previously-persisted data whose
+    DateTimeField/TimeField differs only by sub-second precision (as
+    is expected after any export/import round-trip, since the default
+    text formats have no sub-second precision) must be detected as
+    unchanged by skip_row when skip_unchanged is enabled.
+    """
+
+    def setUp(self):
+        class BookResource(resources.ModelResource):
+            class Meta:
+                model = Book
+                skip_unchanged = True
+                report_skipped = True
+
+        self.resource = BookResource()
+        self.book = Book.objects.create(
+            name="Test Book",
+            added=datetime.datetime(2024, 11, 19, 12, 54, 31, 838000),
+        )
+
+    def test_microsecond_only_difference_is_skipped(self):
+        dataset = self.resource.export()
+        # Simulate the precision loss inherent to any export round-trip:
+        # microseconds are dropped, matching the default text format.
+        row = dataset.dict[0]
+        row["added"] = "2024-11-19 12:54:31"
+        dataset = tablib.Dataset(headers=dataset.headers)
+        dataset.append([row[h] for h in dataset.headers])
+
+        result = self.resource.import_data(dataset, dry_run=True)
+        self.assertEqual(1, result.totals["skip"])
+        self.assertEqual(0, result.totals["update"])
+
+    def test_genuine_second_level_difference_is_not_skipped(self):
+        dataset = self.resource.export()
+        row = dataset.dict[0]
+        row["added"] = "2024-11-19 12:54:41"  # genuinely 10 seconds later
+        dataset = tablib.Dataset(headers=dataset.headers)
+        dataset.append([row[h] for h in dataset.headers])
+
+        result = self.resource.import_data(dataset, dry_run=True)
+        self.assertEqual(0, result.totals["skip"])
+        self.assertEqual(1, result.totals["update"])

--- a/tests/core/tests/test_widgets.py
+++ b/tests/core/tests/test_widgets.py
@@ -236,6 +236,32 @@ class DateTimeWidgetTest(TestCase):
     def test_clean_returns_datetime_when_datetime_passed(self):
         self.assertEqual(self.datetime, self.widget.clean(self.datetime))
 
+    def test_is_equal_ignores_microsecond_difference(self):
+        """
+        Regression test for
+        https://github.com/django-import-export/django-import-export/issues/2018
+
+        The default text format has no sub-second precision, and even
+        native (e.g. xlsx) export/import round-trips can lose
+        microsecond precision. is_equal() should treat two datetimes
+        differing only in microseconds as equal, so re-importing
+        unmodified, previously-exported data is correctly detected as
+        unchanged.
+        """
+        dt1 = datetime(2024, 11, 19, 12, 54, 31, 838000)
+        dt2 = datetime(2024, 11, 19, 12, 54, 31, 837623)
+        self.assertTrue(self.widget.is_equal(dt1, dt2))
+
+    def test_is_equal_detects_second_level_difference(self):
+        dt1 = datetime(2024, 11, 19, 12, 54, 31)
+        dt2 = datetime(2024, 11, 19, 12, 54, 36)
+        self.assertFalse(self.widget.is_equal(dt1, dt2))
+
+    def test_is_equal_handles_none(self):
+        self.assertTrue(self.widget.is_equal(None, None))
+        self.assertFalse(self.widget.is_equal(self.datetime, None))
+        self.assertFalse(self.widget.is_equal(None, self.datetime))
+
     def test_render_datetime_safe(self):
         """datetime_safe is supposed to be used to support dates older than 1000"""
         self.datetime = datetime(10, 8, 2)
@@ -298,6 +324,14 @@ class TimeWidgetTest(TestCase):
 
     def test_clean(self):
         self.assertEqual(self.widget.clean("20:15:00"), self.time)
+
+    def test_is_equal_ignores_microsecond_difference(self):
+        t1 = time(20, 15, 0, 838000)
+        t2 = time(20, 15, 0, 837623)
+        self.assertTrue(self.widget.is_equal(t1, t2))
+
+    def test_is_equal_detects_second_level_difference(self):
+        self.assertFalse(self.widget.is_equal(time(20, 15, 0), time(20, 15, 5)))
 
     @override_settings(TIME_INPUT_FORMATS=None)
     def test_default_format(self):


### PR DESCRIPTION
Fixes #2018.

`skip_row()` compared field values with a plain `!=` check: `field.get_value(instance) != field.get_value(original)`. For `DateTimeField` and `TimeField`, this requires exact equality down to the microsecond.

The default text export format for these fields (`"%Y-%m-%d %H:%M:%S"` / `"%H:%M:%S"`) has no sub-second precision at all, and even native (e.g. xlsx) export/import round-trips can lose microsecond precision. So re-importing completely unmodified, previously-exported data produces a freshly-parsed value that differs from the persisted original by a few hundred microseconds -- and `skip_row()` incorrectly treats this as a real change, reporting an `update` instead of a `skip`.

I verified this end-to-end with an actual Django model + export-to-xlsx + reimport round-trip: an unmodified `Book.added` datetime went from `skip=1` (correct) to `skip=0, update=1` (bug) purely from the export's inherent precision loss, with no data actually changed. (Note: the original issue's proposed fix of applying `timezone.localtime()` wouldn't actually resolve this -- aware datetimes already compare correctly across timezones in Python; the real cause is the precision loss shown above, not a timezone mismatch.)

**Fix**: add an `is_equal(instance_value, original_value)` hook on the base `Widget` class (default: plain equality, preserving existing behavior for every other field type), and override it on `DateTimeWidget` and `TimeWidget` to compare at whole-second precision by zeroing microseconds on both sides before comparing. `skip_row()` now calls `field.widget.is_equal(...)` instead of a raw `!=`.

This does **not** weaken change detection: a genuine difference of even one second is still correctly detected (verified both via a targeted unit test and via the same end-to-end round-trip harness with a deliberate 5-second change, which is still correctly reported as an `update`, not skipped).

**Testing**: added widget-level unit tests (microsecond-only differences treated as equal, second-level differences still detected as different, `None` handled safely) for both `DateTimeWidget` and `TimeWidget`, plus an integration-level test exercising `skip_row()` through `Resource.import_data()` with `skip_unchanged=True`, covering both the false-positive scenario (fails without the fix, passes with it -- confirmed) and confirming genuine changes are still detected.

Ran the full existing test suite (713 tests, 706 baseline + 7 new): all pass, no regressions.
