### PR TITLE
Skip pk sequence reset unless import supplied explicit pk values

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -1109,6 +1109,23 @@ This issue may be more prevalent if using :doc:`bulk imports<bulk_import>`.  Thi
 memory for longer before being written in bulk, therefore there is potentially more risk of another process modifying
 an instance before it has been persisted.
 
+Sequence resets
+---------------
+
+After an import which created new objects, :meth:`~import_export.resources.ModelResource.after_import` resets the
+model's pk sequence, but only if the imported data supplied explicit pk values for created rows.  This supports
+fixture-style imports (as in Django's ``loaddata``), where inserting rows with explicit pks can leave the sequence
+behind the maximum pk, causing subsequent inserts to fail.
+
+If all created rows had their pk assigned by the database, no reset is performed.  This is because the sequence cannot
+be behind in that case, and because the reset itself is not safe under concurrency: on databases such as PostgreSQL it
+rewinds the shared sequence to the importing process's view of the maximum pk, which can re-issue pk values already
+handed to a concurrent import of the same model, causing duplicate key errors in that import.
+
+If an import mixes rows with and without explicit pk values, the reset still runs, and the above race remains possible
+if such imports run concurrently with other writes to the same model.  Avoid supplying pk values in imported data
+unless imports are known not to overlap.
+
 Additional configuration
 ========================
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 5.0.0 (unreleased)
 ------------------
 
-- Fixed pk sequence reset in :meth:`~import_export.resources.ModelResource.after_import` rewinding the sequence below values already issued to a concurrent import of the same model, causing ``IntegrityError`` (duplicate pk) in the concurrent import.  The reset now only runs when imported rows supplied explicit pk values (the ``loaddata``-style scenario it exists for); fixture-style imports are unaffected (`2166 <https://github.com/django-import-export/django-import-export/issues/2166>`_)
+- Fixed pk sequence reset in :meth:`~import_export.resources.ModelResource.after_import` (`2166 <https://github.com/django-import-export/django-import-export/issues/2166>`_)
 - Fixed ``CachedInstanceLoader`` to raise ``MultipleObjectsReturned`` for a duplicated import id instead of silently returning one match, consistent with ``ModelInstanceLoader`` (`2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)
 - Add support for Django 6.0, remove support for Python 3.9 (`2112 <https://github.com/django-import-export/django-import-export/pull/2112>`_)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 5.0.0 (unreleased)
 ------------------
 
+- Fixed pk sequence reset in :meth:`~import_export.resources.ModelResource.after_import` rewinding the sequence below values already issued to a concurrent import of the same model, causing ``IntegrityError`` (duplicate pk) in the concurrent import.  The reset now only runs when imported rows supplied explicit pk values (the ``loaddata``-style scenario it exists for); fixture-style imports are unaffected (`2166 <https://github.com/django-import-export/django-import-export/issues/2166>`_)
 - Fixed ``CachedInstanceLoader`` to raise ``MultipleObjectsReturned`` for a duplicated import id instead of silently returning one match, consistent with ``ModelInstanceLoader`` (`2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)
 - Add support for Django 6.0, remove support for Python 3.9 (`2112 <https://github.com/django-import-export/django-import-export/pull/2112>`_)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -54,6 +54,17 @@ Breaking changes
   Ensure that custom ``import_id_fields`` values uniquely identify one row.
   See `PR 2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_.
 
+* The pk sequence reset in :meth:`~import_export.resources.ModelResource.after_import` now only runs when the
+  imported data supplied explicit pk values for created rows, because resetting an already-correct sequence is
+  unsafe under concurrent imports of the same model
+  (see `issue 2166 <https://github.com/django-import-export/django-import-export/issues/2166>`_).
+  Fixture-style imports which supply pks are unaffected.
+
+  If a sequence was left behind by something other than the import (e.g. an earlier fixture load), imports will no
+  longer incidentally repair it — use Django's ``sqlsequencereset`` management command to fix it directly.
+  Note that the tracking of supplied pks happens in :meth:`~import_export.resources.Resource.save_instance`, so
+  custom overrides which do not call ``super()`` will always skip the reset.
+
 Removed deprecations
 """"""""""""""""""""
 

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -96,6 +96,10 @@ class Resource(metaclass=DeclarativeMetaclass):
         self.update_instances = []
         self.delete_instances = []
 
+        # whether any created row supplied an explicit pk value
+        # (see ModelResource.after_import())
+        self._pk_supplied_on_create = False
+
     @classmethod
     def get_result_class(self):
         """
@@ -297,6 +301,10 @@ class Resource(metaclass=DeclarativeMetaclass):
             See :meth:`import_row
         """
         self.before_save_instance(instance, row, **kwargs)
+        if is_create and instance.pk is not None:
+            # the pk came from the imported data, not the database
+            # (checked before save because bulk_create can populate pks)
+            self._pk_supplied_on_create = True
         if self._meta.use_bulk:
             if is_create:
                 self.create_instances.append(instance)
@@ -844,6 +852,8 @@ class Resource(metaclass=DeclarativeMetaclass):
         result.diff_headers = self.get_diff_headers()
         result.total_rows = len(dataset)
         db_connection = self.get_db_connection_name()
+        # a resource can be reused for multiple imports
+        self._pk_supplied_on_create = False
 
         try:
             with atomic_if_using_transaction(using_transactions, using=db_connection):
@@ -1354,12 +1364,20 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
 
     def after_import(self, dataset, result, **kwargs):
         """
-        Reset the SQL sequences after new objects are imported
+        Reset the SQL sequences after new objects are imported with explicit
+        pk values (which can leave the sequence behind ``max(pk)``, as in
+        Django's ``loaddata``).  The reset is skipped when all created rows had
+        their pk assigned by the database: the sequence cannot be behind in
+        that case, and resetting it is unsafe under concurrent imports of the
+        same model because it can rewind the shared sequence below values
+        already issued to another in-flight import (#2166).
         """
         # Adapted from django's loaddata
         dry_run = self._is_dry_run(kwargs)
-        if not dry_run and any(
-            r.import_type == RowResult.IMPORT_TYPE_NEW for r in result.rows
+        if (
+            not dry_run
+            and self._pk_supplied_on_create
+            and any(r.import_type == RowResult.IMPORT_TYPE_NEW for r in result.rows)
         ):
             db_connection = self.get_db_connection_name()
             connection = connections[db_connection]

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1370,9 +1370,16 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         This can cause issues with concurrent imports.
         Therefore, the reset is skipped when all created rows had their pk assigned
         by the database: the sequence cannot be behind in that case, and resetting it
-         is unsafe under concurrent imports of the same model because it can rewind
-         the shared sequence below values already issued to another in-flight import
+        is unsafe under concurrent imports of the same model because it can rewind
+        the shared sequence below values already issued to another in-flight import
         (See #2166).
+
+        History: the reset was added (#398) to fix #59, where importing a CSV
+        with explicit pk values on PostgreSQL left the sequence behind
+        ``max(pk)``, so subsequent inserts failed with duplicate key errors.
+        The logic was adapted from Django's ``loaddata``, which handles the
+        same problem for fixtures, and was later moved into this then-new
+        ``after_import()`` hook so that subclasses could override it.
         """
         # Adapted from django's loaddata
         dry_run = self._is_dry_run(kwargs)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1365,12 +1365,14 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
     def after_import(self, dataset, result, **kwargs):
         """
         Reset the SQL sequences after new objects are imported with explicit
-        pk values (which can leave the sequence behind ``max(pk)``, as in
-        Django's ``loaddata``).  The reset is skipped when all created rows had
-        their pk assigned by the database: the sequence cannot be behind in
-        that case, and resetting it is unsafe under concurrent imports of the
-        same model because it can rewind the shared sequence below values
-        already issued to another in-flight import (#2166).
+        pk values (which can leave the sequence behind ``max(pk)``).
+
+        This can cause issues with concurrent imports.
+        Therefore, the reset is skipped when all created rows had their pk assigned
+        by the database: the sequence cannot be behind in that case, and resetting it
+         is unsafe under concurrent imports of the same model because it can rewind
+         the shared sequence below values already issued to another in-flight import
+        (See #2166).
         """
         # Adapted from django's loaddata
         dry_run = self._is_dry_run(kwargs)

--- a/tests/core/tests/test_resources/test_modelresource/test_data_import.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_data_import.py
@@ -4,6 +4,7 @@ from unittest import mock
 import tablib
 from core.models import Book
 from core.tests.resources import BookResource, BookResourceWithStoreInstance
+from django.db import connections
 from django.test import TestCase, skipUnlessDBFeature
 
 from import_export import results
@@ -137,3 +138,93 @@ class DataImportTests(TestCase):
         self.assertFalse(result.has_errors())
         self.assertEqual(1, Book.objects.count())
         self.assertTrue(self.resource.is_create)
+
+
+class SequenceResetTests(TestCase):
+    """
+    ``ModelResource.after_import()`` resets the model's pk sequence to support
+    fixture-style imports which supply explicit pk values.  When imported rows
+    do not supply pk values the reset serves no purpose and, on PostgreSQL, can
+    rewind the shared sequence under concurrent imports, causing
+    ``IntegrityError`` on inserts in a concurrent import of the same model
+    (#2166).  The reset must therefore only run when a created row supplied an
+    explicit pk.
+    """
+
+    def setUp(self):
+        self.resource = BookResource()
+        connection_name = self.resource.get_db_connection_name()
+        self.connection = connections[connection_name]
+
+    def import_with_mocked_reset(self, dataset, resource=None, **kwargs):
+        resource = resource or self.resource
+        with mock.patch.object(
+            self.connection.ops, "sequence_reset_sql", return_value=[]
+        ) as mock_reset:
+            result = resource.import_data(dataset, raise_errors=True, **kwargs)
+        return result, mock_reset
+
+    def test_no_reset_when_created_rows_supply_no_pk(self):
+        dataset = tablib.Dataset(headers=["id", "name"])
+        dataset.append(["", "Some book"])
+
+        result, mock_reset = self.import_with_mocked_reset(dataset)
+
+        self.assertEqual(results.RowResult.IMPORT_TYPE_NEW, result.rows[0].import_type)
+        mock_reset.assert_not_called()
+
+    def test_reset_when_created_rows_supply_pk(self):
+        # fixture-style import: the data supplies explicit pk values
+        dataset = tablib.Dataset(headers=["id", "name"])
+        dataset.append([101, "Some book"])
+
+        result, mock_reset = self.import_with_mocked_reset(dataset)
+
+        self.assertEqual(results.RowResult.IMPORT_TYPE_NEW, result.rows[0].import_type)
+        mock_reset.assert_called_once()
+
+    def test_no_reset_when_created_rows_supply_no_pk_use_bulk(self):
+        class BulkBookResource(BookResource):
+            class Meta:
+                model = Book
+                use_bulk = True
+
+        dataset = tablib.Dataset(headers=["id", "name"])
+        dataset.append(["", "Some book"])
+
+        result, mock_reset = self.import_with_mocked_reset(
+            dataset, resource=BulkBookResource()
+        )
+
+        self.assertEqual(results.RowResult.IMPORT_TYPE_NEW, result.rows[0].import_type)
+        self.assertEqual(1, Book.objects.count())
+        mock_reset.assert_not_called()
+
+    def test_reset_when_created_rows_supply_pk_use_bulk(self):
+        class BulkBookResource(BookResource):
+            class Meta:
+                model = Book
+                use_bulk = True
+
+        dataset = tablib.Dataset(headers=["id", "name"])
+        dataset.append([101, "Some book"])
+
+        result, mock_reset = self.import_with_mocked_reset(
+            dataset, resource=BulkBookResource()
+        )
+
+        self.assertEqual(results.RowResult.IMPORT_TYPE_NEW, result.rows[0].import_type)
+        self.assertEqual(1, Book.objects.count())
+        mock_reset.assert_called_once()
+
+    def test_reused_resource_does_not_reset_on_later_import_without_pk(self):
+        # the flag tracking supplied pks must be re-initialized per import run
+        dataset_with_pk = tablib.Dataset(headers=["id", "name"])
+        dataset_with_pk.append([101, "Some book"])
+        _, mock_reset = self.import_with_mocked_reset(dataset_with_pk)
+        mock_reset.assert_called_once()
+
+        dataset_without_pk = tablib.Dataset(headers=["id", "name"])
+        dataset_without_pk.append(["", "Some other book"])
+        _, mock_reset = self.import_with_mocked_reset(dataset_without_pk)
+        mock_reset.assert_not_called()


### PR DESCRIPTION
## Problem

Closes #2166.

`ModelResource.after_import()` resets the model's pk sequence (via `connection.ops.sequence_reset_sql()`, logic adapted from `loaddata`) whenever an import created at least one new row. On PostgreSQL this executes a non-transactional `setval(pg_get_serial_sequence(...), max(id))`.

Under concurrent imports of the same model, import A's reset reads its own view of `max(id)` and rewinds the shared sequence below values already issued to import B's in-flight `nextval()` calls. B's next insert then draws an already-issued id and fails with `duplicate key value violates unique constraint "<table>_pkey"` — colliding with its own earlier row. This was root-caused from a production incident (two Celery workers importing CSVs for different tenants into the same table); forensics in #2166 confirm the sequence rewind as the only possible cause (contiguous id run, `seqcycle=false`, `seqcache=1`, no explicit pks supplied anywhere).

## Fix

The reset's only legitimate purpose is the fixture-style scenario where imported data supplies explicit pk values, leaving the sequence behind `max(pk)`. When all pks are DB-assigned the sequence can never be behind because of the import, so the reset is a no-op when healthy and a race under concurrency.

The resource now tracks whether any *created* row had `instance.pk` set before save (i.e. the pk came from the imported data). If not, `after_import()` skips the reset entirely:

- Flag is checked in `save_instance()` after `before_save_instance()`, covering both the direct-save and `use_bulk` branches (checked at append time, before `bulk_create` can populate pks).
- Flag is re-initialised at the start of each import run, so reused resource instances behave correctly.
- Fixture-style imports (explicit pks) are unaffected — the reset runs exactly as before.
- Behaviour change is effectively PostgreSQL/Oracle only: `sequence_reset_sql()` already returns `[]` on SQLite/MySQL.

Mixed imports (some created rows with explicit pks) still reset and still carry the theoretical race; this residual caveat is documented in the new "Sequence resets" note under the concurrency section of the advanced usage docs.

## Tests

- Import creating rows *without* pk values → `sequence_reset_sql` not called (fails on main, passes with fix).
- Import supplying explicit pks for created rows → reset still runs (regression guard for fixture users).
- `use_bulk` variants of both.
- Reused resource: import with pks then import without → second run does not reset (guards the per-run flag init).

A true concurrency reproduction isn't practical in the test suite; the incident narrative in #2166 serves as the regression rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)