### PR TITLE
Honor IMPORT_EXPORT_SKIP_ADMIN_EXPORT_UI for action and change-form exports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -168,3 +168,4 @@ The following is a list of much appreciated contributors:
 * ghostishev (Yevhen Hostishchev)
 * Lokker29 (Bohdan Bilokon)
 * tuky (Tobias Krönke)
+* DSeaStar (SeaStar Deng)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 5.0.0 (unreleased)
 ------------------
 
+- Honor ``IMPORT_EXPORT_SKIP_ADMIN_EXPORT_UI`` / ``skip_export_form`` when exporting from the Admin action menu or change-form Export button (`2180 <https://github.com/django-import-export/django-import-export/issues/2180>`_)
 - Fixed pk sequence reset in :meth:`~import_export.resources.ModelResource.after_import` (`2166 <https://github.com/django-import-export/django-import-export/issues/2166>`_)
 - Fixed ``CachedInstanceLoader`` to raise ``MultipleObjectsReturned`` for a duplicated import id instead of silently returning one match, consistent with ``ModelInstanceLoader`` (`2169 <https://github.com/django-import-export/django-import-export/pull/2169>`_)
 - Fixed issue where export forms were incorrectly showing import fields instead of export fields (`2118 <https://github.com/django-import-export/django-import-export/pull/2118>`_)

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -871,7 +871,13 @@ class ExportActionMixin(ExportMixin):
         Action runs on POST from instance action menu (if enabled).
         """
         formats = self.get_export_formats()
-        if self.is_skip_export_form_from_action_enabled():
+        # Honor both skip flags so IMPORT_EXPORT_SKIP_ADMIN_EXPORT_UI /
+        # skip_export_form also skip the action and change-form confirm UI,
+        # matching the documented behaviour.
+        if (
+            self.is_skip_export_form_from_action_enabled()
+            or self.is_skip_export_form_enabled()
+        ):
             file_format = formats[0]()
             return self._do_file_export(file_format, request, queryset)
 

--- a/tests/core/tests/admin_integration/test_action_export.py
+++ b/tests/core/tests/admin_integration/test_action_export.py
@@ -470,6 +470,18 @@ class TestSkipExportFormFromAction(AdminTestMixin, TestCase):
         target_file_contents = "id,name\r\n" f"{self.cat1.id},Cat 1\r\n"
         self.assertEqual(target_file_contents.encode(), response.content)
 
+    def test_skip_export_form_enabled(self):
+        self.model_admin.skip_export_form = True
+        response = self.model_admin.export_admin_action(self.request, self.queryset)
+        target_file_contents = "id,name\r\n" f"{self.cat1.id},Cat 1\r\n"
+        self.assertEqual(target_file_contents.encode(), response.content)
+
+    @override_settings(IMPORT_EXPORT_SKIP_ADMIN_EXPORT_UI=True)
+    def test_skip_export_form_setting_enabled(self):
+        response = self.model_admin.export_admin_action(self.request, self.queryset)
+        target_file_contents = "id,name\r\n" f"{self.cat1.id},Cat 1\r\n"
+        self.assertEqual(target_file_contents.encode(), response.content)
+
 
 class TestSkipExportFormFromChangeForm(AdminTestMixin, TestCase):
     """
@@ -515,17 +527,13 @@ class TestSkipExportFormFromChangeForm(AdminTestMixin, TestCase):
 
     @override_settings(IMPORT_EXPORT_SKIP_ADMIN_EXPORT_UI=True)
     def test_export_button_on_change_form_skip_export_setting_enabled(self):
-        # this property has no effect - IMPORT_EXPORT_SKIP_ADMIN_ACTION_EXPORT_UI
-        # should be set instead
         response = self._post_url_response(
             self.change_url, data={"_export-item": "Export", "name": self.cat1.name}
         )
-        target_re = r"This exporter will export the following fields:"
-        self.assertRegex(response.content.decode(), target_re)
+        target_file_contents = "id,name\r\n" f"{self.cat1.id},Cat 1\r\n"
+        self.assertEqual(target_file_contents.encode(), response.content)
 
     def test_export_button_on_change_form_skip_export_form_enabled(self):
-        # this property has no effect - skip_export_form_from_action
-        # should be set instead
         with patch(
             "core.admin.CategoryAdmin.skip_export_form",
             new_callable=PropertyMock,
@@ -534,5 +542,5 @@ class TestSkipExportFormFromChangeForm(AdminTestMixin, TestCase):
             response = self._post_url_response(
                 self.change_url, data={"_export-item": "Export", "name": self.cat1.name}
             )
-            target_re = r"This exporter will export the following fields:"
-            self.assertRegex(response.content.decode(), target_re)
+            target_file_contents = "id,name\r\n" f"{self.cat1.id},Cat 1\r\n"
+            self.assertEqual(target_file_contents.encode(), response.content)


### PR DESCRIPTION
Fixes #2180.

`export_admin_action()` only checked `is_skip_export_form_from_action_enabled()`, so `IMPORT_EXPORT_SKIP_ADMIN_EXPORT_UI` / `skip_export_form` did not skip the confirm form for Admin action or change-form exports. The docs say either flag should.

That also left a bad follow-on: the form was shown, then `export_action()` saw the skip-export-UI setting and exported the full changelist queryset with the default format, ignoring the user's selection.

This skips the form when either flag is set, matching the documented behaviour. Tests that previously asserted the old "no effect" behaviour now expect a direct file export.