### PR TITLE
Fix: ModelResource.after_import() (import_export/resources.py, ~line 1355)...

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1363,9 +1363,25 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
         ):
             db_connection = self.get_db_connection_name()
             connection = connections[db_connection]
-            sequence_sql = connection.ops.sequence_reset_sql(
-                no_style(), [self._meta.model]
-            )
+            if connection.vendor == "postgresql":
+                # PostgreSQL sequences are not transactional, so it is safe
+                # (and necessary) to use GREATEST() to ensure that the
+                # sequence is only ever advanced, never rewound below a
+                # value already handed out to a concurrently-running
+                # import_data() call on another connection (see #2166).
+                #
+                # NOTE: for other database backends, sequence_reset_sql()
+                # is unconditional and *not* concurrency-safe: a
+                # concurrent import of the same model may still rewind
+                # the sequence and cause duplicate-key errors on those
+                # backends.
+                sequence_sql = self._get_safe_postgres_sequence_reset_sql(
+                    connection, self._meta.model
+                )
+            else:
+                sequence_sql = connection.ops.sequence_reset_sql(
+                    no_style(), [self._meta.model]
+                )
             if sequence_sql:
                 cursor = connection.cursor()
                 try:
@@ -1373,6 +1389,45 @@ class ModelResource(Resource, metaclass=ModelDeclarativeMetaclass):
                         cursor.execute(line)
                 finally:
                     cursor.close()
+
+    @staticmethod
+    def _get_safe_postgres_sequence_reset_sql(connection, model):
+        """
+        Build a concurrency-safe sequence reset statement for PostgreSQL.
+
+        Equivalent to ``connection.ops.sequence_reset_sql()``, except the
+        new sequence value is the GREATEST of the computed max primary key
+        and the sequence's current value, so a concurrent import that has
+        already advanced the sequence (e.g. via an in-flight, uncommitted
+        INSERT) is never rewound.
+        """
+        from django.db import models as django_models
+
+        qn = connection.ops.quote_name
+        output = []
+        for f in model._meta.local_fields:
+            if isinstance(f, django_models.AutoField):
+                table = qn(model._meta.db_table)
+                column = qn(f.column)
+                output.append(
+                    "SELECT setval("
+                    "pg_get_serial_sequence('%(table)s','%(column_name)s'), "
+                    "GREATEST("
+                    "coalesce(max(%(column)s), 1), "
+                    "coalesce(pg_sequence_last_value("
+                    "pg_get_serial_sequence('%(table)s','%(column_name)s')"
+                    "), 1)"
+                    "), "
+                    "max(%(column)s) IS NOT null) FROM %(table)s;"
+                    % {
+                        "table": table,
+                        "column": column,
+                        "column_name": f.column,
+                    }
+                )
+                # Only one AutoField is allowed per model.
+                break
+        return output
 
     @classmethod
     def get_display_name(cls):

--- a/tests/core/tests/test_resources/test_modelresource/test_resource_postgres.py
+++ b/tests/core/tests/test_resources/test_modelresource/test_resource_postgres.py
@@ -6,7 +6,7 @@ import tablib
 from core.models import Book
 from core.tests.resources import BookResource
 from django.conf import settings
-from django.db import IntegrityError
+from django.db import IntegrityError, connection
 from django.db.models import CharField
 from django.test import TestCase, TransactionTestCase
 
@@ -66,6 +66,66 @@ class PostgresTests(TransactionTestCase):
         resource = BookResource()
         res = resource.widget_from_django_field(f)
         self.assertEqual(widgets.SimpleArrayWidget, res)
+
+    def test_sequence_reset_does_not_rewind_concurrently_advanced_sequence(self):
+        # Regression test for #2166: after_import() must not rewind the
+        # sequence below a value already issued to a "concurrent" caller
+        # (simulated here by manually advancing the sequence past the
+        # table's current max id before running the import).
+        dataset = tablib.Dataset(headers=["id", "name"])
+        dataset.append([1, "Some book"])
+        resource = BookResource()
+        result = resource.import_data(dataset)
+        self.assertFalse(result.has_errors())
+
+        # Simulate a concurrent transaction that has already called
+        # nextval() several times beyond the current max(id), e.g. via
+        # in-flight INSERTs that have not yet been committed/visible.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT setval(pg_get_serial_sequence('core_book','id'), 100)"
+            )
+
+        dataset2 = tablib.Dataset(headers=["id", "name"])
+        dataset2.append([2, "Another book"])
+        result2 = resource.import_data(dataset2)
+        self.assertFalse(result2.has_errors())
+
+        # The sequence must not have been rewound below the concurrently
+        # advanced value: a subsequent auto-assigned insert must succeed.
+        try:
+            Book.objects.create(name="Some other book")
+        except IntegrityError:
+            self.fail(
+                "IntegrityError was raised: sequence was rewound below a "
+                "value already issued to a concurrent caller."
+            )
+
+
+class SequenceResetSqlUnitTests(TestCase):
+    """
+    Unit tests for the concurrency-safe sequence reset SQL builder.
+
+    These run regardless of the configured database backend (the code
+    under test only builds a SQL string; it does not execute it), so
+    they exercise the fix even when Postgres isn't available in this
+    environment.
+    """
+
+    def test_generated_sql_uses_greatest_and_does_not_rewind(self):
+        from unittest.mock import Mock
+
+        pg_connection = Mock()
+        pg_connection.ops.quote_name = lambda name: '"%s"' % name
+
+        sql = resources.ModelResource._get_safe_postgres_sequence_reset_sql(
+            pg_connection, Book
+        )
+        self.assertEqual(1, len(sql))
+        statement = sql[0]
+        self.assertIn("GREATEST(", statement)
+        self.assertIn("pg_sequence_last_value(", statement)
+        self.assertIn("setval(", statement)
 
 
 if "postgresql" in settings.DATABASES["default"]["ENGINE"]:


### PR DESCRIPTION
## Summary
For the postgresql vendor specifically, after_import() now builds its own setval() SQL (via new static helper ModelResource._get_safe_postgres_sequence_reset_sql) that wraps the target value in GREATEST(coalesce(max(pk),1), pg_sequence_last_value(seq)), so the sequence is only ever advanced, never rewound below its current value. pg_sequence_last_value() reflects concurrent nextval() calls immediately (sequences are non-transactional), so this is safe even against in-flight, uncommitted concurrent inserts. Non-postgresql backends keep the prior, unconditional sequence_reset_sql() behavior (documented in a code comment as still having the concurrency hazard, left as a limitation).

## Problem
django-import-export/django-import-export issue reference: django-import-export/django-import-export#2166

## Root Cause
ModelResource.after_import() (import_export/resources.py, ~line 1355) unconditionally executes Django's sequence_reset_sql() after any import with new rows, with no locking or 'never rewind' guard. This logic was copied from Django's loaddata command, which assumes single-process/non-concurrent execution -- an assumption import_export's typical use case (concurrent user-triggered imports) violates. PostgreSQL sequences are non-transactional, so a concurrent import that already advanced the sequence via nextval() can be rewound below its current value by a second import's unconditional setval().

## Testing
PASS: 228 tests ran, all passed (3 skipped, which are the pre-existing Postgres-only tests correctly skipped on the sqlite test DB in this environment, including my new PostgresTests case; the new backend-agnostic SequenceResetSqlUnitTests case ran and passed).

## Related Issue
django-import-export/django-import-export#2166
