### PR TITLE
Treat ODS as a binary format

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Changelog
 - Refactor bulk updates to use attribute not field (`2145 <https://github.com/django-import-export/django-import-export/issues/2145>`_)
 - Replace ``DEFAULT_FORMATS`` and ``BINARY_FORMATS`` constants with ``get_default_formats()`` and ``get_binary_formats()`` functions to avoid expensive library imports at Django startup (`2149 <https://github.com/django-import-export/django-import-export/issues/2149>`_)
 - Allow ``Resource`` subclasses to be subscripted, e.g. ``ModelResource[MyModel]`` (`2069 <https://github.com/django-import-export/django-import-export/issues/2069>`_)
+- Fixed ``.ods`` import failing with ``UnicodeDecodeError`` because ODS was classified as a text format and read in text mode instead of binary (`2176 <https://github.com/django-import-export/django-import-export/pull/2176>`_)
 
 4.4.1 (2026-05-05)
 -------------------

--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -154,7 +154,7 @@ class TSV(TextFormat):
     CONTENT_TYPE = "text/tab-separated-values"
 
 
-class ODS(TextFormat):
+class ODS(TablibFormat):
     TABLIB_MODULE = "tablib.formats._ods"
     CONTENT_TYPE = "application/vnd.oasis.opendocument.spreadsheet"
 

--- a/tests/core/tests/test_base_formats.py
+++ b/tests/core/tests/test_base_formats.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from io import BytesIO
 from unittest import mock
@@ -170,6 +171,37 @@ class XLSXTest(TestCase):
 
         dataset = self.format.create_dataset(xlsx_data.getvalue())
         assert len(dataset) == rows_before + rows_after  # Without empty rows
+
+
+class ODSTest(TestCase):
+    def setUp(self):
+        self.format = base_formats.ODS()
+
+    def test_binary_format(self):
+        self.assertTrue(self.format.is_binary())
+
+    def test_import(self):
+        # .ods is a binary (zip-based) format, so it must be read using the
+        # format's own (binary) read mode. Reading it in text mode -- as
+        # happened when ODS was misclassified as a text format -- corrupts the
+        # bytes and raises UnicodeDecodeError.
+        dataset = tablib.Dataset(headers=["id", "name"])
+        dataset.append((1, "Some book"))
+        payload = self.format.export_data(dataset)
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(payload)
+            path = f.name
+        try:
+            with open(path, self.format.get_read_mode()) as in_stream:
+                result = self.format.create_dataset(in_stream.read())
+        finally:
+            os.remove(path)
+
+        self.assertEqual(1, len(result))
+        row = result.dict.pop()
+        self.assertEqual(1, row["id"])
+        self.assertEqual("Some book", row["name"])
 
 
 class CSVTest(TestCase):


### PR DESCRIPTION
### Problem

ODS (OpenDocument Spreadsheet) is a ZIP-based **binary** format, but the `ODS` class extends `TextFormat`:

```python
class ODS(TextFormat):        # is_binary() -> False, get_read_mode() -> "r"
    ...
class XLS(TablibFormat):       # is_binary() -> True,  get_read_mode() -> "rb"
class XLSX(TablibFormat):      # is_binary() -> True,  get_read_mode() -> "rb"

_BINARY_FORMAT_TYPES = (XLS, XLSX, ODS)   # ODS declared binary here
```

So the class hierarchy contradicts itself: `_BINARY_FORMAT_TYPES` (used by `get_binary_formats()`) lists ODS as binary, but the `ODS` class reports `is_binary() == False`.

Because the admin (`TempFolderStorage.read`) and CLI import paths choose the file read mode from `is_binary()`, an uploaded `.ods` is opened in **text** mode. Reading the binary ZIP as text corrupts it and raises `UnicodeDecodeError` before the data can be parsed:

```python
>>> from import_export.formats.base_formats import ODS
>>> ODS().is_binary(), ODS().get_read_mode()
(False, 'r')                 # expected (True, 'rb'), like XLS/XLSX
```

Exporting an `.ods` and importing it back through the admin/CLI therefore fails.

### Fix

Extend `TablibFormat` (as `XLS` and `XLSX` do, and as `_BINARY_FORMAT_TYPES` already assumes) so ODS is read in binary mode:

```python
class ODS(TablibFormat):
    ...
```

`TablibFormat` provides exactly the binary behavior ODS needs (`is_binary() == True`, `get_read_mode() == "rb"`, and no text decoding in `create_dataset`). Export was already routed as binary via `get_binary_formats()`, so export behavior is unchanged.

### Tests

Added `ODSTest` (mirroring `XLSTest`/`XLSXTest`): it asserts `is_binary()` is True and performs an export→import round-trip that reads the payload using the format's own `get_read_mode()`. Both checks fail on `main` (`is_binary()` is False; the round-trip raises `UnicodeDecodeError`) and pass with the fix. The full `test_base_formats` module passes (41 tests).